### PR TITLE
v0.4.0: Angular template compiler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,14 @@ Goal: produce a single bundle from the JS file tree.
 - [x] ngc-rs build produces dist/main.js with all project code bundled
 - [x] Integration + snapshot tests verify bundle structure and content
 
-### v0.4 — Angular Template Compiler
+### v0.4 — Angular Template Compiler ✅
 
 Goal: compile Angular component templates natively.
 
-- [ ] Parser for Angular template syntax (pest grammar)
-- [ ] Code-gen: emit \_\_decorate and component factory boilerplate
-- [ ] Drop dependency on tsc subprocess for template compilation
+- [x] Parser for Angular template syntax (pest grammar)
+- [x] Ivy codegen: emit ɵɵdefineComponent, ɵfac, and template function
+- [x] Supports elements, text, interpolation, bindings, events, @if/@for/@switch, pipes
+- [x] JIT fallback for unsupported templates (templateUrl, *ngIf/*ngFor, ng-content)
 
 ### v1.0 — Angular CLI Drop-in
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,11 +680,12 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",
  "ngc-project-resolver",
+ "ngc-template-compiler",
  "ngc-ts-transform",
  "oxc_allocator",
  "oxc_ast",
@@ -696,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -704,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "glob",
@@ -721,21 +722,40 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "colored",
  "ngc-bundler",
  "ngc-diagnostics",
  "ngc-project-resolver",
+ "ngc-template-compiler",
  "ngc-ts-transform",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
+name = "ngc-template-compiler"
+version = "0.4.0"
+dependencies = [
+ "insta",
+ "ngc-diagnostics",
+ "ngc-project-resolver",
+ "ngc-ts-transform",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "pest",
+ "pest_derive",
+ "rayon",
+ "tracing",
+]
+
+[[package]]
 name = "ngc-ts-transform"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -1174,6 +1194,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1543,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1746,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-id-start"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler"]
+members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler"]
 
 [workspace.package]
 version = "0.3.0"

--- a/crates/bundler/Cargo.toml
+++ b/crates/bundler/Cargo.toml
@@ -19,4 +19,5 @@ tracing = "0.1"
 [dev-dependencies]
 ngc-project-resolver = { path = "../project-resolver" }
 ngc-ts-transform = { path = "../ts-transform" }
+ngc-template-compiler = { path = "../template-compiler" }
 insta = { version = "1.46", features = ["glob"] }

--- a/crates/bundler/tests/snapshot_tests.rs
+++ b/crates/bundler/tests/snapshot_tests.rs
@@ -25,8 +25,16 @@ fn build_bundle() -> String {
     let root_dir = root_dir.canonicalize().expect("root_dir should exist");
 
     let files: Vec<PathBuf> = file_graph.graph.node_weights().cloned().collect();
+
+    // Compile templates, then transform to JS (mirrors the full CLI pipeline)
+    let compiled =
+        ngc_template_compiler::compile_templates(&files).expect("should compile templates");
+    let sources: Vec<(PathBuf, String)> = compiled
+        .into_iter()
+        .map(|cf| (cf.source_path, cf.source))
+        .collect();
     let transformed =
-        ngc_ts_transform::transform_to_memory(&files).expect("should transform files");
+        ngc_ts_transform::transform_sources_to_memory(&sources).expect("should transform files");
 
     let modules: HashMap<PathBuf, String> = transformed
         .into_iter()

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -2,9 +2,8 @@
 source: crates/bundler/tests/snapshot_tests.rs
 expression: bundle
 ---
-import { Component } from '@angular/core';
+import { ɵɵStandaloneFeature, ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
 import { RouterOutlet, provideRouter } from '@angular/router';
-import _decorate from '@oxc-project/runtime/helpers/decorate';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 // src/app/shared/logger.js
@@ -29,15 +28,33 @@ class SharedUtils {
 }
 
 // src/app/app.component.js
-let AppComponent = class AppComponent {
+class AppComponent {
+	static ɵfac = function AppComponent_Factory(t) {
+		return new (t || AppComponent)();
+	};
+	static ɵcmp = ɵɵdefineComponent({
+		type: AppComponent,
+		selectors: [['app-root']],
+		standalone: true,
+		features: [ɵɵStandaloneFeature],
+		decls: 3,
+		vars: 1,
+		template: function AppComponent_Template(rf, ctx) {
+			if (rf & 1) {
+				ɵɵelementStart(0, 'h1');
+				ɵɵtext(1);
+				ɵɵelementEnd();
+				ɵɵelement(2, 'router-outlet');
+			}
+			if (rf & 2) {
+				ɵɵadvance();
+				ɵɵtextInterpolate(ctx.title);
+			}
+		},
+		dependencies: [RouterOutlet]
+	});
 	title = SharedUtils.appName();
-};
-AppComponent = _decorate([Component({
-	selector: 'app-root',
-	standalone: true,
-	imports: [RouterOutlet],
-	template: '<router-outlet />'
-})], AppComponent);
+}
 
 // src/app/app.routes.js
 const routes = [];

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ ngc-diagnostics = { path = "../diagnostics" }
 ngc-project-resolver = { path = "../project-resolver" }
 ngc-ts-transform = { path = "../ts-transform" }
 ngc-bundler = { path = "../bundler" }
+ngc-template-compiler = { path = "../template-compiler" }
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -135,11 +135,12 @@ fn run_build(project: &Path, out_dir_override: Option<&Path>) -> NgcResult<Build
     }
 
     // Transform compiled sources (template-compiled TS → JS)
+    // If a compiled source fails oxc parsing, fall back to the original file
     let sources: Vec<(PathBuf, String)> = compiled
         .into_iter()
         .map(|cf| (cf.source_path, cf.source))
         .collect();
-    let transformed = ngc_ts_transform::transform_sources_to_memory(&sources)?;
+    let transformed = transform_with_fallback(&sources)?;
 
     // Build modules map (canonical source path → JS code)
     let modules: HashMap<PathBuf, String> = transformed
@@ -186,6 +187,44 @@ fn run_build(project: &Path, out_dir_override: Option<&Path>) -> NgcResult<Build
         modules_bundled,
         output_path,
     })
+}
+
+/// Transform sources with fallback: if a compiled source fails oxc parsing,
+/// re-read the original file and transform that instead.
+fn transform_with_fallback(
+    sources: &[(PathBuf, String)],
+) -> NgcResult<Vec<ngc_ts_transform::TransformedModule>> {
+    let results: Vec<NgcResult<ngc_ts_transform::TransformedModule>> = sources
+        .iter()
+        .map(|(path, source)| {
+            let file_name = path.to_string_lossy();
+            match ngc_ts_transform::transform_source(source, &file_name) {
+                Ok(code) => Ok(ngc_ts_transform::TransformedModule {
+                    source_path: path.clone(),
+                    code,
+                }),
+                Err(_) => {
+                    // Compiled source failed — fall back to original file
+                    eprintln!(
+                        "{} transform fallback for {}",
+                        "Warning:".yellow().bold(),
+                        path.display()
+                    );
+                    let original = std::fs::read_to_string(path).map_err(|e| NgcError::Io {
+                        path: path.clone(),
+                        source: e,
+                    })?;
+                    let code = ngc_ts_transform::transform_source(&original, &file_name)?;
+                    Ok(ngc_ts_transform::TransformedModule {
+                        source_path: path.clone(),
+                        code,
+                    })
+                }
+            }
+        })
+        .collect();
+
+    results.into_iter().collect()
 }
 
 /// Find the entry point from graph entry points by looking for main.ts.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -119,9 +119,27 @@ fn run_build(project: &Path, out_dir_override: Option<&Path>) -> NgcResult<Build
         })
         .unwrap_or_else(|| config_dir.join("dist"));
 
-    // Transform all files to memory
+    // Compile templates, then transform to JS
     let files: Vec<PathBuf> = file_graph.graph.node_weights().cloned().collect();
-    let transformed = ngc_ts_transform::transform_to_memory(&files)?;
+    let compiled = ngc_template_compiler::compile_templates(&files)?;
+
+    // Report any JIT fallbacks
+    for cf in &compiled {
+        if cf.jit_fallback {
+            eprintln!(
+                "{} JIT fallback for {}",
+                "Warning:".yellow().bold(),
+                cf.source_path.display()
+            );
+        }
+    }
+
+    // Transform compiled sources (template-compiled TS → JS)
+    let sources: Vec<(PathBuf, String)> = compiled
+        .into_iter()
+        .map(|cf| (cf.source_path, cf.source))
+        .collect();
+    let transformed = ngc_ts_transform::transform_sources_to_memory(&sources)?;
 
     // Build modules map (canonical source path → JS code)
     let modules: HashMap<PathBuf, String> = transformed

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -83,6 +83,24 @@ pub enum NgcError {
         /// The file paths forming the dependency cycle.
         cycle: Vec<PathBuf>,
     },
+
+    /// An Angular template could not be parsed.
+    #[error("template parse error in {path}: {message}")]
+    TemplateParseError {
+        /// The path to the file containing the template.
+        path: PathBuf,
+        /// The error message from the template parser.
+        message: String,
+    },
+
+    /// Angular template compilation (Ivy codegen) failed.
+    #[error("template compile error in {path}: {message}")]
+    TemplateCompileError {
+        /// The path to the file that failed to compile.
+        path: PathBuf,
+        /// The error message from the compiler.
+        message: String,
+    },
 }
 
 /// A type alias for Results using NgcError.

--- a/crates/template-compiler/Cargo.toml
+++ b/crates/template-compiler/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ngc-template-compiler"
+description = "Angular template compiler for ngc-rs — compiles @Component templates to Ivy instructions"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+ngc-diagnostics = { path = "../diagnostics" }
+oxc_allocator = "0.122"
+oxc_parser = "0.122"
+oxc_span = "0.122"
+oxc_ast = "0.122"
+pest = "2.7"
+pest_derive = "2.7"
+rayon = "1.11"
+tracing = "0.1"
+
+[dev-dependencies]
+ngc-project-resolver = { path = "../project-resolver" }
+ngc-ts-transform = { path = "../ts-transform" }
+insta = { version = "1.46", features = ["glob"] }

--- a/crates/template-compiler/src/ast.rs
+++ b/crates/template-compiler/src/ast.rs
@@ -1,0 +1,158 @@
+/// A node in the parsed template AST.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TemplateNode {
+    /// An HTML element (paired or void/self-closing).
+    Element(ElementNode),
+    /// A text node.
+    Text(TextNode),
+    /// An interpolation expression `{{ expr }}`.
+    Interpolation(InterpolationNode),
+    /// An `@if` / `@else if` / `@else` control flow block.
+    IfBlock(IfBlockNode),
+    /// An `@for` / `@empty` control flow block.
+    ForBlock(ForBlockNode),
+    /// An `@switch` / `@case` / `@default` control flow block.
+    SwitchBlock(SwitchBlockNode),
+}
+
+/// An HTML element node.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElementNode {
+    /// The tag name (e.g. `div`, `router-outlet`).
+    pub tag: String,
+    /// The element's attributes.
+    pub attributes: Vec<TemplateAttribute>,
+    /// Child nodes (empty for void/self-closing elements).
+    pub children: Vec<TemplateNode>,
+    /// Whether this is a self-closing/void element.
+    pub is_void: bool,
+}
+
+/// An attribute on an element.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TemplateAttribute {
+    /// A static attribute like `class="foo"`.
+    Static {
+        /// Attribute name.
+        name: String,
+        /// Attribute value (None for boolean attributes like `disabled`).
+        value: Option<String>,
+    },
+    /// A property binding like `[title]="expr"`.
+    Property {
+        /// Property name.
+        name: String,
+        /// JavaScript expression.
+        expression: String,
+    },
+    /// A class binding like `[class.active]="expr"`.
+    ClassBinding {
+        /// CSS class name.
+        class_name: String,
+        /// JavaScript expression.
+        expression: String,
+    },
+    /// A style binding like `[style.color]="expr"`.
+    StyleBinding {
+        /// CSS property name.
+        property: String,
+        /// JavaScript expression.
+        expression: String,
+    },
+    /// An attribute binding like `[attr.aria-label]="expr"`.
+    AttrBinding {
+        /// Attribute name.
+        name: String,
+        /// JavaScript expression.
+        expression: String,
+    },
+    /// An event binding like `(click)="handler()"`.
+    Event {
+        /// Event name.
+        name: String,
+        /// Handler expression.
+        handler: String,
+    },
+}
+
+/// A text node.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextNode {
+    /// The text content.
+    pub value: String,
+}
+
+/// An interpolation node `{{ expression }}`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InterpolationNode {
+    /// The raw JavaScript expression.
+    pub expression: String,
+    /// Parsed pipe chain, if any.
+    pub pipes: Vec<PipeCall>,
+}
+
+/// A pipe call in an interpolation expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PipeCall {
+    /// Pipe name.
+    pub name: String,
+    /// Pipe arguments.
+    pub args: Vec<String>,
+}
+
+/// An `@if` block.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfBlockNode {
+    /// The condition expression.
+    pub condition: String,
+    /// Children rendered when condition is true.
+    pub children: Vec<TemplateNode>,
+    /// Optional `@else if` branches.
+    pub else_if_branches: Vec<ElseIfBranch>,
+    /// Optional `@else` branch.
+    pub else_branch: Option<Vec<TemplateNode>>,
+}
+
+/// An `@else if` branch.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElseIfBranch {
+    /// The condition expression.
+    pub condition: String,
+    /// Children rendered when condition is true.
+    pub children: Vec<TemplateNode>,
+}
+
+/// An `@for` block.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForBlockNode {
+    /// The loop variable name.
+    pub item_name: String,
+    /// The iterable expression.
+    pub iterable: String,
+    /// The track expression.
+    pub track_expression: String,
+    /// Children rendered for each item.
+    pub children: Vec<TemplateNode>,
+    /// Optional `@empty` children.
+    pub empty_children: Option<Vec<TemplateNode>>,
+}
+
+/// An `@switch` block.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwitchBlockNode {
+    /// The switch expression.
+    pub expression: String,
+    /// Case branches.
+    pub cases: Vec<CaseBranch>,
+    /// Optional default branch.
+    pub default_branch: Option<Vec<TemplateNode>>,
+}
+
+/// A `@case` branch.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaseBranch {
+    /// The case expression.
+    pub expression: String,
+    /// Children rendered when matched.
+    pub children: Vec<TemplateNode>,
+}

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1,0 +1,770 @@
+use std::collections::BTreeSet;
+
+use ngc_diagnostics::NgcResult;
+
+use crate::ast::*;
+use crate::extract::ExtractedComponent;
+
+/// Generated Ivy output for a component.
+#[derive(Debug, Clone)]
+pub struct IvyOutput {
+    /// The `static ɵfac = ...` field code.
+    pub factory_code: String,
+    /// The `static ɵcmp = ɵɵdefineComponent({...})` field code.
+    pub define_component_code: String,
+    /// Child template functions (for @if, @for, @switch blocks).
+    pub child_template_functions: Vec<String>,
+    /// Set of Ivy runtime symbols needed from `@angular/core`.
+    pub ivy_imports: BTreeSet<String>,
+}
+
+/// Internal codegen state.
+struct IvyCodegen {
+    component_name: String,
+    slot_index: u32,
+    var_count: u32,
+    creation: Vec<String>,
+    update: Vec<String>,
+    child_templates: Vec<ChildTemplate>,
+    ivy_imports: BTreeSet<String>,
+    child_counter: u32,
+}
+
+struct ChildTemplate {
+    #[allow(dead_code)]
+    function_name: String,
+    decls: u32,
+    vars: u32,
+    code: String,
+}
+
+/// Generate Ivy instructions from a parsed template AST and component metadata.
+pub fn generate_ivy(
+    component: &ExtractedComponent,
+    template_nodes: &[TemplateNode],
+) -> NgcResult<IvyOutput> {
+    let mut gen = IvyCodegen {
+        component_name: component.class_name.clone(),
+        slot_index: 0,
+        var_count: 0,
+        creation: Vec::new(),
+        update: Vec::new(),
+        child_templates: Vec::new(),
+        ivy_imports: BTreeSet::new(),
+        child_counter: 0,
+    };
+
+    gen.ivy_imports
+        .insert("\u{0275}\u{0275}defineComponent".to_string());
+    if component.standalone {
+        gen.ivy_imports
+            .insert("\u{0275}\u{0275}StandaloneFeature".to_string());
+    }
+
+    gen.generate_nodes(template_nodes);
+
+    let decls = gen.slot_index;
+    let vars = gen.var_count;
+
+    // Build template function body
+    let mut template_body = String::new();
+    if !gen.creation.is_empty() {
+        template_body.push_str("    if (rf & 1) {\n");
+        for instr in &gen.creation {
+            template_body.push_str("      ");
+            template_body.push_str(instr);
+            template_body.push('\n');
+        }
+        template_body.push_str("    }\n");
+    }
+    if !gen.update.is_empty() {
+        template_body.push_str("    if (rf & 2) {\n");
+        for instr in &gen.update {
+            template_body.push_str("      ");
+            template_body.push_str(instr);
+            template_body.push('\n');
+        }
+        template_body.push_str("    }\n");
+    }
+
+    // Build factory
+    let factory_code = format!(
+        "static \u{0275}fac = function {name}_Factory(t: any) {{ return new (t || {name})(); }}",
+        name = component.class_name
+    );
+
+    // Build defineComponent
+    let mut dc = String::new();
+    dc.push_str("static \u{0275}cmp = \u{0275}\u{0275}defineComponent({\n");
+    dc.push_str(&format!("    type: {},\n", component.class_name));
+    dc.push_str(&format!("    selectors: [['{}']],\n", component.selector));
+    if component.standalone {
+        dc.push_str("    standalone: true,\n");
+        dc.push_str("    features: [\u{0275}\u{0275}StandaloneFeature],\n");
+    }
+    dc.push_str(&format!("    decls: {decls},\n"));
+    dc.push_str(&format!("    vars: {vars},\n"));
+    dc.push_str(&format!(
+        "    template: function {}_Template(rf: number, ctx: {}) {{\n",
+        component.class_name, component.class_name
+    ));
+    dc.push_str(&template_body);
+    dc.push_str("    }");
+
+    // Add dependencies if imports exist
+    if let Some(ref imports_src) = component.imports_source {
+        dc.push_str(&format!(",\n    dependencies: {imports_src}"));
+    }
+    dc.push_str("\n  })");
+
+    // Collect child template functions
+    let child_fns: Vec<String> = gen
+        .child_templates
+        .iter()
+        .map(|ct| ct.code.clone())
+        .collect();
+
+    Ok(IvyOutput {
+        factory_code,
+        define_component_code: dc,
+        child_template_functions: child_fns,
+        ivy_imports: gen.ivy_imports,
+    })
+}
+
+impl IvyCodegen {
+    fn generate_nodes(&mut self, nodes: &[TemplateNode]) {
+        for node in nodes {
+            self.generate_node(node);
+        }
+    }
+
+    fn generate_node(&mut self, node: &TemplateNode) {
+        match node {
+            TemplateNode::Element(el) => self.generate_element(el),
+            TemplateNode::Text(text) => self.generate_text(text),
+            TemplateNode::Interpolation(interp) => self.generate_interpolation(interp),
+            TemplateNode::IfBlock(block) => self.generate_if_block(block),
+            TemplateNode::ForBlock(block) => self.generate_for_block(block),
+            TemplateNode::SwitchBlock(block) => self.generate_switch_block(block),
+        }
+    }
+
+    fn generate_element(&mut self, el: &ElementNode) {
+        let slot = self.slot_index;
+        self.slot_index += 1;
+
+        // Collect event and update bindings
+        let _has_events = el
+            .attributes
+            .iter()
+            .any(|a| matches!(a, TemplateAttribute::Event { .. }));
+        let has_bindings = el.attributes.iter().any(|a| {
+            matches!(
+                a,
+                TemplateAttribute::Property { .. }
+                    | TemplateAttribute::ClassBinding { .. }
+                    | TemplateAttribute::StyleBinding { .. }
+                    | TemplateAttribute::AttrBinding { .. }
+            )
+        });
+
+        // Static attributes for consts
+        let static_attrs: Vec<(&str, &str)> = el
+            .attributes
+            .iter()
+            .filter_map(|a| match a {
+                TemplateAttribute::Static {
+                    name,
+                    value: Some(v),
+                } => Some((name.as_str(), v.as_str())),
+                _ => None,
+            })
+            .collect();
+
+        if el.is_void {
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}element".to_string());
+            if static_attrs.is_empty() {
+                self.creation
+                    .push(format!("\u{0275}\u{0275}element({slot}, '{}');", el.tag));
+            } else {
+                let attrs_str = format_static_attrs(&static_attrs);
+                self.creation.push(format!(
+                    "\u{0275}\u{0275}element({slot}, '{}', {attrs_str});",
+                    el.tag
+                ));
+            }
+        } else {
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}elementStart".to_string());
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}elementEnd".to_string());
+            if static_attrs.is_empty() {
+                self.creation.push(format!(
+                    "\u{0275}\u{0275}elementStart({slot}, '{}');",
+                    el.tag
+                ));
+            } else {
+                let attrs_str = format_static_attrs(&static_attrs);
+                self.creation.push(format!(
+                    "\u{0275}\u{0275}elementStart({slot}, '{}', {attrs_str});",
+                    el.tag
+                ));
+            }
+
+            // Event listeners in creation block
+            for attr in &el.attributes {
+                if let TemplateAttribute::Event { name, handler } = attr {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}listener".to_string());
+                    self.creation.push(format!(
+                        "\u{0275}\u{0275}listener('{}', function() {{ return ctx.{}; }});",
+                        name, handler
+                    ));
+                }
+            }
+
+            // Generate children
+            self.generate_nodes(&el.children);
+
+            self.creation
+                .push("\u{0275}\u{0275}elementEnd();".to_string());
+        }
+
+        // Property bindings in update block
+        if has_bindings {
+            self.add_advance(slot);
+        }
+        for attr in &el.attributes {
+            match attr {
+                TemplateAttribute::Property { name, expression } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}property".to_string());
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}property('{}', ctx.{});",
+                        name, expression
+                    ));
+                    self.var_count += 1;
+                }
+                TemplateAttribute::ClassBinding {
+                    class_name,
+                    expression,
+                } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}classProp".to_string());
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}classProp('{}', ctx.{});",
+                        class_name, expression
+                    ));
+                    self.var_count += 1;
+                }
+                TemplateAttribute::StyleBinding {
+                    property,
+                    expression,
+                } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}styleProp".to_string());
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}styleProp('{}', ctx.{});",
+                        property, expression
+                    ));
+                    self.var_count += 1;
+                }
+                TemplateAttribute::AttrBinding { name, expression } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}attribute".to_string());
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}attribute('{}', ctx.{});",
+                        name, expression
+                    ));
+                    self.var_count += 1;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn generate_text(&mut self, text: &TextNode) {
+        let slot = self.slot_index;
+        self.slot_index += 1;
+        self.ivy_imports.insert("\u{0275}\u{0275}text".to_string());
+
+        let escaped = text.value.replace('\'', "\\'");
+        self.creation
+            .push(format!("\u{0275}\u{0275}text({slot}, '{escaped}');"));
+    }
+
+    fn generate_interpolation(&mut self, interp: &InterpolationNode) {
+        let slot = self.slot_index;
+        self.slot_index += 1;
+        self.ivy_imports.insert("\u{0275}\u{0275}text".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}textInterpolate".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}advance".to_string());
+
+        self.creation.push(format!("\u{0275}\u{0275}text({slot});"));
+
+        // Build the expression with pipe wrapping
+        let expr = if interp.pipes.is_empty() {
+            format!("ctx.{}", interp.expression)
+        } else {
+            self.wrap_with_pipes(&interp.expression, &interp.pipes)
+        };
+
+        self.add_advance(slot);
+        self.update
+            .push(format!("\u{0275}\u{0275}textInterpolate({expr});"));
+        self.var_count += 1;
+    }
+
+    fn generate_if_block(&mut self, block: &IfBlockNode) {
+        let slot = self.slot_index;
+        self.slot_index += 1;
+
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}template".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}conditional".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}advance".to_string());
+
+        // Generate child template for the @if body
+        let child_fn_name = format!(
+            "{}_Conditional_{}_Template",
+            self.component_name, self.child_counter
+        );
+        self.child_counter += 1;
+
+        let child = self.generate_child_template(&child_fn_name, &block.children);
+        self.creation.push(format!(
+            "\u{0275}\u{0275}template({slot}, {child_fn_name}, {}, {});",
+            child.decls, child.vars
+        ));
+        self.child_templates.push(child);
+
+        // Generate else-if and else child templates
+        let mut else_if_fns = Vec::new();
+        for (i, branch) in block.else_if_branches.iter().enumerate() {
+            let fn_name = format!(
+                "{}_ConditionalElseIf_{}_{}_Template",
+                self.component_name, slot, i
+            );
+            let ei_slot = self.slot_index;
+            self.slot_index += 1;
+            let child = self.generate_child_template(&fn_name, &branch.children);
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({ei_slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+            else_if_fns.push((branch.condition.clone(), fn_name.clone()));
+            self.child_templates.push(child);
+        }
+
+        let mut else_fn_name = None;
+        if let Some(ref else_children) = block.else_branch {
+            let fn_name = format!("{}_ConditionalElse_{}_Template", self.component_name, slot);
+            let else_slot = self.slot_index;
+            self.slot_index += 1;
+            let child = self.generate_child_template(&fn_name, else_children);
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({else_slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+            else_fn_name = Some(fn_name.clone());
+            self.child_templates.push(child);
+        }
+
+        // Update block: conditional
+        self.add_advance(slot);
+        let cond_expr = build_conditional_expr(&block.condition, &else_if_fns, &else_fn_name);
+        self.update
+            .push(format!("\u{0275}\u{0275}conditional({cond_expr});"));
+        self.var_count += 1;
+    }
+
+    fn generate_for_block(&mut self, block: &ForBlockNode) {
+        let slot = self.slot_index;
+        self.slot_index += 1;
+
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}repeaterCreate".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}repeater".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}advance".to_string());
+
+        let child_fn_name = format!(
+            "{}_For_{}_Template",
+            self.component_name, self.child_counter
+        );
+        self.child_counter += 1;
+
+        let child =
+            self.generate_for_child_template(&child_fn_name, &block.item_name, &block.children);
+        self.creation.push(format!(
+            "\u{0275}\u{0275}repeaterCreate({slot}, {child_fn_name}, {}, {});",
+            child.decls, child.vars
+        ));
+        self.child_templates.push(child);
+
+        // @empty block
+        if let Some(ref empty_children) = block.empty_children {
+            let empty_fn_name = format!("{}_ForEmpty_{}_Template", self.component_name, slot);
+            let empty_slot = self.slot_index;
+            self.slot_index += 1;
+            let empty_child = self.generate_child_template(&empty_fn_name, empty_children);
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({empty_slot}, {empty_fn_name}, {}, {});",
+                empty_child.decls, empty_child.vars
+            ));
+            self.child_templates.push(empty_child);
+        }
+
+        self.add_advance(slot);
+        self.update
+            .push(format!("\u{0275}\u{0275}repeater(ctx.{});", block.iterable));
+        self.var_count += 1;
+    }
+
+    fn generate_switch_block(&mut self, block: &SwitchBlockNode) {
+        // Similar to @if with multiple conditional branches
+        let slot = self.slot_index;
+        self.slot_index += 1;
+
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}template".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}conditional".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}advance".to_string());
+
+        let mut case_fns = Vec::new();
+        for (i, case) in block.cases.iter().enumerate() {
+            let fn_name = format!("{}_SwitchCase_{}_{}_Template", self.component_name, slot, i);
+            let case_slot = self.slot_index;
+            self.slot_index += 1;
+            let child = self.generate_child_template(&fn_name, &case.children);
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({case_slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+            case_fns.push((case.expression.clone(), i));
+            self.child_templates.push(child);
+        }
+
+        let mut default_fn = None;
+        if let Some(ref default_children) = block.default_branch {
+            let fn_name = format!("{}_SwitchDefault_{}_Template", self.component_name, slot);
+            let default_slot = self.slot_index;
+            self.slot_index += 1;
+            let child = self.generate_child_template(&fn_name, default_children);
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({default_slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+            default_fn = Some(case_fns.len());
+            self.child_templates.push(child);
+        }
+
+        self.add_advance(slot);
+        // Build switch conditional expression
+        let mut cond = String::new();
+        for (i, (expr, idx)) in case_fns.iter().enumerate() {
+            if i > 0 {
+                cond.push_str(" : ");
+            }
+            cond.push_str(&format!("ctx.{} === {} ? {}", block.expression, expr, idx));
+        }
+        if let Some(default_idx) = default_fn {
+            cond.push_str(&format!(" : {default_idx}"));
+        } else {
+            cond.push_str(" : -1");
+        }
+        self.update
+            .push(format!("\u{0275}\u{0275}conditional({cond});"));
+        self.var_count += 1;
+    }
+
+    fn generate_child_template(
+        &mut self,
+        fn_name: &str,
+        children: &[TemplateNode],
+    ) -> ChildTemplate {
+        // Save parent state
+        let parent_slot = self.slot_index;
+        let parent_var = self.var_count;
+        let parent_creation = std::mem::take(&mut self.creation);
+        let parent_update = std::mem::take(&mut self.update);
+
+        self.slot_index = 0;
+        self.var_count = 0;
+
+        self.generate_nodes(children);
+
+        let decls = self.slot_index;
+        let vars = self.var_count;
+
+        let mut code = format!("function {fn_name}(rf: number, ctx: any) {{\n");
+        if !self.creation.is_empty() {
+            code.push_str("  if (rf & 1) {\n");
+            for instr in &self.creation {
+                code.push_str("    ");
+                code.push_str(instr);
+                code.push('\n');
+            }
+            code.push_str("  }\n");
+        }
+        if !self.update.is_empty() {
+            code.push_str("  if (rf & 2) {\n");
+            for instr in &self.update {
+                code.push_str("    ");
+                code.push_str(instr);
+                code.push('\n');
+            }
+            code.push_str("  }\n");
+        }
+        code.push('}');
+
+        // Restore parent state
+        self.slot_index = parent_slot;
+        self.var_count = parent_var;
+        self.creation = parent_creation;
+        self.update = parent_update;
+
+        ChildTemplate {
+            function_name: fn_name.to_string(),
+            decls,
+            vars,
+            code,
+        }
+    }
+
+    fn generate_for_child_template(
+        &mut self,
+        fn_name: &str,
+        item_name: &str,
+        children: &[TemplateNode],
+    ) -> ChildTemplate {
+        // Save parent state
+        let parent_slot = self.slot_index;
+        let parent_var = self.var_count;
+        let parent_creation = std::mem::take(&mut self.creation);
+        let parent_update = std::mem::take(&mut self.update);
+
+        self.slot_index = 0;
+        self.var_count = 0;
+
+        self.generate_nodes(children);
+
+        let decls = self.slot_index;
+        let vars = self.var_count;
+
+        let mut code = format!("function {fn_name}(rf: number, ctx: any) {{\n");
+        if !self.creation.is_empty() {
+            code.push_str("  if (rf & 1) {\n");
+            for instr in &self.creation {
+                code.push_str("    ");
+                code.push_str(instr);
+                code.push('\n');
+            }
+            code.push_str("  }\n");
+        }
+        if !self.update.is_empty() {
+            code.push_str("  if (rf & 2) {\n");
+            code.push_str(&format!("    const {item_name} = ctx.$implicit;\n"));
+            for instr in &self.update {
+                code.push_str("    ");
+                code.push_str(instr);
+                code.push('\n');
+            }
+            code.push_str("  }\n");
+        }
+        code.push('}');
+
+        // Restore parent state
+        self.slot_index = parent_slot;
+        self.var_count = parent_var;
+        self.creation = parent_creation;
+        self.update = parent_update;
+
+        ChildTemplate {
+            function_name: fn_name.to_string(),
+            decls,
+            vars,
+            code,
+        }
+    }
+
+    fn wrap_with_pipes(&mut self, base_expr: &str, pipes: &[PipeCall]) -> String {
+        let mut expr = format!("ctx.{base_expr}");
+        for pipe in pipes {
+            let pipe_slot = self.slot_index;
+            self.slot_index += 1;
+            self.var_count += 1 + pipe.args.len() as u32;
+
+            self.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
+            self.creation.push(format!(
+                "\u{0275}\u{0275}pipe({pipe_slot}, '{}');",
+                pipe.name
+            ));
+
+            let bind_fn = match pipe.args.len() {
+                0 => "\u{0275}\u{0275}pipeBind1".to_string(),
+                1 => "\u{0275}\u{0275}pipeBind2".to_string(),
+                2 => "\u{0275}\u{0275}pipeBind3".to_string(),
+                _ => "\u{0275}\u{0275}pipeBindV".to_string(),
+            };
+            self.ivy_imports.insert(bind_fn.clone());
+
+            let pipe_var_slot = self.var_count;
+            if pipe.args.is_empty() {
+                expr = format!("{bind_fn}({pipe_slot}, {pipe_var_slot}, {expr})");
+            } else {
+                let args_str = pipe.args.join(", ");
+                expr = format!("{bind_fn}({pipe_slot}, {pipe_var_slot}, {expr}, {args_str})");
+            }
+        }
+        expr
+    }
+
+    /// Add an `ɵɵadvance()` instruction to the update block if needed.
+    fn add_advance(&mut self, _target_slot: u32) {
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}advance".to_string());
+        // For simplicity, always emit advance() (delta = 1)
+        // A more sophisticated implementation would compute exact deltas
+        self.update.push("\u{0275}\u{0275}advance();".to_string());
+    }
+}
+
+/// Build a conditional expression for @if chains.
+fn build_conditional_expr(
+    condition: &str,
+    else_ifs: &[(String, String)],
+    else_fn: &Option<String>,
+) -> String {
+    let mut expr = format!("ctx.{condition} ? 0 : ");
+
+    for (i, (cond, _fn_name)) in else_ifs.iter().enumerate() {
+        expr.push_str(&format!("ctx.{cond} ? {} : ", i + 1));
+    }
+
+    if else_fn.is_some() {
+        expr.push_str(&format!("{}", else_ifs.len() + 1));
+    } else {
+        expr.push_str("-1");
+    }
+
+    expr
+}
+
+/// Format static attributes as an array expression.
+fn format_static_attrs(attrs: &[(&str, &str)]) -> String {
+    let pairs: Vec<String> = attrs
+        .iter()
+        .flat_map(|(k, v)| vec![format!("'{k}'"), format!("'{v}'")])
+        .collect();
+    format!("[{}]", pairs.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::*;
+    use crate::extract::ExtractedComponent;
+
+    fn test_component() -> ExtractedComponent {
+        ExtractedComponent {
+            class_name: "TestComponent".to_string(),
+            selector: "app-test".to_string(),
+            template: Some("<h1>Hello</h1>".to_string()),
+            template_url: None,
+            standalone: true,
+            imports_source: None,
+            imports_identifiers: Vec::new(),
+            decorator_span: (0, 0),
+            class_body_start: 0,
+            export_keyword_start: None,
+            class_keyword_start: 0,
+            angular_core_import_span: None,
+            other_angular_core_imports: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_void_element_codegen() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "br".to_string(),
+            attributes: Vec::new(),
+            children: Vec::new(),
+            is_void: true,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        assert!(output.define_component_code.contains("decls: 1"));
+        assert!(output.define_component_code.contains("vars: 0"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}element"));
+    }
+
+    #[test]
+    fn test_paired_element_with_text() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "h1".to_string(),
+            attributes: Vec::new(),
+            children: vec![TemplateNode::Text(TextNode {
+                value: "Hello".to_string(),
+            })],
+            is_void: false,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        assert!(output.define_component_code.contains("decls: 2"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}elementStart"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}text"));
+    }
+
+    #[test]
+    fn test_interpolation_codegen() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Interpolation(InterpolationNode {
+            expression: "title".to_string(),
+            pipes: Vec::new(),
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        assert!(output.define_component_code.contains("decls: 1"));
+        assert!(output.define_component_code.contains("vars: 1"));
+        assert!(output
+            .define_component_code
+            .contains("\u{0275}\u{0275}textInterpolate(ctx.title)"));
+    }
+
+    #[test]
+    fn test_event_binding_codegen() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "button".to_string(),
+            attributes: vec![TemplateAttribute::Event {
+                name: "click".to_string(),
+                handler: "onClick()".to_string(),
+            }],
+            children: vec![TemplateNode::Text(TextNode {
+                value: "Click".to_string(),
+            })],
+            is_void: false,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}listener"));
+        assert!(output.define_component_code.contains("listener"));
+    }
+
+    #[test]
+    fn test_factory_code() {
+        let comp = test_component();
+        let nodes = vec![];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        assert!(output.factory_code.contains("TestComponent_Factory"));
+        assert!(output.factory_code.contains("new (t || TestComponent)()"));
+    }
+}

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -672,7 +672,6 @@ fn format_static_attrs(attrs: &[(&str, &str)]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::*;
     use crate::extract::ExtractedComponent;
 
     fn test_component() -> ExtractedComponent {

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -1,0 +1,427 @@
+use std::path::Path;
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Argument, Decorator, Expression, ObjectPropertyKind, PropertyKey, Statement};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+/// Metadata extracted from an `@Component` decorator.
+#[derive(Debug, Clone)]
+pub struct ExtractedComponent {
+    /// The class name (e.g. `AppComponent`).
+    pub class_name: String,
+    /// The component selector (e.g. `app-root`).
+    pub selector: String,
+    /// The inline template string, if present.
+    pub template: Option<String>,
+    /// The templateUrl, if present (triggers JIT fallback).
+    pub template_url: Option<String>,
+    /// Whether the component is standalone.
+    pub standalone: bool,
+    /// Raw source text of the imports array (e.g. `[RouterOutlet]`).
+    pub imports_source: Option<String>,
+    /// Individual import identifiers (e.g. `["RouterOutlet"]`).
+    #[allow(dead_code)]
+    pub imports_identifiers: Vec<String>,
+    /// Byte offset range of the full decorator (from `@` to closing `)`).
+    pub decorator_span: (u32, u32),
+    /// Byte offset of the class body opening `{`.
+    pub class_body_start: u32,
+    /// Byte offset of the `export` keyword, if present.
+    #[allow(dead_code)]
+    pub export_keyword_start: Option<u32>,
+    /// Byte offset of the class keyword.
+    #[allow(dead_code)]
+    pub class_keyword_start: u32,
+    /// The source text of the `@angular/core` import declaration span, for rewriting.
+    pub angular_core_import_span: Option<(u32, u32)>,
+    /// Named imports from `@angular/core` other than `Component`.
+    pub other_angular_core_imports: Vec<String>,
+}
+
+impl ExtractedComponent {
+    /// Check whether the component should use JIT fallback.
+    pub fn needs_jit_fallback(&self) -> bool {
+        // templateUrl always requires JIT
+        if self.template_url.is_some() {
+            return true;
+        }
+        // Check template for unsupported patterns
+        if let Some(ref tpl) = self.template {
+            if tpl.contains("*ngIf")
+                || tpl.contains("*ngFor")
+                || tpl.contains("[(")
+                || tpl.contains("<ng-content")
+                || tpl.contains("<ng-template")
+                || tpl.contains("<ng-container")
+            {
+                return true;
+            }
+            // Check for template reference variables (# followed by a letter)
+            let bytes = tpl.as_bytes();
+            for i in 0..bytes.len().saturating_sub(1) {
+                if bytes[i] == b'#' && bytes[i + 1].is_ascii_alphabetic() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+/// Extract `@Component` metadata from a TypeScript source file.
+///
+/// Returns `None` if no `@Component` decorator is found. Returns an error
+/// if the source can't be parsed.
+pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<ExtractedComponent>> {
+    let allocator = Allocator::new();
+    let source_type =
+        SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "unsupported file extension".to_string(),
+        })?;
+
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked {
+        return Err(NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "parser panicked".to_string(),
+        });
+    }
+
+    // Find @angular/core import span and non-Component imports
+    let mut angular_core_import_span = None;
+    let mut other_angular_core_imports = Vec::new();
+
+    for stmt in &parsed.program.body {
+        if let Statement::ImportDeclaration(import) = stmt {
+            if import.source.value.as_str() == "@angular/core" {
+                angular_core_import_span = Some((import.span.start, import.span.end));
+                if let Some(specifiers) = &import.specifiers {
+                    for spec in specifiers {
+                        if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(s) = spec {
+                            let name = s.local.name.as_str();
+                            if name != "Component" {
+                                other_angular_core_imports.push(name.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Find class with @Component decorator
+    for stmt in &parsed.program.body {
+        let (class, export_start) = match stmt {
+            Statement::ExportDefaultDeclaration(export) => {
+                if let oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class) =
+                    &export.declaration
+                {
+                    (class, Some(export.span.start))
+                } else {
+                    continue;
+                }
+            }
+            Statement::ExportNamedDeclaration(export) => {
+                if let Some(oxc_ast::ast::Declaration::ClassDeclaration(class)) =
+                    &export.declaration
+                {
+                    (class, Some(export.span.start))
+                } else {
+                    continue;
+                }
+            }
+            Statement::ClassDeclaration(class) => (class, None),
+            _ => continue,
+        };
+
+        let component_decorator = find_component_decorator(&class.decorators);
+        if component_decorator.is_none() {
+            continue;
+        }
+        let decorator = component_decorator.expect("checked above");
+
+        let class_name = class
+            .id
+            .as_ref()
+            .map(|id| id.name.to_string())
+            .unwrap_or_else(|| "AnonymousComponent".to_string());
+
+        let class_body_start = class.body.span.start;
+        let class_keyword_start = class.span.start;
+
+        let metadata = extract_decorator_metadata(source, decorator)?;
+
+        return Ok(Some(ExtractedComponent {
+            class_name,
+            selector: metadata.selector,
+            template: metadata.template,
+            template_url: metadata.template_url,
+            standalone: metadata.standalone,
+            imports_source: metadata.imports_source,
+            imports_identifiers: metadata.imports_identifiers,
+            decorator_span: (decorator.span.start, decorator.span.end),
+            class_body_start,
+            export_keyword_start: export_start,
+            class_keyword_start,
+            angular_core_import_span,
+            other_angular_core_imports,
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Find the `@Component(...)` decorator in a list of decorators.
+fn find_component_decorator<'a>(decorators: &'a [Decorator<'a>]) -> Option<&'a Decorator<'a>> {
+    decorators.iter().find(|d| {
+        if let Expression::CallExpression(call) = &d.expression {
+            if let Expression::Identifier(ident) = &call.callee {
+                return ident.name.as_str() == "Component";
+            }
+        }
+        false
+    })
+}
+
+/// Metadata extracted from the decorator's argument object.
+struct DecoratorMetadata {
+    selector: String,
+    template: Option<String>,
+    template_url: Option<String>,
+    standalone: bool,
+    imports_source: Option<String>,
+    imports_identifiers: Vec<String>,
+}
+
+/// Extract metadata from the `@Component({...})` decorator argument.
+fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<DecoratorMetadata> {
+    let call = match &decorator.expression {
+        Expression::CallExpression(call) => call,
+        _ => {
+            return Ok(DecoratorMetadata {
+                selector: String::new(),
+                template: None,
+                template_url: None,
+                standalone: false,
+                imports_source: None,
+                imports_identifiers: Vec::new(),
+            });
+        }
+    };
+
+    let arg = match call.arguments.first() {
+        Some(Argument::ObjectExpression(obj)) => obj,
+        _ => {
+            return Ok(DecoratorMetadata {
+                selector: String::new(),
+                template: None,
+                template_url: None,
+                standalone: false,
+                imports_source: None,
+                imports_identifiers: Vec::new(),
+            });
+        }
+    };
+
+    let mut selector = String::new();
+    let mut template = None;
+    let mut template_url = None;
+    let mut standalone = false;
+    let mut imports_source = None;
+    let mut imports_identifiers = Vec::new();
+
+    for prop in &arg.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+            let key_name = match &prop.key {
+                PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                _ => continue,
+            };
+
+            match key_name.as_str() {
+                "selector" => {
+                    if let Expression::StringLiteral(s) = &prop.value {
+                        selector = s.value.to_string();
+                    }
+                }
+                "template" => {
+                    if let Expression::StringLiteral(s) = &prop.value {
+                        template = Some(s.value.to_string());
+                    } else if let Expression::TemplateLiteral(tpl) = &prop.value {
+                        // Template literal with no expressions = static string
+                        if tpl.expressions.is_empty() {
+                            let text: String =
+                                tpl.quasis.iter().map(|q| q.value.raw.as_str()).collect();
+                            template = Some(text);
+                        }
+                    }
+                }
+                "templateUrl" => {
+                    if let Expression::StringLiteral(s) = &prop.value {
+                        template_url = Some(s.value.to_string());
+                    }
+                }
+                "standalone" => {
+                    if let Expression::BooleanLiteral(b) = &prop.value {
+                        standalone = b.value;
+                    }
+                }
+                "imports" => {
+                    // Capture the raw source text for the imports array
+                    let start = prop.value.span().start as usize;
+                    let end = prop.value.span().end as usize;
+                    if start < source.len() && end <= source.len() {
+                        imports_source = Some(source[start..end].to_string());
+                    }
+                    // Also extract individual identifiers
+                    if let Expression::ArrayExpression(arr) = &prop.value {
+                        for elem in &arr.elements {
+                            if let oxc_ast::ast::ArrayExpressionElement::Identifier(ident) = elem {
+                                imports_identifiers.push(ident.name.to_string());
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(DecoratorMetadata {
+        selector,
+        template,
+        template_url,
+        standalone,
+        imports_source,
+        imports_identifiers,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_path() -> PathBuf {
+        PathBuf::from("test.ts")
+    }
+
+    #[test]
+    fn test_extract_simple_component() {
+        let source = r#"import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: '<h1>Hello</h1>'
+})
+export class AppComponent {
+  title = 'app';
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert_eq!(result.class_name, "AppComponent");
+        assert_eq!(result.selector, "app-root");
+        assert_eq!(result.template.as_deref(), Some("<h1>Hello</h1>"));
+        assert!(result.standalone);
+        assert!(result.template_url.is_none());
+    }
+
+    #[test]
+    fn test_extract_with_imports_array() {
+        let source = r#"import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet],
+  template: '<router-outlet />'
+})
+export class AppComponent {}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert_eq!(result.imports_identifiers, vec!["RouterOutlet"]);
+        assert!(result.imports_source.is_some());
+    }
+
+    #[test]
+    fn test_extract_template_url_triggers_jit() {
+        let source = r#"import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent {}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert!(result.needs_jit_fallback());
+    }
+
+    #[test]
+    fn test_no_component_returns_none() {
+        let source = "export class PlainClass { x = 1; }\n";
+        let result = extract_component(source, &test_path()).expect("should not error");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_ngif_triggers_jit() {
+        let source = r#"import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  template: '<div *ngIf="show">Hello</div>'
+})
+export class TestComponent {}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert!(result.needs_jit_fallback());
+    }
+
+    #[test]
+    fn test_template_literal() {
+        let source = r#"import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `<h1>Hello</h1>`
+})
+export class AppComponent {}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert_eq!(result.template.as_deref(), Some("<h1>Hello</h1>"));
+    }
+
+    #[test]
+    fn test_angular_core_import_tracking() {
+        let source = r#"import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: '<h1>Hello</h1>'
+})
+export class AppComponent implements OnInit {
+  ngOnInit() {}
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert!(result.angular_core_import_span.is_some());
+        assert_eq!(result.other_angular_core_imports, vec!["OnInit"]);
+    }
+}

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -2,17 +2,26 @@
 
 template = { SOI ~ node* ~ EOI }
 
-node = _{ control_flow | element | interpolation | text }
+node = _{ control_flow | html_comment | element | interpolation | text }
+
+// HTML comments: <!-- ... -->
+html_comment = { "<!--" ~ (!"-->" ~ ANY)* ~ "-->" }
 
 // Text: anything not starting a tag, interpolation, or control flow keyword
 text = @{ (!("<" | "{{" | "}" | "@if" | "@for" | "@switch" | "@else" | "@case" | "@default" | "@empty") ~ ANY)+ }
 
 // Text interpolation: {{ expression | pipe }}
+// Handles || (logical OR), balanced parens, and | only as top-level pipe separator
 interpolation = { "{{" ~ interp_expression ~ "}}" }
-interp_expression = { interp_raw ~ ("|" ~ pipe_call)* }
-interp_raw = @{ (!("}}" | "|") ~ ANY)+ }
+interp_expression = { interp_segment ~ ("|" ~ !"|" ~ pipe_call)* }
+interp_segment = { interp_token+ }
+interp_token = _{ interp_paren_group | interp_or | interp_atom }
+interp_paren_group = { "(" ~ (interp_paren_group | interp_or | interp_atom_in_paren)* ~ ")" }
+interp_or = { "||" }
+interp_atom = @{ (!("}}" | "|" | "(" | ")") ~ ANY)+ }
+interp_atom_in_paren = @{ (!"(" ~ !")" ~ ANY)+ }
 pipe_call = { identifier ~ (":" ~ pipe_arg)* }
-pipe_arg = @{ (!("}}" | "|") ~ ANY)+ }
+pipe_arg = @{ (!("}}") ~ ("||" | (!"|" ~ ANY)))+ }
 
 // HTML elements
 element = { void_element | paired_element }
@@ -35,15 +44,15 @@ static_attribute = { attr_name ~ ("=" ~ quoted_value)? }
 
 event_name = @{ (ASCII_ALPHANUMERIC | "." | "-")+ }
 prop_name = @{ (ASCII_ALPHANUMERIC | "-")+ }
-class_name = @{ (ASCII_ALPHANUMERIC | "-")+ }
-style_prop = @{ (ASCII_ALPHANUMERIC | "-")+ }
+class_name = @{ (ASCII_ALPHANUMERIC | "-" | ":" | "_" | "." | "/")+ }
+style_prop = @{ (ASCII_ALPHANUMERIC | "-" | "." | "%")+ }
 attr_name = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }
 
 quoted_value = { "\"" ~ inner_value ~ "\"" | "'" ~ inner_value_sq ~ "'" }
 inner_value = @{ (!("\"") ~ ANY)* }
 inner_value_sq = @{ (!("'") ~ ANY)* }
 
-identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Control flow blocks
 control_flow = _{ if_block | for_block | switch_block }
@@ -53,14 +62,20 @@ if_block = { "@if" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" ~ else_if_b
 else_if_block = { "@else" ~ "if" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" }
 else_block = { "@else" ~ "{" ~ node* ~ "}" }
 
-// Control flow expression — captures everything up to closing )
-ctrl_expression = @{ (!(")") ~ ANY)+ }
+// Control flow expression — handles balanced parentheses
+ctrl_expression = { ctrl_token+ }
+ctrl_token = _{ ctrl_paren_group | ctrl_char }
+ctrl_paren_group = { "(" ~ (ctrl_paren_group | ctrl_char)* ~ ")" }
+ctrl_char = @{ (!"(" ~ !")" ~ ANY)+ }
 
 // @for / @empty
 for_block = { "@for" ~ "(" ~ for_vars ~ ")" ~ "{" ~ node* ~ "}" ~ empty_block? }
 for_vars = { identifier ~ "of" ~ for_iterable ~ ";" ~ "track" ~ track_expression }
 for_iterable = @{ (!(";") ~ ANY)+ }
-track_expression = @{ (!(")") ~ ANY)+ }
+track_expression = { track_token+ }
+track_token = _{ track_paren_group | track_char }
+track_paren_group = { "(" ~ (track_paren_group | track_char)* ~ ")" }
+track_char = @{ (!"(" ~ !")" ~ ANY)+ }
 empty_block = { "@empty" ~ "{" ~ node* ~ "}" }
 
 // @switch / @case / @default

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -1,0 +1,72 @@
+// Angular template grammar for ngc-rs
+
+template = { SOI ~ node* ~ EOI }
+
+node = _{ control_flow | element | interpolation | text }
+
+// Text: anything not starting a tag, interpolation, or control flow keyword
+text = @{ (!("<" | "{{" | "}" | "@if" | "@for" | "@switch" | "@else" | "@case" | "@default" | "@empty") ~ ANY)+ }
+
+// Text interpolation: {{ expression | pipe }}
+interpolation = { "{{" ~ interp_expression ~ "}}" }
+interp_expression = { interp_raw ~ ("|" ~ pipe_call)* }
+interp_raw = @{ (!("}}" | "|") ~ ANY)+ }
+pipe_call = { identifier ~ (":" ~ pipe_arg)* }
+pipe_arg = @{ (!("}}" | "|") ~ ANY)+ }
+
+// HTML elements
+element = { void_element | paired_element }
+void_element = { "<" ~ tag_name ~ attribute* ~ "/>" }
+paired_element = { open_tag ~ node* ~ close_tag }
+open_tag = { "<" ~ tag_name ~ attribute* ~ ">" }
+close_tag = { "</" ~ tag_name ~ ">" }
+
+tag_name = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "-")* }
+
+// Attributes (ordered by specificity to avoid ambiguity)
+attribute = _{ class_binding | style_binding | attr_binding | event_binding | property_binding | static_attribute }
+
+event_binding = { "(" ~ event_name ~ ")" ~ "=" ~ quoted_value }
+property_binding = { "[" ~ prop_name ~ "]" ~ "=" ~ quoted_value }
+class_binding = { "[class." ~ class_name ~ "]" ~ "=" ~ quoted_value }
+style_binding = { "[style." ~ style_prop ~ "]" ~ "=" ~ quoted_value }
+attr_binding = { "[attr." ~ attr_name ~ "]" ~ "=" ~ quoted_value }
+static_attribute = { attr_name ~ ("=" ~ quoted_value)? }
+
+event_name = @{ (ASCII_ALPHANUMERIC | "." | "-")+ }
+prop_name = @{ (ASCII_ALPHANUMERIC | "-")+ }
+class_name = @{ (ASCII_ALPHANUMERIC | "-")+ }
+style_prop = @{ (ASCII_ALPHANUMERIC | "-")+ }
+attr_name = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }
+
+quoted_value = { "\"" ~ inner_value ~ "\"" | "'" ~ inner_value_sq ~ "'" }
+inner_value = @{ (!("\"") ~ ANY)* }
+inner_value_sq = @{ (!("'") ~ ANY)* }
+
+identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+
+// Control flow blocks
+control_flow = _{ if_block | for_block | switch_block }
+
+// @if / @else if / @else
+if_block = { "@if" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" ~ else_if_block* ~ else_block? }
+else_if_block = { "@else" ~ "if" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" }
+else_block = { "@else" ~ "{" ~ node* ~ "}" }
+
+// Control flow expression — captures everything up to closing )
+ctrl_expression = @{ (!(")") ~ ANY)+ }
+
+// @for / @empty
+for_block = { "@for" ~ "(" ~ for_vars ~ ")" ~ "{" ~ node* ~ "}" ~ empty_block? }
+for_vars = { identifier ~ "of" ~ for_iterable ~ ";" ~ "track" ~ track_expression }
+for_iterable = @{ (!(";") ~ ANY)+ }
+track_expression = @{ (!(")") ~ ANY)+ }
+empty_block = { "@empty" ~ "{" ~ node* ~ "}" }
+
+// @switch / @case / @default
+switch_block = { "@switch" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ switch_body* ~ "}" }
+switch_body = _{ case_block | default_block }
+case_block = { "@case" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" }
+default_block = { "@default" ~ "{" ~ node* ~ "}" }
+
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -1,0 +1,117 @@
+//! Angular template compiler for ngc-rs.
+//!
+//! Compiles `@Component` templates to Angular Ivy instructions. Parses template
+//! HTML with pest, generates Ivy codegen (ɵɵdefineComponent, template function),
+//! and rewrites TypeScript source to replace the decorator with static Ivy metadata.
+
+mod ast;
+mod codegen;
+mod extract;
+mod parser;
+mod rewrite;
+
+use std::path::{Path, PathBuf};
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use rayon::prelude::*;
+use tracing::debug;
+
+/// Result of template compilation for a single file.
+#[derive(Debug, Clone)]
+pub struct CompiledFile {
+    /// The original source file path.
+    pub source_path: PathBuf,
+    /// The rewritten TypeScript source (or original if no @Component found).
+    pub source: String,
+    /// Whether Ivy compilation was applied.
+    pub compiled: bool,
+    /// Whether JIT fallback was used (decorator left as-is).
+    pub jit_fallback: bool,
+}
+
+/// Compile Angular component templates in the given TypeScript source files.
+///
+/// For each file that contains an `@Component` decorator with an inline `template`,
+/// parses the template, generates Ivy instructions, and rewrites the source to
+/// replace the decorator with static Ivy metadata. Files without `@Component`
+/// decorators are returned unchanged.
+///
+/// Files are processed in parallel using rayon.
+pub fn compile_templates(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
+    let results: Vec<NgcResult<CompiledFile>> = files
+        .par_iter()
+        .map(|file_path| {
+            let source = std::fs::read_to_string(file_path).map_err(|e| NgcError::Io {
+                path: file_path.clone(),
+                source: e,
+            })?;
+
+            compile_component(&source, file_path)
+        })
+        .collect();
+
+    results.into_iter().collect()
+}
+
+/// Compile a single TypeScript source string containing an Angular component.
+///
+/// If the source contains an `@Component` decorator with an inline `template`,
+/// parses the template, generates Ivy instructions, and rewrites the source.
+/// If no `@Component` is found, returns the source unchanged.
+pub fn compile_component(source: &str, file_path: &Path) -> NgcResult<CompiledFile> {
+    let extracted = match extract::extract_component(source, file_path)? {
+        Some(ext) => ext,
+        None => {
+            return Ok(CompiledFile {
+                source_path: file_path.to_path_buf(),
+                source: source.to_string(),
+                compiled: false,
+                jit_fallback: false,
+            });
+        }
+    };
+
+    // Check for JIT fallback triggers
+    if extracted.needs_jit_fallback() {
+        tracing::warn!(
+            path = %file_path.display(),
+            "template contains unsupported constructs, using JIT fallback"
+        );
+        return Ok(CompiledFile {
+            source_path: file_path.to_path_buf(),
+            source: source.to_string(),
+            compiled: false,
+            jit_fallback: true,
+        });
+    }
+
+    let template_source = match &extracted.template {
+        Some(t) => t.as_str(),
+        None => {
+            return Ok(CompiledFile {
+                source_path: file_path.to_path_buf(),
+                source: source.to_string(),
+                compiled: false,
+                jit_fallback: false,
+            });
+        }
+    };
+
+    // Parse the template
+    let template_ast = parser::parse_template(template_source, file_path)?;
+
+    // Generate Ivy code
+    let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;
+
+    // Rewrite the source
+    let rewritten = rewrite::rewrite_source(source, &extracted, &ivy_output)?;
+
+    debug!(path = %file_path.display(), "compiled template to Ivy");
+
+    Ok(CompiledFile {
+        source_path: file_path.to_path_buf(),
+        source: rewritten,
+        compiled: true,
+        jit_fallback: false,
+    })
+}

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -49,6 +49,7 @@ fn parse_node(pair: pest::iterators::Pair<Rule>) -> NgcResult<Option<TemplateNod
             }
             Ok(Some(TemplateNode::Text(crate::ast::TextNode { value })))
         }
+        Rule::html_comment => Ok(None), // Skip HTML comments
         Rule::interpolation => Ok(Some(parse_interpolation(pair)?)),
         Rule::if_block => Ok(Some(parse_if_block(pair)?)),
         Rule::for_block => Ok(Some(parse_for_block(pair)?)),
@@ -247,6 +248,7 @@ fn parse_interp_expression(
     pair: pest::iterators::Pair<Rule>,
 ) -> NgcResult<(String, Vec<crate::ast::PipeCall>)> {
     let mut inner = pair.into_inner();
+    // interp_segment contains the full expression text (including balanced parens)
     let raw_expr = inner
         .next()
         .map(|p| p.as_str().trim().to_string())
@@ -431,8 +433,10 @@ fn parse_switch_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNo
     }))
 }
 
-/// Extract the text content from an expression pair.
+/// Extract the text content from an expression pair, handling nested rules.
 fn extract_expression_text(pair: pest::iterators::Pair<Rule>) -> String {
+    // For ctrl_expression and track_expression, the text comes from
+    // the span of the full pair (including inner paren groups)
     pair.as_str().trim().to_string()
 }
 

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -1,0 +1,614 @@
+use std::path::Path;
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use pest_derive::Parser;
+
+use crate::ast::TemplateNode;
+
+#[derive(Parser)]
+#[grammar = "grammar/angular.pest"]
+struct AngularTemplateParser;
+
+/// Parse an Angular template string into an AST.
+///
+/// Uses a pest grammar to parse the HTML-like template syntax including
+/// elements, interpolation, bindings, control flow, and pipes.
+pub fn parse_template(template: &str, file_path: &Path) -> NgcResult<Vec<TemplateNode>> {
+    use pest::Parser;
+
+    let pairs = AngularTemplateParser::parse(Rule::template, template).map_err(|e| {
+        NgcError::TemplateParseError {
+            path: file_path.to_path_buf(),
+            message: e.to_string(),
+        }
+    })?;
+
+    let mut nodes = Vec::new();
+    for pair in pairs {
+        if pair.as_rule() == Rule::template {
+            for inner in pair.into_inner() {
+                if inner.as_rule() != Rule::EOI {
+                    if let Some(node) = parse_node(inner)? {
+                        nodes.push(node);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(nodes)
+}
+
+fn parse_node(pair: pest::iterators::Pair<Rule>) -> NgcResult<Option<TemplateNode>> {
+    match pair.as_rule() {
+        Rule::element | Rule::void_element | Rule::paired_element => Ok(Some(parse_element(pair)?)),
+        Rule::text => {
+            let value = pair.as_str().to_string();
+            if value.trim().is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(TemplateNode::Text(crate::ast::TextNode { value })))
+        }
+        Rule::interpolation => Ok(Some(parse_interpolation(pair)?)),
+        Rule::if_block => Ok(Some(parse_if_block(pair)?)),
+        Rule::for_block => Ok(Some(parse_for_block(pair)?)),
+        Rule::switch_block => Ok(Some(parse_switch_block(pair)?)),
+        Rule::node => {
+            let inner = pair.into_inner().next();
+            match inner {
+                Some(p) => parse_node(p),
+                None => Ok(None),
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+fn parse_element(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let rule = pair.as_rule();
+    let mut inner = pair.into_inner();
+
+    match rule {
+        Rule::void_element => {
+            let tag = inner
+                .next()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_default();
+            let attributes = parse_attributes(&mut inner)?;
+            Ok(TemplateNode::Element(crate::ast::ElementNode {
+                tag,
+                attributes,
+                children: Vec::new(),
+                is_void: true,
+            }))
+        }
+        Rule::paired_element => {
+            let open_tag = inner.next();
+            let (tag, attributes) = if let Some(open) = open_tag {
+                let mut open_inner = open.into_inner();
+                let tag = open_inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let attrs = parse_attributes(&mut open_inner)?;
+                (tag, attrs)
+            } else {
+                (String::new(), Vec::new())
+            };
+
+            let mut children = Vec::new();
+            for child_pair in inner {
+                match child_pair.as_rule() {
+                    Rule::close_tag => break,
+                    _ => {
+                        if let Some(node) = parse_node(child_pair)? {
+                            children.push(node);
+                        }
+                    }
+                }
+            }
+
+            Ok(TemplateNode::Element(crate::ast::ElementNode {
+                tag,
+                attributes,
+                children,
+                is_void: false,
+            }))
+        }
+        Rule::element => {
+            // element is a choice between void_element and paired_element
+            if let Some(child) = inner.next() {
+                parse_element(child)
+            } else {
+                Ok(TemplateNode::Text(crate::ast::TextNode {
+                    value: String::new(),
+                }))
+            }
+        }
+        _ => Ok(TemplateNode::Text(crate::ast::TextNode {
+            value: String::new(),
+        })),
+    }
+}
+
+fn parse_attributes(
+    pairs: &mut pest::iterators::Pairs<Rule>,
+) -> NgcResult<Vec<crate::ast::TemplateAttribute>> {
+    let mut attrs = Vec::new();
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::event_binding => {
+                let mut inner = pair.into_inner();
+                let name = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let handler = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                attrs.push(crate::ast::TemplateAttribute::Event { name, handler });
+            }
+            Rule::property_binding => {
+                let mut inner = pair.into_inner();
+                let name = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let expression = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                attrs.push(crate::ast::TemplateAttribute::Property { name, expression });
+            }
+            Rule::class_binding => {
+                let mut inner = pair.into_inner();
+                let class_name = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let expression = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                attrs.push(crate::ast::TemplateAttribute::ClassBinding {
+                    class_name,
+                    expression,
+                });
+            }
+            Rule::style_binding => {
+                let mut inner = pair.into_inner();
+                let property = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let expression = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                attrs.push(crate::ast::TemplateAttribute::StyleBinding {
+                    property,
+                    expression,
+                });
+            }
+            Rule::attr_binding => {
+                let mut inner = pair.into_inner();
+                let name = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let expression = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                attrs.push(crate::ast::TemplateAttribute::AttrBinding { name, expression });
+            }
+            Rule::static_attribute => {
+                let mut inner = pair.into_inner();
+                let name = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                let value = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string());
+                attrs.push(crate::ast::TemplateAttribute::Static { name, value });
+            }
+            _ => {}
+        }
+    }
+    Ok(attrs)
+}
+
+fn parse_interpolation(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let mut inner = pair.into_inner();
+    // inner should be interp_expression
+    let expr_pair = inner.next();
+
+    let (expression, pipes) = if let Some(expr) = expr_pair {
+        parse_interp_expression(expr)?
+    } else {
+        (String::new(), Vec::new())
+    };
+
+    Ok(TemplateNode::Interpolation(crate::ast::InterpolationNode {
+        expression,
+        pipes,
+    }))
+}
+
+fn parse_interp_expression(
+    pair: pest::iterators::Pair<Rule>,
+) -> NgcResult<(String, Vec<crate::ast::PipeCall>)> {
+    let mut inner = pair.into_inner();
+    let raw_expr = inner
+        .next()
+        .map(|p| p.as_str().trim().to_string())
+        .unwrap_or_default();
+
+    let mut pipes = Vec::new();
+    for pipe_pair in inner {
+        if pipe_pair.as_rule() == Rule::pipe_call {
+            let mut pipe_inner = pipe_pair.into_inner();
+            let name = pipe_inner
+                .next()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_default();
+            let args: Vec<String> = pipe_inner
+                .filter(|p| p.as_rule() == Rule::pipe_arg)
+                .map(|p| p.as_str().trim().to_string())
+                .collect();
+            pipes.push(crate::ast::PipeCall { name, args });
+        }
+    }
+
+    Ok((raw_expr, pipes))
+}
+
+fn parse_if_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let mut inner = pair.into_inner();
+
+    let condition = inner
+        .next()
+        .map(|p| extract_expression_text(p))
+        .unwrap_or_default();
+
+    let mut children = Vec::new();
+    let mut else_if_branches = Vec::new();
+    let mut else_branch = None;
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::else_if_block => {
+                let mut ei_inner = p.into_inner();
+                let ei_cond = ei_inner
+                    .next()
+                    .map(|p| extract_expression_text(p))
+                    .unwrap_or_default();
+                let mut ei_children = Vec::new();
+                for child in ei_inner {
+                    if let Some(node) = parse_node(child)? {
+                        ei_children.push(node);
+                    }
+                }
+                else_if_branches.push(crate::ast::ElseIfBranch {
+                    condition: ei_cond,
+                    children: ei_children,
+                });
+            }
+            Rule::else_block => {
+                let mut eb_children = Vec::new();
+                for child in p.into_inner() {
+                    if let Some(node) = parse_node(child)? {
+                        eb_children.push(node);
+                    }
+                }
+                else_branch = Some(eb_children);
+            }
+            _ => {
+                if let Some(node) = parse_node(p)? {
+                    children.push(node);
+                }
+            }
+        }
+    }
+
+    Ok(TemplateNode::IfBlock(crate::ast::IfBlockNode {
+        condition,
+        children,
+        else_if_branches,
+        else_branch,
+    }))
+}
+
+fn parse_for_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let mut inner = pair.into_inner();
+
+    let for_vars = inner.next();
+    let (item_name, iterable, track_expression) = if let Some(vars) = for_vars {
+        let mut vars_inner = vars.into_inner();
+        let item = vars_inner
+            .next()
+            .map(|p| p.as_str().to_string())
+            .unwrap_or_default();
+        let iter = vars_inner
+            .next()
+            .map(|p| p.as_str().trim().to_string())
+            .unwrap_or_default();
+        let track = vars_inner
+            .next()
+            .map(|p| p.as_str().trim().to_string())
+            .unwrap_or_default();
+        (item, iter, track)
+    } else {
+        (String::new(), String::new(), String::new())
+    };
+
+    let mut children = Vec::new();
+    let mut empty_children = None;
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::empty_block => {
+                let mut eb_children = Vec::new();
+                for child in p.into_inner() {
+                    if let Some(node) = parse_node(child)? {
+                        eb_children.push(node);
+                    }
+                }
+                empty_children = Some(eb_children);
+            }
+            _ => {
+                if let Some(node) = parse_node(p)? {
+                    children.push(node);
+                }
+            }
+        }
+    }
+
+    Ok(TemplateNode::ForBlock(crate::ast::ForBlockNode {
+        item_name,
+        iterable,
+        track_expression,
+        children,
+        empty_children,
+    }))
+}
+
+fn parse_switch_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let mut inner = pair.into_inner();
+
+    let expression = inner
+        .next()
+        .map(|p| extract_expression_text(p))
+        .unwrap_or_default();
+
+    let mut cases = Vec::new();
+    let mut default_branch = None;
+
+    for p in inner {
+        match p.as_rule() {
+            Rule::case_block => {
+                let mut case_inner = p.into_inner();
+                let case_expr = case_inner
+                    .next()
+                    .map(|p| extract_expression_text(p))
+                    .unwrap_or_default();
+                let mut case_children = Vec::new();
+                for child in case_inner {
+                    if let Some(node) = parse_node(child)? {
+                        case_children.push(node);
+                    }
+                }
+                cases.push(crate::ast::CaseBranch {
+                    expression: case_expr,
+                    children: case_children,
+                });
+            }
+            Rule::default_block => {
+                let mut db_children = Vec::new();
+                for child in p.into_inner() {
+                    if let Some(node) = parse_node(child)? {
+                        db_children.push(node);
+                    }
+                }
+                default_branch = Some(db_children);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(TemplateNode::SwitchBlock(crate::ast::SwitchBlockNode {
+        expression,
+        cases,
+        default_branch,
+    }))
+}
+
+/// Extract the text content from an expression pair.
+fn extract_expression_text(pair: pest::iterators::Pair<Rule>) -> String {
+    pair.as_str().trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::*;
+    use std::path::PathBuf;
+
+    fn parse(template: &str) -> Vec<TemplateNode> {
+        parse_template(template, &PathBuf::from("test.html")).expect("should parse")
+    }
+
+    #[test]
+    fn test_void_element() {
+        let nodes = parse("<br />");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::Element(e) => {
+                assert_eq!(e.tag, "br");
+                assert!(e.is_void);
+            }
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_paired_element_with_text() {
+        let nodes = parse("<h1>Hello</h1>");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::Element(e) => {
+                assert_eq!(e.tag, "h1");
+                assert!(!e.is_void);
+                assert_eq!(e.children.len(), 1);
+                match &e.children[0] {
+                    TemplateNode::Text(t) => assert_eq!(t.value, "Hello"),
+                    _ => panic!("expected text child"),
+                }
+            }
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_interpolation() {
+        let nodes = parse("{{ title }}");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::Interpolation(i) => {
+                assert_eq!(i.expression, "title");
+                assert!(i.pipes.is_empty());
+            }
+            _ => panic!("expected interpolation"),
+        }
+    }
+
+    #[test]
+    fn test_interpolation_with_pipe() {
+        let nodes = parse("{{ value | date:'short' }}");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::Interpolation(i) => {
+                assert_eq!(i.expression, "value");
+                assert_eq!(i.pipes.len(), 1);
+                assert_eq!(i.pipes[0].name, "date");
+                assert_eq!(i.pipes[0].args, vec!["'short'"]);
+            }
+            _ => panic!("expected interpolation"),
+        }
+    }
+
+    #[test]
+    fn test_static_attribute() {
+        let nodes = parse("<div class=\"container\"></div>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => {
+                assert_eq!(e.attributes.len(), 1);
+                match &e.attributes[0] {
+                    TemplateAttribute::Static { name, value } => {
+                        assert_eq!(name, "class");
+                        assert_eq!(value.as_deref(), Some("container"));
+                    }
+                    _ => panic!("expected static attribute"),
+                }
+            }
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_property_binding() {
+        let nodes = parse("<div [title]=\"expr\"></div>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => match &e.attributes[0] {
+                TemplateAttribute::Property { name, expression } => {
+                    assert_eq!(name, "title");
+                    assert_eq!(expression, "expr");
+                }
+                _ => panic!("expected property binding"),
+            },
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_event_binding() {
+        let nodes = parse("<button (click)=\"onClick()\">Click</button>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => {
+                assert_eq!(e.tag, "button");
+                match &e.attributes[0] {
+                    TemplateAttribute::Event { name, handler } => {
+                        assert_eq!(name, "click");
+                        assert_eq!(handler, "onClick()");
+                    }
+                    _ => panic!("expected event binding"),
+                }
+            }
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_if_block() {
+        let nodes = parse("@if (show) { <p>Hello</p> }");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::IfBlock(b) => {
+                assert_eq!(b.condition, "show");
+                assert_eq!(b.children.len(), 1);
+                assert!(b.else_branch.is_none());
+            }
+            _ => panic!("expected if block"),
+        }
+    }
+
+    #[test]
+    fn test_if_else_block() {
+        let nodes = parse("@if (show) { <p>Yes</p> } @else { <p>No</p> }");
+        match &nodes[0] {
+            TemplateNode::IfBlock(b) => {
+                assert_eq!(b.condition, "show");
+                assert!(b.else_branch.is_some());
+                assert_eq!(b.else_branch.as_ref().map(|v| v.len()), Some(1));
+            }
+            _ => panic!("expected if block"),
+        }
+    }
+
+    #[test]
+    fn test_for_block() {
+        let nodes = parse("@for (item of items; track item.id) { <li>{{ item.name }}</li> }");
+        match &nodes[0] {
+            TemplateNode::ForBlock(b) => {
+                assert_eq!(b.item_name, "item");
+                assert_eq!(b.iterable, "items");
+                assert_eq!(b.track_expression, "item.id");
+                assert_eq!(b.children.len(), 1);
+            }
+            _ => panic!("expected for block"),
+        }
+    }
+
+    #[test]
+    fn test_switch_block() {
+        let nodes =
+            parse("@switch (color) { @case ('red') { <p>Red</p> } @default { <p>Other</p> } }");
+        match &nodes[0] {
+            TemplateNode::SwitchBlock(b) => {
+                assert_eq!(b.expression, "color");
+                assert_eq!(b.cases.len(), 1);
+                assert_eq!(b.cases[0].expression, "'red'");
+                assert!(b.default_branch.is_some());
+            }
+            _ => panic!("expected switch block"),
+        }
+    }
+}

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -1,0 +1,182 @@
+use ngc_diagnostics::NgcResult;
+
+use crate::codegen::IvyOutput;
+use crate::extract::ExtractedComponent;
+
+/// Rewrite a TypeScript source string to replace the `@Component` decorator
+/// with Ivy static metadata.
+///
+/// Removes the decorator, updates the `@angular/core` import to include Ivy
+/// runtime symbols, and inserts `static ɵfac` and `static ɵcmp` inside the
+/// class body.
+pub fn rewrite_source(
+    source: &str,
+    component: &ExtractedComponent,
+    ivy_output: &IvyOutput,
+) -> NgcResult<String> {
+    // Collect all edits as (offset, operation) and apply in reverse order
+    let mut result = source.to_string();
+
+    // 1. Insert static fields inside the class body (after the opening `{`)
+    let class_body_start = component.class_body_start as usize;
+    if class_body_start < result.len() {
+        let insert_pos = class_body_start + 1; // after `{`
+        let mut insertion = String::new();
+        insertion.push('\n');
+        insertion.push_str("  ");
+        insertion.push_str(&ivy_output.factory_code);
+        insertion.push_str(";\n");
+        insertion.push_str("  ");
+        insertion.push_str(&ivy_output.define_component_code);
+        insertion.push_str(";\n");
+        result.insert_str(insert_pos, &insertion);
+    }
+
+    // 2. Remove the decorator (must be done after insertion to avoid offset issues
+    //    since decorator comes before the class body)
+    // Actually, since the decorator is BEFORE the class body, and we inserted INTO
+    // the class body, the decorator's original spans are still valid in `source`
+    // but shifted in `result`. Let's recalculate.
+    //
+    // Better approach: work on the original source positions and compute a diff.
+    // For correctness, let's rebuild from scratch.
+
+    let mut result = String::new();
+
+    // Build the new @angular/core import line
+    let mut ivy_symbols: Vec<&str> = ivy_output.ivy_imports.iter().map(|s| s.as_str()).collect();
+    // Add back any non-Component imports from the original
+    for imp in &component.other_angular_core_imports {
+        if !ivy_symbols.contains(&imp.as_str()) {
+            ivy_symbols.push(imp);
+        }
+    }
+    ivy_symbols.sort();
+    let new_import = format!(
+        "import {{ {} }} from '@angular/core';",
+        ivy_symbols.join(", ")
+    );
+
+    // Prepend child template functions
+    for child_fn in &ivy_output.child_template_functions {
+        result.push_str(child_fn);
+        result.push('\n');
+    }
+
+    // Process the source line by line, but use spans for precision
+    let decorator_start = component.decorator_span.0 as usize;
+    let decorator_end = component.decorator_span.1 as usize;
+
+    // Part 1: everything before the decorator, with import rewriting
+    let before_decorator = &source[..decorator_start];
+    if let Some((import_start, import_end)) = component.angular_core_import_span {
+        let import_start = import_start as usize;
+        let import_end = import_end as usize;
+        // Before the import
+        result.push_str(&source[..import_start]);
+        // Rewritten import
+        result.push_str(&new_import);
+        // Between import end and decorator start
+        result.push_str(&source[import_end..decorator_start]);
+    } else {
+        // No @angular/core import found — prepend new import and keep everything
+        result.push_str(&new_import);
+        result.push('\n');
+        result.push_str(before_decorator);
+    }
+
+    // Part 2: skip the decorator — find where the decorator ends
+    // The decorator span may include trailing whitespace/newline; skip it
+    let mut after_decorator_pos = decorator_end;
+    while after_decorator_pos < source.len()
+        && (source.as_bytes()[after_decorator_pos] == b'\n'
+            || source.as_bytes()[after_decorator_pos] == b'\r')
+    {
+        after_decorator_pos += 1;
+    }
+
+    // Part 3: the class declaration (without the decorator) — insert static fields
+    let rest = &source[after_decorator_pos..];
+
+    // Find the class body opening `{` in the remaining source
+    let class_body_offset = component.class_body_start as usize;
+    if class_body_offset >= after_decorator_pos && class_body_offset < source.len() {
+        let relative_body_start = class_body_offset - after_decorator_pos;
+        // Before class body opening
+        result.push_str(&rest[..relative_body_start + 1]); // include the `{`
+                                                           // Insert static fields
+        result.push('\n');
+        result.push_str("  ");
+        result.push_str(&ivy_output.factory_code);
+        result.push_str(";\n");
+        result.push_str("  ");
+        result.push_str(&ivy_output.define_component_code);
+        result.push_str(";\n");
+        // Rest of the class and file
+        result.push_str(&rest[relative_body_start + 1..]);
+    } else {
+        result.push_str(rest);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codegen::IvyOutput;
+    use crate::extract::ExtractedComponent;
+    use std::collections::BTreeSet;
+
+    fn make_component() -> ExtractedComponent {
+        ExtractedComponent {
+            class_name: "AppComponent".to_string(),
+            selector: "app-root".to_string(),
+            template: Some("<h1>Hello</h1>".to_string()),
+            template_url: None,
+            standalone: true,
+            imports_source: None,
+            imports_identifiers: Vec::new(),
+            decorator_span: (45, 130),
+            class_body_start: 162,
+            export_keyword_start: Some(131),
+            class_keyword_start: 138,
+            angular_core_import_span: Some((0, 44)),
+            other_angular_core_imports: Vec::new(),
+        }
+    }
+
+    fn make_ivy_output() -> IvyOutput {
+        IvyOutput {
+            factory_code: "static \u{0275}fac = function AppComponent_Factory(t: any) { return new (t || AppComponent)(); }".to_string(),
+            define_component_code: "static \u{0275}cmp = \u{0275}\u{0275}defineComponent({\n    type: AppComponent\n  })".to_string(),
+            child_template_functions: Vec::new(),
+            ivy_imports: BTreeSet::from([
+                "\u{0275}\u{0275}defineComponent".to_string(),
+                "\u{0275}\u{0275}element".to_string(),
+            ]),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_removes_decorator() {
+        let source = "import { Component } from '@angular/core';\n\n@Component({\n  selector: 'app-root',\n  template: '<h1>Hello</h1>'\n})\nexport class AppComponent {\n  title = 'app';\n}\n";
+        let component = make_component();
+        let ivy = make_ivy_output();
+        let result = rewrite_source(source, &component, &ivy).expect("should rewrite");
+        assert!(!result.contains("@Component"));
+        assert!(result.contains("\u{0275}\u{0275}defineComponent"));
+    }
+
+    #[test]
+    fn test_rewrite_updates_imports() {
+        let source = "import { Component } from '@angular/core';\n\n@Component({\n  selector: 'app-root',\n  template: '<h1>Hello</h1>'\n})\nexport class AppComponent {\n  title = 'app';\n}\n";
+        let component = make_component();
+        let ivy = make_ivy_output();
+        let result = rewrite_source(source, &component, &ivy).expect("should rewrite");
+        // Should have Ivy imports instead of Component
+        assert!(result.contains("\u{0275}\u{0275}defineComponent"));
+        assert!(result.contains("\u{0275}\u{0275}element"));
+        assert!(!result.contains("import { Component }"));
+    }
+}

--- a/crates/ts-transform/src/lib.rs
+++ b/crates/ts-transform/src/lib.rs
@@ -6,5 +6,6 @@
 mod transform;
 
 pub use transform::{
-    transform_project, transform_source, transform_to_memory, TransformResult, TransformedModule,
+    transform_project, transform_source, transform_sources_to_memory, transform_to_memory,
+    TransformResult, TransformedModule,
 };

--- a/crates/ts-transform/src/transform.rs
+++ b/crates/ts-transform/src/transform.rs
@@ -180,6 +180,31 @@ pub fn transform_to_memory(files: &[PathBuf]) -> NgcResult<Vec<TransformedModule
     results.into_iter().collect()
 }
 
+/// Transform pre-compiled TypeScript sources to JavaScript in memory.
+///
+/// Unlike `transform_to_memory`, this takes source strings directly rather than
+/// reading from disk. Each tuple maps a canonical file path to its (potentially
+/// template-compiled) TypeScript source. Files are processed in parallel using rayon.
+pub fn transform_sources_to_memory(
+    sources: &[(PathBuf, String)],
+) -> NgcResult<Vec<TransformedModule>> {
+    let results: Vec<NgcResult<TransformedModule>> = sources
+        .par_iter()
+        .map(|(file_path, source)| {
+            let file_name = file_path.to_string_lossy();
+            let code = transform_source(source, &file_name)?;
+
+            debug!(?file_path, "transformed source to memory");
+            Ok(TransformedModule {
+                source_path: file_path.clone(),
+                code,
+            })
+        })
+        .collect();
+
+    results.into_iter().collect()
+}
+
 /// Map TypeScript extensions to JavaScript equivalents.
 fn map_extension(path: &Path) -> PathBuf {
     match path.extension().and_then(|e| e.to_str()) {

--- a/crates/ts-transform/tests/snapshots/snapshot_tests__app_component_js.snap
+++ b/crates/ts-transform/tests/snapshots/snapshot_tests__app_component_js.snap
@@ -13,6 +13,6 @@ AppComponent = _decorate([Component({
 	selector: 'app-root',
 	standalone: true,
 	imports: [RouterOutlet],
-	template: '<router-outlet />'
+	template: '<h1>{{ title }}</h1><router-outlet />'
 })], AppComponent);
 export { AppComponent };

--- a/tests/fixtures/simple-app/src/app/app.component.ts
+++ b/tests/fixtures/simple-app/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { SharedUtils } from '@app/shared';
   selector: 'app-root',
   standalone: true,
   imports: [RouterOutlet],
-  template: '<router-outlet />'
+  template: '<h1>{{ title }}</h1><router-outlet />'
 })
 export class AppComponent {
   title = SharedUtils.appName();


### PR DESCRIPTION
## Summary
- Add `crates/template-compiler` — compiles `@Component` templates to Angular Ivy instructions
- Pest grammar parses elements, text, interpolation, bindings, events, @if/@for/@switch, pipes
- Ivy codegen generates `ɵɵdefineComponent`, `ɵfac`, and template function with creation/update blocks
- Source rewriter replaces `@Component` decorator with static Ivy metadata before oxc type-stripping
- JIT fallback for unsupported templates (templateUrl, *ngIf/*ngFor, ng-content, etc.)
- Pipeline: resolve → compile_templates → transform_sources_to_memory → bundle → write
- Enhanced fixture template: `<h1>{{ title }}</h1><router-outlet />`
- Created lukekania/ngc-rs#3 for future native Rust handling of JIT fallback cases
- Bump workspace version to 0.4.0

### Bundle output (before → after)
**Before (v0.3):** `_decorate([Component({ template: '...' })], AppComponent)`
**After (v0.4):** `class AppComponent { static ɵcmp = ɵɵdefineComponent({ template: function(rf, ctx) { ... } }) }`

## Test plan
- [x] 11 parser unit tests (elements, text, interpolation, pipes, @if, @for, @switch, bindings, events)
- [x] 5 codegen unit tests (void element, paired element, interpolation, event, factory)
- [x] 7 extract unit tests (simple component, imports, templateUrl JIT, *ngIf JIT, template literal, no component)
- [x] 2 rewrite unit tests (decorator removal, import update)
- [x] Bundle snapshot updated to show Ivy output (no more _decorate)
- [x] All 107 workspace tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo run -- build --project tests/fixtures/simple-app/tsconfig.app.json` produces correct Ivy bundle