### PR TITLE
feat: v0.6 — code splitting & lazy routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,14 @@ Goal: produce browser-loadable output from ngc-rs build.
 - [x] 3rdpartylicenses.txt generation
 - [x] JSON output mode (--output-json for builder integration)
 
-### v0.6 — Code Splitting & Lazy Routes
+### v0.6 — Code Splitting & Lazy Routes ✅
 
 Goal: support lazy-loaded Angular routes with separate chunk files.
 
-- [ ] Dynamic import() detection in bundler
-- [ ] Chunk graph construction (main + lazy chunks + shared chunks)
-- [ ] Multi-file bundle output (main.js + chunk-*.js)
-- [ ] Import rewriting for chunk filenames
+- [x] Dynamic import() detection in bundler
+- [x] Chunk graph construction (main + lazy chunks + shared chunks)
+- [x] Multi-file bundle output (main.js + chunk-*.js)
+- [x] Import rewriting for chunk filenames
 
 ### v0.7 — Source Maps & Optimization
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "glob",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "colored",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/Cargo.toml
+++ b/crates/bundler/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 ngc-diagnostics = { path = "../diagnostics" }
+ngc-project-resolver = { path = "../project-resolver" }
 oxc_allocator = "0.122"
 oxc_parser = "0.122"
 oxc_span = "0.122"
@@ -17,7 +18,6 @@ petgraph = "0.8"
 tracing = "0.1"
 
 [dev-dependencies]
-ngc-project-resolver = { path = "../project-resolver" }
 ngc-ts-transform = { path = "../ts-transform" }
 ngc-template-compiler = { path = "../template-compiler" }
 insta = { version = "1.46", features = ["glob"] }

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -1,0 +1,502 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use ngc_project_resolver::ImportKind;
+use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::visit::{Dfs, EdgeRef};
+use tracing::debug;
+
+/// Identifies the kind of chunk in the output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChunkKind {
+    /// The main entry chunk.
+    Main,
+    /// A lazy-loaded chunk triggered by a dynamic import.
+    Lazy,
+    /// A shared chunk extracted because multiple lazy chunks import it.
+    Shared,
+}
+
+/// A chunk is a set of modules that will be bundled into one output file.
+#[derive(Debug)]
+pub struct Chunk {
+    /// The kind of chunk.
+    pub kind: ChunkKind,
+    /// The output filename (e.g. `"main.js"`, `"chunk-admin-component.js"`).
+    pub filename: String,
+    /// The canonical paths of modules in this chunk, in topological order.
+    pub modules: Vec<PathBuf>,
+    /// The entry module for this chunk (for lazy chunks, the dynamic import target).
+    pub entry: PathBuf,
+}
+
+/// The result of chunk graph construction.
+#[derive(Debug)]
+pub struct ChunkGraph {
+    /// All chunks, with the main chunk always at index 0.
+    pub chunks: Vec<Chunk>,
+    /// Map from dynamic import target path to its chunk filename.
+    pub dynamic_import_map: HashMap<PathBuf, String>,
+}
+
+/// Build a chunk graph by partitioning modules into main, lazy, and shared chunks.
+///
+/// Detects dynamic import edges as split points, then assigns each module to
+/// exactly one chunk based on static reachability analysis.
+pub fn build_chunk_graph(
+    graph: &DiGraph<PathBuf, ImportKind>,
+    entry: &PathBuf,
+    root_dir: &Path,
+) -> NgcResult<ChunkGraph> {
+    // Build path -> node index map
+    let mut path_to_idx: HashMap<PathBuf, NodeIndex> = HashMap::new();
+    for idx in graph.node_indices() {
+        path_to_idx.insert(graph[idx].clone(), idx);
+    }
+
+    let entry_idx = path_to_idx.get(entry).ok_or_else(|| NgcError::ChunkError {
+        message: format!(
+            "entry point {} not found in the dependency graph",
+            entry.display()
+        ),
+    })?;
+
+    // Step 1: Identify split points (targets of dynamic import edges)
+    let mut split_points: BTreeSet<NodeIndex> = BTreeSet::new();
+    for edge in graph.edge_indices() {
+        if let Some(weight) = graph.edge_weight(edge) {
+            if *weight == ImportKind::Dynamic {
+                if let Some((_source, target)) = graph.edge_endpoints(edge) {
+                    split_points.insert(target);
+                }
+            }
+        }
+    }
+
+    // If no dynamic imports, return a single main chunk
+    if split_points.is_empty() {
+        let ordered = toposort_all_reachable(graph, *entry_idx)?;
+        let modules: Vec<PathBuf> = ordered.iter().map(|idx| graph[*idx].clone()).collect();
+        debug!(
+            module_count = modules.len(),
+            "no dynamic imports, single chunk"
+        );
+        return Ok(ChunkGraph {
+            chunks: vec![Chunk {
+                kind: ChunkKind::Main,
+                filename: "main.js".to_string(),
+                modules,
+                entry: entry.clone(),
+            }],
+            dynamic_import_map: HashMap::new(),
+        });
+    }
+
+    // Step 2: Compute static-only reachability from main entry
+    let main_reachable = static_reachable(graph, *entry_idx);
+
+    // Step 3: Compute static-only reachability from each split point
+    let mut split_reachable: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::new();
+    for &sp in &split_points {
+        split_reachable.insert(sp, static_reachable(graph, sp));
+    }
+
+    // Step 4: Assign modules to chunks
+    // - Module in main_reachable → main chunk
+    // - Module reachable from exactly 1 split point (not in main) → that lazy chunk
+    // - Module reachable from 2+ split points (not in main) → shared chunk
+
+    // For each non-main module, track which split points can reach it
+    let mut module_consumers: HashMap<NodeIndex, BTreeSet<NodeIndex>> = HashMap::new();
+    for (&sp, reachable) in &split_reachable {
+        for &node in reachable {
+            if !main_reachable.contains(&node) {
+                module_consumers.entry(node).or_default().insert(sp);
+            }
+        }
+    }
+
+    // Group shared modules by their consumer set
+    let mut shared_groups: HashMap<BTreeSet<NodeIndex>, Vec<NodeIndex>> = HashMap::new();
+    let mut lazy_exclusive: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
+
+    for (&module, consumers) in &module_consumers {
+        if consumers.len() == 1 {
+            let sp = *consumers.iter().next().expect("consumer set is non-empty");
+            lazy_exclusive.entry(sp).or_default().push(module);
+        } else {
+            shared_groups
+                .entry(consumers.clone())
+                .or_default()
+                .push(module);
+        }
+    }
+
+    // Step 5: Build chunks with topological ordering
+
+    // Main chunk
+    let main_ordered = toposort_subset(graph, *entry_idx, &main_reachable)?;
+    let main_modules: Vec<PathBuf> = main_ordered.iter().map(|idx| graph[*idx].clone()).collect();
+
+    let mut chunks = vec![Chunk {
+        kind: ChunkKind::Main,
+        filename: "main.js".to_string(),
+        modules: main_modules,
+        entry: entry.clone(),
+    }];
+
+    let mut dynamic_import_map: HashMap<PathBuf, String> = HashMap::new();
+
+    // Lazy chunks
+    for &sp in &split_points {
+        let sp_path = graph[sp].clone();
+
+        // If the split point is in main_reachable, it stays in main — no lazy chunk
+        if main_reachable.contains(&sp) {
+            continue;
+        }
+
+        let filename = chunk_filename_from_path(&sp_path, root_dir);
+
+        // Modules exclusive to this lazy chunk + the split point itself
+        let mut chunk_nodes: HashSet<NodeIndex> = HashSet::new();
+        chunk_nodes.insert(sp);
+        if let Some(exclusive) = lazy_exclusive.get(&sp) {
+            for &node in exclusive {
+                chunk_nodes.insert(node);
+            }
+        }
+
+        let ordered = toposort_subset(graph, sp, &chunk_nodes)?;
+        let modules: Vec<PathBuf> = ordered.iter().map(|idx| graph[*idx].clone()).collect();
+
+        dynamic_import_map.insert(sp_path.clone(), filename.clone());
+
+        chunks.push(Chunk {
+            kind: ChunkKind::Lazy,
+            filename,
+            modules,
+            entry: sp_path,
+        });
+    }
+
+    // Shared chunks
+    let mut shared_index = 0;
+    for nodes in shared_groups.values() {
+        let filename = format!("chunk-shared-{shared_index}.js");
+        shared_index += 1;
+
+        let node_set: HashSet<NodeIndex> = nodes.iter().copied().collect();
+        // Pick any node as "entry" for toposort — use the first in the set
+        let first_node = *nodes.first().expect("shared group is non-empty");
+        let ordered = toposort_subset(graph, first_node, &node_set)?;
+        let modules: Vec<PathBuf> = ordered.iter().map(|idx| graph[*idx].clone()).collect();
+
+        // Use the first module as the chunk entry
+        let chunk_entry = modules.first().cloned().unwrap_or_default();
+
+        chunks.push(Chunk {
+            kind: ChunkKind::Shared,
+            filename,
+            modules,
+            entry: chunk_entry,
+        });
+    }
+
+    debug!(
+        chunk_count = chunks.len(),
+        lazy_count = split_points.len(),
+        shared_count = shared_index,
+        "built chunk graph"
+    );
+
+    Ok(ChunkGraph {
+        chunks,
+        dynamic_import_map,
+    })
+}
+
+/// Compute the set of nodes reachable from `start` following only static edges.
+fn static_reachable(graph: &DiGraph<PathBuf, ImportKind>, start: NodeIndex) -> HashSet<NodeIndex> {
+    let mut visited = HashSet::new();
+    let mut stack = vec![start];
+
+    while let Some(node) = stack.pop() {
+        if !visited.insert(node) {
+            continue;
+        }
+        for edge in graph.edges(node) {
+            if *edge.weight() == ImportKind::Static {
+                stack.push(edge.target());
+            }
+        }
+    }
+
+    visited
+}
+
+/// Topological sort of all nodes reachable from `start` (following all edge kinds).
+fn toposort_all_reachable(
+    graph: &DiGraph<PathBuf, ImportKind>,
+    start: NodeIndex,
+) -> NgcResult<Vec<NodeIndex>> {
+    let mut reachable = HashSet::new();
+    let mut dfs = Dfs::new(graph, start);
+    while let Some(node) = dfs.next(graph) {
+        reachable.insert(node);
+    }
+
+    toposort_subset(graph, start, &reachable)
+}
+
+/// Topological sort of a subset of nodes within the graph.
+///
+/// Returns nodes in dependency-first order (leaves before roots).
+fn toposort_subset(
+    graph: &DiGraph<PathBuf, ImportKind>,
+    _start: NodeIndex,
+    subset: &HashSet<NodeIndex>,
+) -> NgcResult<Vec<NodeIndex>> {
+    let topo = petgraph::algo::toposort(graph, None).map_err(|cycle| {
+        let cycle_node = &graph[cycle.node_id()];
+        NgcError::CircularDependency {
+            cycle: vec![cycle_node.clone()],
+        }
+    })?;
+
+    let mut ordered: Vec<NodeIndex> = topo
+        .into_iter()
+        .filter(|idx| subset.contains(idx))
+        .collect();
+    ordered.reverse();
+
+    Ok(ordered)
+}
+
+/// Derive a chunk filename from a split point's file path.
+///
+/// Example: `/root/src/app/admin/admin.component.ts` → `"chunk-admin-component.js"`
+fn chunk_filename_from_path(path: &Path, root_dir: &Path) -> String {
+    let relative = path.strip_prefix(root_dir).unwrap_or(path);
+    let stem = relative.with_extension("");
+    let stem_str = stem.to_string_lossy();
+
+    // Take only the filename part (last component), sanitize it
+    let name = stem_str
+        .replace(['/', '\\'], "-")
+        .replace('.', "-")
+        .to_lowercase();
+
+    // Take the last two path segments for a more readable name
+    let parts: Vec<&str> = name.split('-').filter(|s| !s.is_empty()).collect();
+    let short_name = if parts.len() > 2 {
+        parts[parts.len() - 2..].join("-")
+    } else {
+        parts.join("-")
+    };
+
+    format!("chunk-{short_name}.js")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_path(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn test_no_dynamic_imports_single_chunk() {
+        let mut graph = DiGraph::new();
+        let leaf = graph.add_node(make_path("/root/src/leaf.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+        graph.add_edge(entry, leaf, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        assert_eq!(result.chunks.len(), 1);
+        assert_eq!(result.chunks[0].kind, ChunkKind::Main);
+        assert_eq!(result.chunks[0].filename, "main.js");
+        assert!(result.dynamic_import_map.is_empty());
+    }
+
+    #[test]
+    fn test_one_dynamic_import_creates_lazy_chunk() {
+        let mut graph = DiGraph::new();
+        let lazy = graph.add_node(make_path("/root/src/admin/admin.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+        graph.add_edge(entry, lazy, ImportKind::Dynamic);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        assert_eq!(result.chunks.len(), 2);
+        assert_eq!(result.chunks[0].kind, ChunkKind::Main);
+        assert_eq!(result.chunks[1].kind, ChunkKind::Lazy);
+        assert!(result.chunks[1].filename.contains("chunk-"));
+        assert!(result.chunks[1].filename.ends_with(".js"));
+        assert_eq!(result.dynamic_import_map.len(), 1);
+    }
+
+    #[test]
+    fn test_shared_dependency_creates_shared_chunk() {
+        // main --dynamic--> admin
+        // main --dynamic--> dashboard
+        // admin --static--> shared
+        // dashboard --static--> shared
+        let mut graph = DiGraph::new();
+        let shared = graph.add_node(make_path("/root/src/shared/shared.service.ts"));
+        let admin = graph.add_node(make_path("/root/src/admin/admin.component.ts"));
+        let dashboard = graph.add_node(make_path("/root/src/dashboard/dashboard.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, admin, ImportKind::Dynamic);
+        graph.add_edge(entry, dashboard, ImportKind::Dynamic);
+        graph.add_edge(admin, shared, ImportKind::Static);
+        graph.add_edge(dashboard, shared, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        // Should have: main + 2 lazy + 1 shared = 4 chunks
+        assert_eq!(result.chunks.len(), 4);
+        assert_eq!(
+            result
+                .chunks
+                .iter()
+                .filter(|c| c.kind == ChunkKind::Main)
+                .count(),
+            1
+        );
+        assert_eq!(
+            result
+                .chunks
+                .iter()
+                .filter(|c| c.kind == ChunkKind::Lazy)
+                .count(),
+            2
+        );
+        assert_eq!(
+            result
+                .chunks
+                .iter()
+                .filter(|c| c.kind == ChunkKind::Shared)
+                .count(),
+            1
+        );
+
+        // Shared chunk should contain the shared module
+        let shared_chunk = result
+            .chunks
+            .iter()
+            .find(|c| c.kind == ChunkKind::Shared)
+            .expect("should have shared chunk");
+        assert!(shared_chunk
+            .modules
+            .iter()
+            .any(|m| m.to_str().unwrap_or("").contains("shared.service")));
+
+        // Lazy chunks should NOT contain the shared module
+        for chunk in result.chunks.iter().filter(|c| c.kind == ChunkKind::Lazy) {
+            assert!(!chunk
+                .modules
+                .iter()
+                .any(|m| m.to_str().unwrap_or("").contains("shared.service")));
+        }
+    }
+
+    #[test]
+    fn test_lazy_target_also_static_stays_in_main() {
+        // main --static--> shared_mod
+        // main --dynamic--> shared_mod (same module is also dynamically imported)
+        let mut graph = DiGraph::new();
+        let shared_mod = graph.add_node(make_path("/root/src/shared.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, shared_mod, ImportKind::Static);
+        graph.add_edge(entry, shared_mod, ImportKind::Dynamic);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        // shared_mod is statically reachable from main → stays in main, no lazy chunk
+        assert_eq!(result.chunks.len(), 1);
+        assert_eq!(result.chunks[0].kind, ChunkKind::Main);
+        assert!(result.chunks[0]
+            .modules
+            .iter()
+            .any(|m| m.to_str().unwrap_or("").contains("shared")));
+    }
+
+    #[test]
+    fn test_chunk_filename_from_path() {
+        let root = Path::new("/root/src");
+
+        assert_eq!(
+            chunk_filename_from_path(Path::new("/root/src/admin/admin.component.ts"), root),
+            "chunk-admin-component.js"
+        );
+        assert_eq!(
+            chunk_filename_from_path(Path::new("/root/src/dashboard/dashboard.routes.ts"), root),
+            "chunk-dashboard-routes.js"
+        );
+        assert_eq!(
+            chunk_filename_from_path(Path::new("/root/src/lazy.ts"), root),
+            "chunk-lazy.js"
+        );
+    }
+
+    #[test]
+    fn test_main_chunk_contains_only_statically_reachable() {
+        // main --static--> routes --dynamic--> admin
+        let mut graph = DiGraph::new();
+        let admin = graph.add_node(make_path("/root/src/admin.ts"));
+        let routes = graph.add_node(make_path("/root/src/routes.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, routes, ImportKind::Static);
+        graph.add_edge(routes, admin, ImportKind::Dynamic);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        let main_chunk = &result.chunks[0];
+        assert_eq!(main_chunk.kind, ChunkKind::Main);
+        // Main should have entry + routes, NOT admin
+        assert!(main_chunk
+            .modules
+            .iter()
+            .any(|m| m.to_str().unwrap_or("").contains("main")));
+        assert!(main_chunk
+            .modules
+            .iter()
+            .any(|m| m.to_str().unwrap_or("").contains("routes")));
+        assert!(!main_chunk
+            .modules
+            .iter()
+            .any(|m| m.to_str().unwrap_or("").contains("admin")));
+    }
+}

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use ngc_diagnostics::{NgcError, NgcResult};
+use ngc_project_resolver::ImportKind;
 use petgraph::graph::DiGraph;
 use petgraph::visit::Dfs;
 use tracing::debug;
@@ -13,8 +14,8 @@ use crate::rewrite::{self, ExternalImport};
 pub struct BundleInput {
     /// Map from canonical source path to transformed JS code.
     pub modules: HashMap<PathBuf, String>,
-    /// The file dependency graph (nodes are canonical paths, edges are imports).
-    pub graph: DiGraph<PathBuf, ()>,
+    /// The file dependency graph (nodes are canonical paths, edges carry import kind).
+    pub graph: DiGraph<PathBuf, ImportKind>,
     /// The entry point canonical path.
     pub entry: PathBuf,
     /// Prefixes that identify local imports (e.g. `["."]`, `[".", "@app/", "@env/"]`).
@@ -31,6 +32,15 @@ struct MergedImport {
     is_side_effect: bool,
 }
 
+/// The output of the bundler: one or more chunks.
+#[derive(Debug)]
+pub struct BundleOutput {
+    /// Map from output filename to generated code.
+    pub chunks: HashMap<String, String>,
+    /// The main chunk filename (always `"main.js"`).
+    pub main_filename: String,
+}
+
 /// Bundle all modules reachable from the entry point into a single ESM string.
 ///
 /// Topologically sorts the reachable subgraph so that dependencies appear before
@@ -44,6 +54,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<String> {
     let prefix_refs: Vec<&str> = input.local_prefixes.iter().map(|s| s.as_str()).collect();
     let mut all_externals: Vec<ExternalImport> = Vec::new();
     let mut chunks: Vec<String> = Vec::new();
+    let empty_rewrites = HashMap::new();
 
     for module_path in &ordered {
         let js_code = input
@@ -57,7 +68,8 @@ pub fn bundle(input: &BundleInput) -> NgcResult<String> {
             })?;
 
         let file_name = module_path.to_string_lossy();
-        let rewritten = rewrite::rewrite_module(js_code, &file_name, &prefix_refs)?;
+        let rewritten =
+            rewrite::rewrite_module(js_code, &file_name, &prefix_refs, &empty_rewrites)?;
 
         all_externals.extend(rewritten.external_imports);
 
@@ -202,6 +214,7 @@ fn format_import(imp: &MergedImport) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ngc_project_resolver::ImportKind;
     use petgraph::graph::DiGraph;
 
     fn make_path(s: &str) -> PathBuf {
@@ -213,7 +226,7 @@ mod tests {
         let mut graph = DiGraph::new();
         let leaf = graph.add_node(make_path("/root/src/leaf.ts"));
         let entry = graph.add_node(make_path("/root/src/main.ts"));
-        graph.add_edge(entry, leaf, ());
+        graph.add_edge(entry, leaf, ImportKind::Static);
 
         let mut modules = HashMap::new();
         modules.insert(
@@ -248,8 +261,8 @@ mod tests {
         let a = graph.add_node(make_path("/root/a.ts"));
         let b = graph.add_node(make_path("/root/b.ts"));
         let entry = graph.add_node(make_path("/root/main.ts"));
-        graph.add_edge(entry, a, ());
-        graph.add_edge(entry, b, ());
+        graph.add_edge(entry, a, ImportKind::Static);
+        graph.add_edge(entry, b, ImportKind::Static);
 
         let mut modules = HashMap::new();
         modules.insert(
@@ -288,7 +301,7 @@ mod tests {
         let leaf = graph.add_node(make_path("/root/leaf.ts"));
         let entry = graph.add_node(make_path("/root/main.ts"));
         let _orphan = graph.add_node(make_path("/root/orphan.ts"));
-        graph.add_edge(entry, leaf, ());
+        graph.add_edge(entry, leaf, ImportKind::Static);
 
         let mut modules = HashMap::new();
         modules.insert(

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -1,12 +1,12 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 
 use ngc_diagnostics::{NgcError, NgcResult};
 use ngc_project_resolver::ImportKind;
 use petgraph::graph::DiGraph;
-use petgraph::visit::Dfs;
 use tracing::debug;
 
+use crate::chunk::build_chunk_graph;
 use crate::rewrite::{self, ExternalImport};
 
 /// Input to the bundler.
@@ -41,24 +41,132 @@ pub struct BundleOutput {
     pub main_filename: String,
 }
 
-/// Bundle all modules reachable from the entry point into a single ESM string.
+/// Bundle all modules into one or more ESM chunk files.
 ///
-/// Topologically sorts the reachable subgraph so that dependencies appear before
-/// dependents. External imports are hoisted and deduplicated at the top of the
-/// bundle. Local imports and exports are stripped from each module.
-pub fn bundle(input: &BundleInput) -> NgcResult<String> {
-    let ordered = toposort_reachable(input)?;
+/// Builds a chunk graph to detect code splitting boundaries from dynamic
+/// `import()` expressions. For each chunk, topologically sorts its modules,
+/// hoists and deduplicates external imports, strips local imports/exports,
+/// and rewrites dynamic import specifiers to point to chunk filenames.
+pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
+    let chunk_graph = build_chunk_graph(&input.graph, &input.entry, &input.root_dir)?;
 
-    debug!(module_count = ordered.len(), "bundling modules");
+    debug!(
+        chunk_count = chunk_graph.chunks.len(),
+        "bundling with code splitting"
+    );
+
+    // Build specifier-to-filename rewrite map for dynamic imports.
+    // Maps the raw specifier as it appears in source code to the chunk filename.
+    let specifier_rewrites = build_specifier_rewrite_map(input, &chunk_graph.dynamic_import_map)?;
 
     let prefix_refs: Vec<&str> = input.local_prefixes.iter().map(|s| s.as_str()).collect();
-    let mut all_externals: Vec<ExternalImport> = Vec::new();
-    let mut chunks: Vec<String> = Vec::new();
-    let empty_rewrites = HashMap::new();
+    let mut output_chunks: HashMap<String, String> = HashMap::new();
 
-    for module_path in &ordered {
-        let js_code = input
-            .modules
+    for chunk in &chunk_graph.chunks {
+        let chunk_code = bundle_chunk(
+            &chunk.modules,
+            &input.modules,
+            &input.root_dir,
+            &prefix_refs,
+            &specifier_rewrites,
+        )?;
+        output_chunks.insert(chunk.filename.clone(), chunk_code);
+    }
+
+    Ok(BundleOutput {
+        chunks: output_chunks,
+        main_filename: "main.js".to_string(),
+    })
+}
+
+/// Build a mapping from raw import specifiers (as they appear in source) to chunk filenames.
+///
+/// The chunk graph maps canonical `PathBuf` → chunk filename.
+/// The rewriter needs raw specifier string → chunk filename.
+/// We bridge this by computing relative specifiers from each importing module.
+fn build_specifier_rewrite_map(
+    input: &BundleInput,
+    dynamic_import_map: &HashMap<PathBuf, String>,
+) -> NgcResult<HashMap<String, String>> {
+    if dynamic_import_map.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut rewrites: HashMap<String, String> = HashMap::new();
+
+    // For each dynamic import target, compute the specifiers that could reference it.
+    // We need to match what appears in the source code. The import scanner uses regex
+    // to extract specifiers, so we need to match those exact strings.
+    // Walk all modules and find dynamic import specifiers that resolve to chunk targets.
+    for module_path in input.modules.keys() {
+        let module_dir = module_path.parent();
+        for (target_path, chunk_filename) in dynamic_import_map {
+            if let Some(dir) = module_dir {
+                // Compute relative path from module to target
+                if let Ok(relative) = pathdiff(target_path, dir) {
+                    // Try common specifier forms
+                    let rel_str = relative.to_string_lossy();
+                    let specifier = if rel_str.starts_with('.') {
+                        rel_str.to_string()
+                    } else {
+                        format!("./{rel_str}")
+                    };
+
+                    // Strip known extensions to match how imports typically appear
+                    for ext in &[".ts", ".tsx", ".js", ".mjs"] {
+                        if let Some(stripped) = specifier.strip_suffix(ext) {
+                            rewrites.insert(stripped.to_string(), chunk_filename.clone());
+                        }
+                    }
+                    rewrites.insert(specifier, chunk_filename.clone());
+                }
+            }
+        }
+    }
+
+    Ok(rewrites)
+}
+
+/// Compute a relative path from `base` directory to `target`.
+fn pathdiff(target: &std::path::Path, base: &std::path::Path) -> Result<PathBuf, ()> {
+    // Use a simple implementation: strip common prefix, add ../ for remaining base components
+    let target_components: Vec<_> = target.components().collect();
+    let base_components: Vec<_> = base.components().collect();
+
+    let common_len = target_components
+        .iter()
+        .zip(base_components.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    if common_len == 0 {
+        return Err(());
+    }
+
+    let mut result = PathBuf::new();
+    for _ in common_len..base_components.len() {
+        result.push("..");
+    }
+    for component in &target_components[common_len..] {
+        result.push(component);
+    }
+
+    Ok(result)
+}
+
+/// Bundle a single chunk's modules into an ESM string.
+fn bundle_chunk(
+    module_paths: &[PathBuf],
+    all_modules: &HashMap<PathBuf, String>,
+    root_dir: &PathBuf,
+    prefix_refs: &[&str],
+    specifier_rewrites: &HashMap<String, String>,
+) -> NgcResult<String> {
+    let mut all_externals: Vec<ExternalImport> = Vec::new();
+    let mut code_sections: Vec<String> = Vec::new();
+
+    for module_path in module_paths {
+        let js_code = all_modules
             .get(module_path)
             .ok_or_else(|| NgcError::BundleError {
                 message: format!(
@@ -69,17 +177,15 @@ pub fn bundle(input: &BundleInput) -> NgcResult<String> {
 
         let file_name = module_path.to_string_lossy();
         let rewritten =
-            rewrite::rewrite_module(js_code, &file_name, &prefix_refs, &empty_rewrites)?;
+            rewrite::rewrite_module(js_code, &file_name, prefix_refs, specifier_rewrites)?;
 
         all_externals.extend(rewritten.external_imports);
 
         let trimmed = rewritten.code.trim();
         if !trimmed.is_empty() {
-            let relative = module_path
-                .strip_prefix(&input.root_dir)
-                .unwrap_or(module_path);
+            let relative = module_path.strip_prefix(root_dir).unwrap_or(module_path);
             let display_path = relative.with_extension("js");
-            chunks.push(format!("// {}\n{}", display_path.display(), trimmed));
+            code_sections.push(format!("// {}\n{}", display_path.display(), trimmed));
         }
     }
 
@@ -91,13 +197,13 @@ pub fn bundle(input: &BundleInput) -> NgcResult<String> {
         output.push('\n');
     }
 
-    if !merged.is_empty() && !chunks.is_empty() {
+    if !merged.is_empty() && !code_sections.is_empty() {
         output.push('\n');
     }
 
-    for (i, chunk) in chunks.iter().enumerate() {
-        output.push_str(chunk);
-        if i < chunks.len() - 1 {
+    for (i, section) in code_sections.iter().enumerate() {
+        output.push_str(section);
+        if i < code_sections.len() - 1 {
             output.push_str("\n\n");
         } else {
             output.push('\n');
@@ -105,56 +211,6 @@ pub fn bundle(input: &BundleInput) -> NgcResult<String> {
     }
 
     Ok(output)
-}
-
-/// Compute the reachable subgraph from the entry point and return nodes
-/// in topological order (dependencies first, entry last).
-fn toposort_reachable(input: &BundleInput) -> NgcResult<Vec<PathBuf>> {
-    // Build path -> node index map
-    let mut path_to_idx = HashMap::new();
-    for idx in input.graph.node_indices() {
-        path_to_idx.insert(input.graph[idx].clone(), idx);
-    }
-
-    let entry_idx = path_to_idx
-        .get(&input.entry)
-        .ok_or_else(|| NgcError::BundleError {
-            message: format!(
-                "entry point {} not found in the dependency graph",
-                input.entry.display()
-            ),
-        })?;
-
-    // DFS to find reachable nodes
-    let mut reachable = HashSet::new();
-    let mut dfs = Dfs::new(&input.graph, *entry_idx);
-    while let Some(node) = dfs.next(&input.graph) {
-        reachable.insert(node);
-    }
-
-    // Build subgraph of reachable nodes for toposort
-    let topo = petgraph::algo::toposort(&input.graph, None).map_err(|cycle| {
-        let cycle_node = &input.graph[cycle.node_id()];
-        NgcError::CircularDependency {
-            cycle: vec![cycle_node.clone()],
-        }
-    })?;
-
-    // Filter to reachable and reverse so dependencies come first (leaves before entry)
-    let mut ordered: Vec<PathBuf> = topo
-        .into_iter()
-        .filter(|idx| reachable.contains(idx))
-        .map(|idx| input.graph[idx].clone())
-        .collect();
-    ordered.reverse();
-
-    debug!(
-        reachable_count = ordered.len(),
-        total_count = input.graph.node_count(),
-        "computed bundle order"
-    );
-
-    Ok(ordered)
 }
 
 /// Merge external imports by source, combining named imports and deduplicating.
@@ -221,6 +277,14 @@ mod tests {
         PathBuf::from(s)
     }
 
+    /// Helper to get the main chunk code from a BundleOutput.
+    fn main_chunk(output: &BundleOutput) -> &str {
+        output
+            .chunks
+            .get(&output.main_filename)
+            .expect("main chunk should exist")
+    }
+
     #[test]
     fn test_two_module_bundle() {
         let mut graph = DiGraph::new();
@@ -246,7 +310,9 @@ mod tests {
             root_dir: make_path("/root/src"),
         };
 
-        let result = bundle(&input).expect("should bundle");
+        let output = bundle(&input).expect("should bundle");
+        let result = main_chunk(&output);
+        assert_eq!(output.chunks.len(), 1, "should produce single chunk");
         // leaf should appear before main
         let leaf_pos = result.find("const x = 42").expect("leaf code present");
         let main_pos = result.find("console.log(x)").expect("main code present");
@@ -287,7 +353,8 @@ mod tests {
             root_dir: make_path("/root"),
         };
 
-        let result = bundle(&input).expect("should bundle");
+        let output = bundle(&input).expect("should bundle");
+        let result = main_chunk(&output);
         // Should have a single merged import from @angular/core
         let import_count = result.matches("@angular/core").count();
         assert_eq!(import_count, 1, "imports should be merged");
@@ -325,10 +392,77 @@ mod tests {
             root_dir: make_path("/root"),
         };
 
-        let result = bundle(&input).expect("should bundle");
+        let output = bundle(&input).expect("should bundle");
+        let result = main_chunk(&output);
         assert!(
             !result.contains("orphan"),
             "orphan module should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_code_splitting_produces_multiple_chunks() {
+        // main --static--> routes --dynamic--> lazy
+        let mut graph = DiGraph::new();
+        let lazy = graph.add_node(make_path("/root/lazy.ts"));
+        let routes = graph.add_node(make_path("/root/routes.ts"));
+        let entry = graph.add_node(make_path("/root/main.ts"));
+        graph.add_edge(entry, routes, ImportKind::Static);
+        graph.add_edge(routes, lazy, ImportKind::Dynamic);
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            make_path("/root/lazy.ts"),
+            "export class LazyComponent {}\n".to_string(),
+        );
+        modules.insert(
+            make_path("/root/routes.ts"),
+            "export const routes = [{ loadComponent: () => import('./lazy').then(m => m.LazyComponent) }];\n".to_string(),
+        );
+        modules.insert(
+            make_path("/root/main.ts"),
+            "import { routes } from './routes';\nconsole.log(routes);\n".to_string(),
+        );
+
+        let input = BundleInput {
+            modules,
+            graph,
+            entry: make_path("/root/main.ts"),
+            local_prefixes: vec![".".to_string()],
+            root_dir: make_path("/root"),
+        };
+
+        let output = bundle(&input).expect("should bundle");
+        // Should produce 2 chunks: main + lazy
+        assert_eq!(output.chunks.len(), 2, "should produce 2 chunks");
+
+        let main_code = main_chunk(&output);
+        // Main should NOT contain the lazy module's class declaration
+        assert!(
+            !main_code.contains("class LazyComponent"),
+            "main chunk should not contain lazy module's class"
+        );
+        // Main should contain routes
+        assert!(
+            main_code.contains("routes"),
+            "main chunk should contain routes"
+        );
+
+        // Find the lazy chunk
+        let lazy_chunk = output
+            .chunks
+            .iter()
+            .find(|(k, _)| k.starts_with("chunk-"))
+            .expect("should have a lazy chunk");
+        assert!(
+            lazy_chunk.1.contains("class LazyComponent"),
+            "lazy chunk should contain LazyComponent class"
+        );
+
+        // Main should have rewritten the import specifier
+        assert!(
+            main_code.contains(lazy_chunk.0.as_str()),
+            "main chunk should reference the lazy chunk filename"
         );
     }
 

--- a/crates/bundler/src/lib.rs
+++ b/crates/bundler/src/lib.rs
@@ -1,11 +1,13 @@
 //! ESM concatenation bundler for ngc-rs.
 //!
 //! Takes transformed JavaScript modules and a dependency graph, then produces
-//! a single bundled ESM file with external imports hoisted and project-local
-//! imports inlined.
+//! bundled ESM files with external imports hoisted and project-local imports
+//! inlined. Supports code splitting via dynamic `import()` detection.
 
+mod chunk;
 mod concat;
 mod rewrite;
 
-pub use concat::{bundle, BundleInput};
+pub use chunk::{build_chunk_graph, Chunk, ChunkGraph, ChunkKind};
+pub use concat::{bundle, BundleInput, BundleOutput};
 pub use rewrite::{ExternalImport, RewrittenModule};

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use ngc_diagnostics::{NgcError, NgcResult};
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{ExportDefaultDeclarationKind, ModuleDeclaration};
+use oxc_ast::ast::{ExportDefaultDeclarationKind, Expression, ModuleDeclaration, Statement};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
@@ -13,6 +13,8 @@ pub struct RewrittenModule {
     pub code: String,
     /// External imports collected from this module.
     pub external_imports: Vec<ExternalImport>,
+    /// Dynamic imports found in this module.
+    pub dynamic_imports: Vec<DynamicImportInfo>,
 }
 
 /// An external import that should be hoisted to the top of the bundle.
@@ -28,21 +30,32 @@ pub struct ExternalImport {
     pub is_side_effect: bool,
 }
 
-/// A span range to remove from the source text.
-struct Removal {
+/// Information about a dynamic `import()` expression found in a module.
+#[derive(Debug, Clone)]
+pub struct DynamicImportInfo {
+    /// The original import specifier string.
+    pub original_specifier: String,
+}
+
+/// A text edit to apply to the source: either a removal or a replacement.
+struct TextEdit {
     start: u32,
     end: u32,
+    /// `None` means removal, `Some(text)` means replacement.
+    replacement: Option<String>,
 }
 
 /// Rewrite a single JavaScript module for bundling.
 ///
 /// Parses the JS code, classifies each import as local or external based on
-/// `local_prefixes`, strips local imports and export keywords, and collects
-/// external imports for hoisting.
+/// `local_prefixes`, strips local imports and export keywords, collects
+/// external imports for hoisting, and rewrites dynamic `import()` specifiers
+/// according to `dynamic_import_rewrites`.
 pub fn rewrite_module(
     js_code: &str,
     file_name: &str,
     local_prefixes: &[&str],
+    dynamic_import_rewrites: &HashMap<String, String>,
 ) -> NgcResult<RewrittenModule> {
     let allocator = Allocator::new();
     let source_type = SourceType::mjs();
@@ -54,121 +67,335 @@ pub fn rewrite_module(
         });
     }
 
-    let mut removals: Vec<Removal> = Vec::new();
+    let mut edits: Vec<TextEdit> = Vec::new();
     let mut external_imports: Vec<ExternalImport> = Vec::new();
+    let mut dynamic_imports: Vec<DynamicImportInfo> = Vec::new();
 
     for stmt in &parsed.program.body {
-        let module_decl = match stmt.as_module_declaration() {
-            Some(decl) => decl,
-            None => continue,
-        };
-
-        match module_decl {
-            ModuleDeclaration::ImportDeclaration(import) => {
-                let source = import.source.value.as_str();
-                if is_local(source, local_prefixes) {
-                    removals.push(Removal {
-                        start: import.span.start,
-                        end: import.span.end,
-                    });
-                } else {
-                    let mut named = BTreeSet::new();
-                    let mut default = None;
-                    let mut is_side_effect = true;
-
-                    if let Some(specifiers) = &import.specifiers {
-                        for spec in specifiers {
-                            is_side_effect = false;
-                            match spec {
-                                oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(s) => {
-                                    named.insert(s.local.name.to_string());
-                                }
-                                oxc_ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(
-                                    s,
-                                ) => {
-                                    default = Some(s.local.name.to_string());
-                                }
-                                oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
-                                    s,
-                                ) => {
-                                    named.insert(format!("* as {}", s.local.name));
-                                }
-                            }
-                        }
-                    }
-
-                    external_imports.push(ExternalImport {
-                        source: source.to_string(),
-                        default_import: default,
-                        named_imports: named,
-                        is_side_effect,
-                    });
-                    removals.push(Removal {
-                        start: import.span.start,
-                        end: import.span.end,
-                    });
-                }
-            }
-            ModuleDeclaration::ExportNamedDeclaration(export) => {
-                if export.source.is_some() {
-                    // Re-export: `export { Foo } from './foo'` — remove entirely
-                    removals.push(Removal {
-                        start: export.span.start,
-                        end: export.span.end,
-                    });
-                } else if export.declaration.is_some() {
-                    // `export class Foo` or `export const x` — remove only `export` keyword
-                    removals.push(Removal {
-                        start: export.span.start,
-                        end: export.span.start + 7, // "export "
-                    });
-                } else {
-                    // `export { Foo, Bar }` — export list, remove entirely
-                    removals.push(Removal {
-                        start: export.span.start,
-                        end: export.span.end,
-                    });
-                }
-            }
-            ModuleDeclaration::ExportDefaultDeclaration(export) => {
-                match &export.declaration {
-                    ExportDefaultDeclarationKind::FunctionDeclaration(_)
-                    | ExportDefaultDeclarationKind::ClassDeclaration(_) => {
-                        // `export default class Foo` — remove `export default`
-                        removals.push(Removal {
-                            start: export.span.start,
-                            end: export.span.start + 15, // "export default "
-                        });
-                    }
-                    _ => {
-                        // `export default expr` — remove entirely for now
-                        removals.push(Removal {
-                            start: export.span.start,
-                            end: export.span.end,
-                        });
-                    }
-                }
-            }
-            ModuleDeclaration::ExportAllDeclaration(export) => {
-                if is_local(export.source.value.as_str(), local_prefixes) {
-                    removals.push(Removal {
-                        start: export.span.start,
-                        end: export.span.end,
-                    });
-                } else {
-                    // External re-export — keep as-is for now
-                }
-            }
-            _ => {}
+        // Walk top-level module declarations (import/export)
+        if let Some(module_decl) = stmt.as_module_declaration() {
+            collect_module_decl_edits(
+                module_decl,
+                local_prefixes,
+                &mut edits,
+                &mut external_imports,
+            );
         }
+
+        // Walk all expressions recursively for dynamic import()
+        collect_dynamic_import_edits(
+            stmt,
+            dynamic_import_rewrites,
+            &mut edits,
+            &mut dynamic_imports,
+        );
     }
 
-    let code = apply_removals(js_code, &mut removals);
+    let code = apply_edits(js_code, &mut edits);
 
     Ok(RewrittenModule {
         code,
         external_imports,
+        dynamic_imports,
     })
+}
+
+/// Process a top-level module declaration (import/export) and collect edits.
+fn collect_module_decl_edits(
+    module_decl: &ModuleDeclaration,
+    local_prefixes: &[&str],
+    edits: &mut Vec<TextEdit>,
+    external_imports: &mut Vec<ExternalImport>,
+) {
+    match module_decl {
+        ModuleDeclaration::ImportDeclaration(import) => {
+            let source = import.source.value.as_str();
+            if is_local(source, local_prefixes) {
+                edits.push(TextEdit {
+                    start: import.span.start,
+                    end: import.span.end,
+                    replacement: None,
+                });
+            } else {
+                let mut named = BTreeSet::new();
+                let mut default = None;
+                let mut is_side_effect = true;
+
+                if let Some(specifiers) = &import.specifiers {
+                    for spec in specifiers {
+                        is_side_effect = false;
+                        match spec {
+                            oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(s) => {
+                                named.insert(s.local.name.to_string());
+                            }
+                            oxc_ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
+                                default = Some(s.local.name.to_string());
+                            }
+                            oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+                                s,
+                            ) => {
+                                named.insert(format!("* as {}", s.local.name));
+                            }
+                        }
+                    }
+                }
+
+                external_imports.push(ExternalImport {
+                    source: source.to_string(),
+                    default_import: default,
+                    named_imports: named,
+                    is_side_effect,
+                });
+                edits.push(TextEdit {
+                    start: import.span.start,
+                    end: import.span.end,
+                    replacement: None,
+                });
+            }
+        }
+        ModuleDeclaration::ExportNamedDeclaration(export) => {
+            if export.source.is_some() {
+                edits.push(TextEdit {
+                    start: export.span.start,
+                    end: export.span.end,
+                    replacement: None,
+                });
+            } else if export.declaration.is_some() {
+                edits.push(TextEdit {
+                    start: export.span.start,
+                    end: export.span.start + 7, // "export "
+                    replacement: None,
+                });
+            } else {
+                edits.push(TextEdit {
+                    start: export.span.start,
+                    end: export.span.end,
+                    replacement: None,
+                });
+            }
+        }
+        ModuleDeclaration::ExportDefaultDeclaration(export) => {
+            match &export.declaration {
+                ExportDefaultDeclarationKind::FunctionDeclaration(_)
+                | ExportDefaultDeclarationKind::ClassDeclaration(_) => {
+                    edits.push(TextEdit {
+                        start: export.span.start,
+                        end: export.span.start + 15, // "export default "
+                        replacement: None,
+                    });
+                }
+                _ => {
+                    edits.push(TextEdit {
+                        start: export.span.start,
+                        end: export.span.end,
+                        replacement: None,
+                    });
+                }
+            }
+        }
+        ModuleDeclaration::ExportAllDeclaration(export) => {
+            if is_local(export.source.value.as_str(), local_prefixes) {
+                edits.push(TextEdit {
+                    start: export.span.start,
+                    end: export.span.end,
+                    replacement: None,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walk a statement recursively to find dynamic `import()` expressions.
+fn collect_dynamic_import_edits(
+    stmt: &Statement,
+    rewrites: &HashMap<String, String>,
+    edits: &mut Vec<TextEdit>,
+    dynamic_imports: &mut Vec<DynamicImportInfo>,
+) {
+    // Walk expressions within this statement
+    match stmt {
+        Statement::ExpressionStatement(expr_stmt) => {
+            walk_expr_for_dynamic_imports(&expr_stmt.expression, rewrites, edits, dynamic_imports);
+        }
+        Statement::VariableDeclaration(decl) => {
+            for declarator in &decl.declarations {
+                if let Some(init) = &declarator.init {
+                    walk_expr_for_dynamic_imports(init, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        Statement::ReturnStatement(ret) => {
+            if let Some(arg) = &ret.argument {
+                walk_expr_for_dynamic_imports(arg, rewrites, edits, dynamic_imports);
+            }
+        }
+        Statement::ExportNamedDeclaration(export) => {
+            if let Some(decl) = &export.declaration {
+                collect_dynamic_import_edits_from_decl(decl, rewrites, edits, dynamic_imports);
+            }
+        }
+        Statement::ExportDefaultDeclaration(export) => {
+            if let ExportDefaultDeclarationKind::FunctionDeclaration(f) = &export.declaration {
+                if let Some(body) = &f.body {
+                    for s in &body.statements {
+                        collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walk a declaration for dynamic imports (used inside export statements).
+fn collect_dynamic_import_edits_from_decl(
+    decl: &oxc_ast::ast::Declaration,
+    rewrites: &HashMap<String, String>,
+    edits: &mut Vec<TextEdit>,
+    dynamic_imports: &mut Vec<DynamicImportInfo>,
+) {
+    match decl {
+        oxc_ast::ast::Declaration::VariableDeclaration(var_decl) => {
+            for declarator in &var_decl.declarations {
+                if let Some(init) = &declarator.init {
+                    walk_expr_for_dynamic_imports(init, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        oxc_ast::ast::Declaration::FunctionDeclaration(f) => {
+            if let Some(body) = &f.body {
+                for s in &body.statements {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Recursively walk an expression tree to find `import()` calls.
+fn walk_expr_for_dynamic_imports(
+    expr: &Expression,
+    rewrites: &HashMap<String, String>,
+    edits: &mut Vec<TextEdit>,
+    dynamic_imports: &mut Vec<DynamicImportInfo>,
+) {
+    match expr {
+        Expression::ImportExpression(import_expr) => {
+            // Extract the specifier from the source argument
+            if let Expression::StringLiteral(lit) = &import_expr.source {
+                let specifier = lit.value.as_str();
+                dynamic_imports.push(DynamicImportInfo {
+                    original_specifier: specifier.to_string(),
+                });
+
+                // Rewrite if we have a mapping
+                if let Some(chunk_filename) = rewrites.get(specifier) {
+                    // Replace the entire string literal (including quotes) with new value
+                    edits.push(TextEdit {
+                        start: lit.span.start,
+                        end: lit.span.end,
+                        replacement: Some(format!("'./{chunk_filename}'")),
+                    });
+                }
+            }
+        }
+        Expression::CallExpression(call) => {
+            walk_expr_for_dynamic_imports(&call.callee, rewrites, edits, dynamic_imports);
+            for arg in &call.arguments {
+                if let Some(expr) = arg.as_expression() {
+                    walk_expr_for_dynamic_imports(expr, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        Expression::ArrowFunctionExpression(arrow) => {
+            // Walk the body — could be an expression or statements
+            if arrow.expression {
+                // Single expression body
+                if let Some(Statement::ExpressionStatement(expr_stmt)) =
+                    arrow.body.statements.first()
+                {
+                    walk_expr_for_dynamic_imports(
+                        &expr_stmt.expression,
+                        rewrites,
+                        edits,
+                        dynamic_imports,
+                    );
+                }
+            } else {
+                for s in &arrow.body.statements {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        // Handle member expressions (StaticMember, ComputedMember, PrivateField)
+        _ if expr.as_member_expression().is_some() => {
+            let member = expr.as_member_expression().expect("checked above");
+            walk_expr_for_dynamic_imports(member.object(), rewrites, edits, dynamic_imports);
+        }
+        Expression::ArrayExpression(arr) => {
+            for elem in &arr.elements {
+                if let oxc_ast::ast::ArrayExpressionElement::SpreadElement(spread) = elem {
+                    walk_expr_for_dynamic_imports(
+                        &spread.argument,
+                        rewrites,
+                        edits,
+                        dynamic_imports,
+                    );
+                } else if let Some(expr) = elem.as_expression() {
+                    walk_expr_for_dynamic_imports(expr, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        Expression::ObjectExpression(obj) => {
+            for prop in &obj.properties {
+                match prop {
+                    oxc_ast::ast::ObjectPropertyKind::ObjectProperty(p) => {
+                        walk_expr_for_dynamic_imports(&p.value, rewrites, edits, dynamic_imports);
+                    }
+                    oxc_ast::ast::ObjectPropertyKind::SpreadProperty(spread) => {
+                        walk_expr_for_dynamic_imports(
+                            &spread.argument,
+                            rewrites,
+                            edits,
+                            dynamic_imports,
+                        );
+                    }
+                }
+            }
+        }
+        Expression::ConditionalExpression(cond) => {
+            walk_expr_for_dynamic_imports(&cond.test, rewrites, edits, dynamic_imports);
+            walk_expr_for_dynamic_imports(&cond.consequent, rewrites, edits, dynamic_imports);
+            walk_expr_for_dynamic_imports(&cond.alternate, rewrites, edits, dynamic_imports);
+        }
+        Expression::LogicalExpression(logic) => {
+            walk_expr_for_dynamic_imports(&logic.left, rewrites, edits, dynamic_imports);
+            walk_expr_for_dynamic_imports(&logic.right, rewrites, edits, dynamic_imports);
+        }
+        Expression::AssignmentExpression(assign) => {
+            walk_expr_for_dynamic_imports(&assign.right, rewrites, edits, dynamic_imports);
+        }
+        Expression::SequenceExpression(seq) => {
+            for expr in &seq.expressions {
+                walk_expr_for_dynamic_imports(expr, rewrites, edits, dynamic_imports);
+            }
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            walk_expr_for_dynamic_imports(&paren.expression, rewrites, edits, dynamic_imports);
+        }
+        Expression::AwaitExpression(aw) => {
+            walk_expr_for_dynamic_imports(&aw.argument, rewrites, edits, dynamic_imports);
+        }
+        Expression::TemplateLiteral(tl) => {
+            for expr in &tl.expressions {
+                walk_expr_for_dynamic_imports(expr, rewrites, edits, dynamic_imports);
+            }
+        }
+        // For other expression types, we don't recurse (no nested import() possible)
+        _ => {}
+    }
 }
 
 /// Check if an import specifier is local based on known prefixes.
@@ -178,23 +405,30 @@ fn is_local(specifier: &str, local_prefixes: &[&str]) -> bool {
         .any(|prefix| specifier.starts_with(prefix))
 }
 
-/// Apply span removals to the source text, producing the rewritten code.
-fn apply_removals(source: &str, removals: &mut [Removal]) -> String {
-    // Sort in reverse order so later removals don't shift earlier offsets
-    removals.sort_by(|a, b| b.start.cmp(&a.start));
+/// Apply text edits to the source, producing the rewritten code.
+fn apply_edits(source: &str, edits: &mut [TextEdit]) -> String {
+    // Sort in reverse order so later edits don't shift earlier offsets
+    edits.sort_by(|a, b| b.start.cmp(&a.start));
 
     let mut result = source.to_string();
-    for removal in removals.iter() {
-        let start = removal.start as usize;
-        let end = removal.end as usize;
+    for edit in edits.iter() {
+        let start = edit.start as usize;
+        let end = edit.end as usize;
         if start <= result.len() && end <= result.len() {
-            // Also remove trailing newline if present
-            let actual_end = if end < result.len() && result.as_bytes()[end] == b'\n' {
-                end + 1
-            } else {
-                end
-            };
-            result.replace_range(start..actual_end, "");
+            match &edit.replacement {
+                Some(new_text) => {
+                    result.replace_range(start..end, new_text);
+                }
+                None => {
+                    // Removal: also remove trailing newline if present
+                    let actual_end = if end < result.len() && result.as_bytes()[end] == b'\n' {
+                        end + 1
+                    } else {
+                        end
+                    };
+                    result.replace_range(start..actual_end, "");
+                }
+            }
         }
     }
 
@@ -205,10 +439,15 @@ fn apply_removals(source: &str, removals: &mut [Removal]) -> String {
 mod tests {
     use super::*;
 
+    fn empty_rewrites() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
     #[test]
     fn test_external_named_import_collected_and_removed() {
         let code = "import { Component } from '@angular/core';\nclass Foo {}\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert!(!result.code.contains("import"));
         assert_eq!(result.external_imports.len(), 1);
         assert_eq!(result.external_imports[0].source, "@angular/core");
@@ -220,7 +459,8 @@ mod tests {
     #[test]
     fn test_external_default_import_collected() {
         let code = "import _decorate from '@oxc-project/runtime/helpers/decorate';\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert_eq!(
             result.external_imports[0].default_import,
             Some("_decorate".to_string())
@@ -230,7 +470,8 @@ mod tests {
     #[test]
     fn test_local_relative_import_removed() {
         let code = "import { Foo } from './foo';\nconst x = 1;\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert!(!result.code.contains("import"));
         assert!(result.code.contains("const x = 1"));
         assert!(result.external_imports.is_empty());
@@ -239,7 +480,8 @@ mod tests {
     #[test]
     fn test_local_alias_import_removed() {
         let code = "import { SharedUtils } from '@app/shared';\n";
-        let result = rewrite_module(code, "test.js", &[".", "@app/"]).expect("should rewrite");
+        let result = rewrite_module(code, "test.js", &[".", "@app/"], &empty_rewrites())
+            .expect("should rewrite");
         assert!(!result.code.contains("import"));
         assert!(result.external_imports.is_empty());
     }
@@ -247,7 +489,8 @@ mod tests {
     #[test]
     fn test_reexport_removed() {
         let code = "export { SharedUtils } from './utils';\nexport { Logger } from './logger';\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert!(!result.code.contains("export"));
         assert!(!result.code.contains("SharedUtils"));
     }
@@ -255,7 +498,8 @@ mod tests {
     #[test]
     fn test_export_class_keyword_stripped() {
         let code = "export class Logger {\n\tstatic log(msg) {}\n}\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert!(result.code.contains("class Logger"));
         assert!(!result.code.contains("export"));
     }
@@ -263,7 +507,8 @@ mod tests {
     #[test]
     fn test_export_const_keyword_stripped() {
         let code = "export const routes = [];\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert!(result.code.contains("const routes = []"));
         assert!(!result.code.contains("export"));
     }
@@ -271,7 +516,8 @@ mod tests {
     #[test]
     fn test_export_list_removed() {
         let code = "let AppComponent = class AppComponent {};\nexport { AppComponent };\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert!(result.code.contains("let AppComponent"));
         assert!(!result.code.contains("export"));
     }
@@ -279,7 +525,8 @@ mod tests {
     #[test]
     fn test_side_effect_external_import() {
         let code = "import 'zone.js';\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert_eq!(result.external_imports.len(), 1);
         assert!(result.external_imports[0].is_side_effect);
         assert_eq!(result.external_imports[0].source, "zone.js");
@@ -288,8 +535,58 @@ mod tests {
     #[test]
     fn test_module_with_no_imports() {
         let code = "const x = 42;\n";
-        let result = rewrite_module(code, "test.js", &["."]).expect("should rewrite");
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
         assert_eq!(result.code.trim(), "const x = 42;");
         assert!(result.external_imports.is_empty());
+    }
+
+    #[test]
+    fn test_dynamic_import_detected() {
+        let code = "const m = import('./lazy-module');\n";
+        let result =
+            rewrite_module(code, "test.js", &["."], &empty_rewrites()).expect("should rewrite");
+        assert_eq!(result.dynamic_imports.len(), 1);
+        assert_eq!(
+            result.dynamic_imports[0].original_specifier,
+            "./lazy-module"
+        );
+        // Without rewrites, the import() should pass through as-is
+        assert!(result.code.contains("import('./lazy-module')"));
+    }
+
+    #[test]
+    fn test_dynamic_import_rewritten() {
+        let code = "const m = import('./admin/admin.component');\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert(
+            "./admin/admin.component".to_string(),
+            "chunk-admin-component.js".to_string(),
+        );
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(result.code.contains("'./chunk-admin-component.js'"));
+        assert!(!result.code.contains("./admin/admin.component"));
+    }
+
+    #[test]
+    fn test_dynamic_import_in_arrow_function() {
+        let code = "const routes = [{ path: 'admin', loadComponent: () => import('./admin').then(m => m.Admin) }];\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./admin".to_string(), "chunk-admin.js".to_string());
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(result.code.contains("'./chunk-admin.js'"));
+        assert!(!result.code.contains("import('./admin')"));
+        assert_eq!(result.dynamic_imports.len(), 1);
+    }
+
+    #[test]
+    fn test_dynamic_import_in_export_const() {
+        let code =
+            "export const routes = [{ loadComponent: () => import('./lazy').then(m => m.C) }];\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(result.code.contains("'./chunk-lazy.js'"));
+        assert_eq!(result.dynamic_imports.len(), 1);
     }
 }

--- a/crates/bundler/tests/snapshot_tests.rs
+++ b/crates/bundler/tests/snapshot_tests.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use ngc_bundler::BundleInput;
+use ngc_bundler::{BundleInput, BundleOutput};
 
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/simple-app")
 }
 
-fn build_bundle() -> String {
+fn build_bundle() -> BundleOutput {
     let tsconfig_path = fixture_path().join("tsconfig.app.json");
     let config = ngc_project_resolver::tsconfig::resolve_tsconfig(&tsconfig_path)
         .expect("should resolve tsconfig");
@@ -68,15 +68,25 @@ fn build_bundle() -> String {
     ngc_bundler::bundle(&input).expect("should bundle")
 }
 
+/// Helper to get the main chunk code from a BundleOutput.
+fn main_chunk(output: &BundleOutput) -> &str {
+    output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk should exist")
+}
+
 #[test]
 fn test_bundle_snapshot() {
-    let bundle = build_bundle();
+    let output = build_bundle();
+    let bundle = main_chunk(&output);
     insta::assert_snapshot!("bundle_output", bundle);
 }
 
 #[test]
 fn test_bundle_has_no_local_imports() {
-    let bundle = build_bundle();
+    let output = build_bundle();
+    let bundle = main_chunk(&output);
     for line in bundle.lines() {
         if line.starts_with("import") && line.contains("from") {
             let from_part = line.split("from").last().unwrap_or("");
@@ -98,7 +108,8 @@ fn test_bundle_has_no_local_imports() {
 
 #[test]
 fn test_bundle_preserves_external_imports() {
-    let bundle = build_bundle();
+    let output = build_bundle();
+    let bundle = main_chunk(&output);
     assert!(
         bundle.contains("@angular/core"),
         "should preserve @angular/core import"
@@ -115,7 +126,8 @@ fn test_bundle_preserves_external_imports() {
 
 #[test]
 fn test_bundle_excludes_unreachable_modules() {
-    let bundle = build_bundle();
+    let output = build_bundle();
+    let bundle = main_chunk(&output);
     // environment.prod.ts exports `production: true` and is not reachable from main.ts
     assert!(
         !bundle.contains("environment.prod"),
@@ -130,7 +142,8 @@ fn test_bundle_excludes_unreachable_modules() {
 
 #[test]
 fn test_bundle_entry_point_last() {
-    let bundle = build_bundle();
+    let output = build_bundle();
+    let bundle = main_chunk(&output);
     let main_comment_pos = bundle
         .rfind("// src/main.js")
         .expect("main.js comment should exist");

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -57,7 +57,13 @@ class AppComponent {
 }
 
 // src/app/app.routes.js
-const routes = [];
+const routes = [{
+	path: 'admin',
+	loadComponent: () => import('./chunk-admin-component.js').then((m) => m.AdminComponent)
+}, {
+	path: 'dashboard',
+	loadChildren: () => import('./chunk-dashboard-routes.js').then((m) => m.dashboardRoutes)
+}];
 
 // src/app/app.config.js
 const appConfig = { providers: [provideRouter(routes)] };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -222,7 +222,11 @@ fn run_build(
     };
 
     let bundle_output = ngc_bundler::bundle(&bundle_input)?;
-    let modules_bundled = bundle_output.matches("\n// ").count() + 1;
+    let modules_bundled: usize = bundle_output
+        .chunks
+        .values()
+        .map(|code| code.matches("\n// ").count() + 1)
+        .sum();
 
     // Step 7: Write outputs
     std::fs::create_dir_all(&out_dir).map_err(|e| NgcError::Io {
@@ -232,13 +236,15 @@ fn run_build(
 
     let mut output_files: Vec<PathBuf> = Vec::new();
 
-    // Write main.js
-    let main_js_path = out_dir.join("main.js");
-    std::fs::write(&main_js_path, &bundle_output).map_err(|e| NgcError::Io {
-        path: main_js_path.clone(),
-        source: e,
-    })?;
-    output_files.push(main_js_path);
+    // Write all chunk files (main.js + chunk-*.js)
+    for (filename, code) in &bundle_output.chunks {
+        let path = out_dir.join(filename);
+        std::fs::write(&path, code).map_err(|e| NgcError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        output_files.push(path);
+    }
 
     // Step 8: Generate polyfills.js
     if let Some(ref ap) = angular_project {
@@ -279,7 +285,13 @@ fn run_build(
     }
 
     // Step 12: Generate 3rdpartylicenses.txt
-    if let Some(lp) = generate_third_party_licenses(&bundle_output, &config_dir, &out_dir)? {
+    let all_bundle_code: String = bundle_output
+        .chunks
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    if let Some(lp) = generate_third_party_licenses(&all_bundle_code, &config_dir, &out_dir)? {
         output_files.push(lp);
     }
 

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -144,6 +144,13 @@ pub enum NgcError {
         /// Description of what went wrong.
         message: String,
     },
+
+    /// A code splitting / chunk graph error occurred.
+    #[error("chunk error: {message}")]
+    ChunkError {
+        /// Description of what went wrong during chunk graph construction.
+        message: String,
+    },
 }
 
 /// A type alias for Results using NgcError.

--- a/crates/project-resolver/src/graph.rs
+++ b/crates/project-resolver/src/graph.rs
@@ -6,14 +6,15 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use rayon::prelude::*;
 use tracing::debug;
 
-use crate::import_scanner::scan_imports;
+use crate::import_scanner::{scan_imports_with_kind, ImportKind};
 use crate::tsconfig::ResolvedTsConfig;
 
 /// The file dependency graph for an Angular project.
 #[derive(Debug)]
 pub struct FileGraph {
-    /// The directed graph where nodes are file paths and edges represent imports.
-    pub graph: DiGraph<PathBuf, ()>,
+    /// The directed graph where nodes are file paths and edges are import relationships.
+    /// Edge weight indicates whether the import is static or dynamic.
+    pub graph: DiGraph<PathBuf, ImportKind>,
     /// Map from canonical file path to its node index, for O(1) lookup.
     pub path_index: HashMap<PathBuf, NodeIndex>,
     /// Files with in-degree 0 (no other project file imports them).
@@ -103,12 +104,12 @@ pub fn build_file_graph(config: &ResolvedTsConfig) -> NgcResult<FileGraph> {
         path_index.insert(file.clone(), idx);
     }
 
-    // Parallel scan: read each file and extract imports
-    let scan_results: Vec<(PathBuf, Vec<String>)> = discovered_files
+    // Parallel scan: read each file and extract imports with kind
+    let scan_results: Vec<(PathBuf, Vec<crate::import_scanner::ScannedImport>)> = discovered_files
         .par_iter()
         .filter_map(|file_path| {
             let contents = std::fs::read_to_string(file_path).ok()?;
-            let imports = scan_imports(&contents);
+            let imports = scan_imports_with_kind(&contents);
             Some((file_path.clone(), imports))
         })
         .collect();
@@ -116,22 +117,22 @@ pub fn build_file_graph(config: &ResolvedTsConfig) -> NgcResult<FileGraph> {
     let mut unresolved = Vec::new();
 
     // Resolve imports and add edges (single-threaded for graph mutation)
-    for (from_file, specifiers) in &scan_results {
+    for (from_file, scanned_imports) in &scan_results {
         let from_idx = path_index[from_file];
-        for specifier in specifiers {
-            match resolve_specifier(specifier, from_file, &resolver_config) {
+        for scanned in scanned_imports {
+            match resolve_specifier(&scanned.specifier, from_file, &resolver_config) {
                 Some(resolved_path) => {
                     if let Some(&to_idx) = path_index.get(&resolved_path) {
-                        graph.add_edge(from_idx, to_idx, ());
+                        graph.add_edge(from_idx, to_idx, scanned.kind);
                     }
                     // If resolved but not in our file set, it's an external file — skip
                 }
                 None => {
                     // Only record as unresolved if it looks like a project-local import
-                    if is_project_local(specifier, &resolver_config) {
+                    if is_project_local(&scanned.specifier, &resolver_config) {
                         unresolved.push(UnresolvedImport {
                             from_file: from_file.clone(),
-                            specifier: specifier.clone(),
+                            specifier: scanned.specifier.clone(),
                         });
                     }
                 }

--- a/crates/project-resolver/src/graph.rs
+++ b/crates/project-resolver/src/graph.rs
@@ -431,7 +431,7 @@ mod tests {
     fn test_discover_files_from_include() {
         let config = crate::tsconfig::resolve_tsconfig(&fixture_path("tsconfig.app.json")).unwrap();
         let files = discover_files(&config).unwrap();
-        assert_eq!(files.len(), 9);
+        assert_eq!(files.len(), 13);
 
         // Verify all expected files are present
         let file_names: Vec<String> = files
@@ -450,8 +450,8 @@ mod tests {
         let file_graph = build_file_graph(&config).unwrap();
         let summary = summarize(&file_graph);
 
-        assert_eq!(summary.file_count, 9);
-        assert_eq!(summary.edge_count, 8);
+        assert_eq!(summary.file_count, 13);
+        assert_eq!(summary.edge_count, 13);
         assert_eq!(summary.unresolved_count, 0);
         assert_eq!(summary.entry_point_count, 2);
     }

--- a/crates/project-resolver/src/import_scanner.rs
+++ b/crates/project-resolver/src/import_scanner.rs
@@ -18,6 +18,78 @@ static DYNAMIC_IMPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"import\(\s*['"]([^'"]+)['"]\s*\)"#).expect("DYNAMIC_IMPORT_RE is a valid regex")
 });
 
+/// Distinguishes static `import`/`export` declarations from dynamic `import()` expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ImportKind {
+    /// A static `import ... from '...'`, `export ... from '...'`, or side-effect `import '...'`.
+    Static,
+    /// A dynamic `import('...')` expression (triggers code splitting).
+    Dynamic,
+}
+
+/// An import specifier with its kind (static or dynamic).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedImport {
+    /// The raw import specifier string.
+    pub specifier: String,
+    /// Whether this is a static or dynamic import.
+    pub kind: ImportKind,
+}
+
+/// Scan a TypeScript source file and extract all import specifiers with their kind.
+///
+/// Extracts specifiers from:
+/// - Static `import ... from '...'` statements → [`ImportKind::Static`]
+/// - `export ... from '...'` re-exports → [`ImportKind::Static`]
+/// - Side-effect `import '...'` statements → [`ImportKind::Static`]
+/// - Dynamic `import('...')` expressions → [`ImportKind::Dynamic`]
+///
+/// If the same specifier appears as both static and dynamic, both entries are emitted.
+/// Within each kind, specifiers are deduplicated.
+pub fn scan_imports_with_kind(source: &str) -> Vec<ScannedImport> {
+    let mut imports = Vec::new();
+    let mut seen_static = std::collections::HashSet::new();
+    let mut seen_dynamic = std::collections::HashSet::new();
+
+    for cap in FROM_CLAUSE_RE.captures_iter(source) {
+        if let Some(m) = cap.get(1) {
+            let s = m.as_str().to_string();
+            if seen_static.insert(s.clone()) {
+                imports.push(ScannedImport {
+                    specifier: s,
+                    kind: ImportKind::Static,
+                });
+            }
+        }
+    }
+
+    for cap in SIDE_EFFECT_IMPORT_RE.captures_iter(source) {
+        if let Some(m) = cap.get(1) {
+            let s = m.as_str().to_string();
+            if seen_static.insert(s.clone()) {
+                imports.push(ScannedImport {
+                    specifier: s,
+                    kind: ImportKind::Static,
+                });
+            }
+        }
+    }
+
+    for cap in DYNAMIC_IMPORT_RE.captures_iter(source) {
+        if let Some(m) = cap.get(1) {
+            let s = m.as_str().to_string();
+            if seen_dynamic.insert(s.clone()) {
+                imports.push(ScannedImport {
+                    specifier: s,
+                    kind: ImportKind::Dynamic,
+                });
+            }
+        }
+    }
+
+    imports
+}
+
 /// Scan a TypeScript source file's contents and extract all import specifiers.
 ///
 /// Extracts specifiers from:
@@ -32,30 +104,9 @@ pub fn scan_imports(source: &str) -> Vec<String> {
     let mut specifiers = Vec::new();
     let mut seen = std::collections::HashSet::new();
 
-    for cap in FROM_CLAUSE_RE.captures_iter(source) {
-        if let Some(m) = cap.get(1) {
-            let s = m.as_str().to_string();
-            if seen.insert(s.clone()) {
-                specifiers.push(s);
-            }
-        }
-    }
-
-    for cap in SIDE_EFFECT_IMPORT_RE.captures_iter(source) {
-        if let Some(m) = cap.get(1) {
-            let s = m.as_str().to_string();
-            if seen.insert(s.clone()) {
-                specifiers.push(s);
-            }
-        }
-    }
-
-    for cap in DYNAMIC_IMPORT_RE.captures_iter(source) {
-        if let Some(m) = cap.get(1) {
-            let s = m.as_str().to_string();
-            if seen.insert(s.clone()) {
-                specifiers.push(s);
-            }
+    for imp in scan_imports_with_kind(source) {
+        if seen.insert(imp.specifier.clone()) {
+            specifiers.push(imp.specifier);
         }
     }
 
@@ -172,5 +223,51 @@ import { Bar } from "./bar";"#;
         let source = "const x = 42;\nconsole.log(x);";
         let imports = scan_imports(source);
         assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn test_scan_with_kind_static() {
+        let source = r#"import { Component } from '@angular/core';"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].specifier, "@angular/core");
+        assert_eq!(imports[0].kind, ImportKind::Static);
+    }
+
+    #[test]
+    fn test_scan_with_kind_dynamic() {
+        let source = r#"const m = import('./lazy-module');"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].specifier, "./lazy-module");
+        assert_eq!(imports[0].kind, ImportKind::Dynamic);
+    }
+
+    #[test]
+    fn test_scan_with_kind_mixed() {
+        let source = r#"import { Routes } from '@angular/router';
+const routes = [
+  { path: 'admin', loadComponent: () => import('./admin/admin.component').then(m => m.AdminComponent) },
+];"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].specifier, "@angular/router");
+        assert_eq!(imports[0].kind, ImportKind::Static);
+        assert_eq!(imports[1].specifier, "./admin/admin.component");
+        assert_eq!(imports[1].kind, ImportKind::Dynamic);
+    }
+
+    #[test]
+    fn test_scan_with_kind_same_specifier_both_kinds() {
+        let source = r#"import { Foo } from './foo';
+const lazy = import('./foo');"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 2);
+        assert!(imports
+            .iter()
+            .any(|i| i.specifier == "./foo" && i.kind == ImportKind::Static));
+        assert!(imports
+            .iter()
+            .any(|i| i.specifier == "./foo" && i.kind == ImportKind::Dynamic));
     }
 }

--- a/crates/project-resolver/src/lib.rs
+++ b/crates/project-resolver/src/lib.rs
@@ -5,7 +5,8 @@ pub mod tsconfig;
 
 use std::path::Path;
 
-use graph::{FileGraph, GraphSummary};
+pub use graph::{FileGraph, GraphSummary};
+pub use import_scanner::ImportKind;
 use ngc_diagnostics::NgcResult;
 
 /// Resolve the complete file dependency graph for an Angular project.

--- a/crates/project-resolver/tests/snapshots/snapshot_tests__simple_app_edges.snap
+++ b/crates/project-resolver/tests/snapshots/snapshot_tests__simple_app_edges.snap
@@ -2,8 +2,13 @@
 source: crates/project-resolver/tests/snapshot_tests.rs
 expression: "edges.join(\"\\n\")"
 ---
+src/app/admin/admin.component.ts -> src/app/shared/shared.service.ts
 src/app/app.component.ts -> src/app/shared/index.ts
 src/app/app.config.ts -> src/app/app.routes.ts
+src/app/app.routes.ts -> src/app/admin/admin.component.ts
+src/app/app.routes.ts -> src/app/dashboard/dashboard.routes.ts
+src/app/dashboard/dashboard.component.ts -> src/app/shared/shared.service.ts
+src/app/dashboard/dashboard.routes.ts -> src/app/dashboard/dashboard.component.ts
 src/app/shared/index.ts -> src/app/shared/logger.ts
 src/app/shared/index.ts -> src/app/shared/utils.ts
 src/app/shared/utils.ts -> src/app/shared/logger.ts

--- a/crates/project-resolver/tests/snapshots/snapshot_tests__simple_app_files.snap
+++ b/crates/project-resolver/tests/snapshots/snapshot_tests__simple_app_files.snap
@@ -2,11 +2,15 @@
 source: crates/project-resolver/tests/snapshot_tests.rs
 expression: "files.join(\"\\n\")"
 ---
+src/app/admin/admin.component.ts
 src/app/app.component.ts
 src/app/app.config.ts
 src/app/app.routes.ts
+src/app/dashboard/dashboard.component.ts
+src/app/dashboard/dashboard.routes.ts
 src/app/shared/index.ts
 src/app/shared/logger.ts
+src/app/shared/shared.service.ts
 src/app/shared/utils.ts
 src/environments/environment.prod.ts
 src/environments/environment.ts

--- a/crates/project-resolver/tests/snapshots/snapshot_tests__simple_app_summary.snap
+++ b/crates/project-resolver/tests/snapshots/snapshot_tests__simple_app_summary.snap
@@ -3,8 +3,8 @@ source: crates/project-resolver/tests/snapshot_tests.rs
 expression: "format!(\"{summary:#?}\")"
 ---
 GraphSummary {
-    file_count: 9,
+    file_count: 13,
     entry_point_count: 2,
-    edge_count: 8,
+    edge_count: 13,
     unresolved_count: 0,
 }

--- a/crates/ts-transform/tests/integration_tests.rs
+++ b/crates/ts-transform/tests/integration_tests.rs
@@ -17,7 +17,7 @@ fn test_transform_project_produces_js_files() {
     let result = ngc_ts_transform::transform_project(&files, &root_dir, out_dir.path())
         .expect("transform should succeed");
 
-    assert_eq!(result.files_transformed, 9);
+    assert_eq!(result.files_transformed, 13);
     assert!(out_dir.path().join("app/app.component.js").exists());
     assert!(out_dir.path().join("main.js").exists());
     assert!(out_dir.path().join("app/shared/logger.js").exists());

--- a/crates/ts-transform/tests/snapshots/snapshot_tests__app_routes_js.snap
+++ b/crates/ts-transform/tests/snapshots/snapshot_tests__app_routes_js.snap
@@ -2,4 +2,10 @@
 source: crates/ts-transform/tests/snapshot_tests.rs
 expression: result
 ---
-export const routes = [];
+export const routes = [{
+	path: 'admin',
+	loadComponent: () => import('./admin/admin.component').then((m) => m.AdminComponent)
+}, {
+	path: 'dashboard',
+	loadChildren: () => import('./dashboard/dashboard.routes').then((m) => m.dashboardRoutes)
+}];

--- a/tests/fixtures/simple-app/src/app/admin/admin.component.ts
+++ b/tests/fixtures/simple-app/src/app/admin/admin.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { SharedService } from '../shared/shared.service';
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  template: '<h2>Admin: {{ data }}</h2>'
+})
+export class AdminComponent {
+  data = SharedService.getData().join(', ');
+}

--- a/tests/fixtures/simple-app/src/app/app.routes.ts
+++ b/tests/fixtures/simple-app/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'admin', loadComponent: () => import('./admin/admin.component').then(m => m.AdminComponent) },
+  { path: 'dashboard', loadChildren: () => import('./dashboard/dashboard.routes').then(m => m.dashboardRoutes) },
+];

--- a/tests/fixtures/simple-app/src/app/dashboard/dashboard.component.ts
+++ b/tests/fixtures/simple-app/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { SharedService } from '../shared/shared.service';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  template: '<h2>Dashboard: {{ items }}</h2>'
+})
+export class DashboardComponent {
+  items = SharedService.getData().length;
+}

--- a/tests/fixtures/simple-app/src/app/dashboard/dashboard.routes.ts
+++ b/tests/fixtures/simple-app/src/app/dashboard/dashboard.routes.ts
@@ -1,0 +1,6 @@
+import { Routes } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+
+export const dashboardRoutes: Routes = [
+  { path: '', component: DashboardComponent }
+];

--- a/tests/fixtures/simple-app/src/app/shared/shared.service.ts
+++ b/tests/fixtures/simple-app/src/app/shared/shared.service.ts
@@ -1,0 +1,5 @@
+export class SharedService {
+  static getData(): string[] {
+    return ['shared-data-1', 'shared-data-2'];
+  }
+}


### PR DESCRIPTION
## Summary
- **Dynamic import() detection**: `ImportKind` enum distinguishes static vs dynamic imports in the file graph, enabling code splitting boundaries
- **Chunk graph construction**: New `build_chunk_graph()` partitions modules into main, lazy, and shared chunks based on static reachability analysis
- **Multi-file bundle output**: `bundle()` now returns `BundleOutput` with `HashMap<String, String>` of chunk filename → code, producing `main.js + chunk-*.js`
- **Import rewriting**: Dynamic `import('./admin/admin.component')` expressions are rewritten to `import('./chunk-admin-component.js')` pointing to generated chunk filenames

## Changes across crates
- **diagnostics**: Added `ChunkError` variant
- **project-resolver**: `ImportKind` enum, `scan_imports_with_kind()`, `DiGraph<PathBuf, ImportKind>` edge metadata
- **bundler**: New `chunk.rs` module with chunk graph algorithm, `rewrite.rs` recursive AST walk for `import()` expressions, `BundleOutput` multi-chunk return type
- **cli**: Writes all chunk files, scans all chunks for license generation

## Test plan
- [x] 139 tests pass across all crates
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end build produces `main.js`, `chunk-admin-component.js`, `chunk-dashboard-routes.js`, `chunk-shared-0.js`
- [x] Main chunk does not contain lazy module classes
- [x] Dynamic imports rewritten to chunk filenames
- [x] Shared service extracted into shared chunk (used by both admin and dashboard)
- [x] Backward compat: projects without dynamic imports still produce single `main.js`