### PR TITLE
feat: Angular linker for partially compiled npm packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ Goal: file watching, incremental rebuilds, and ng serve support.
 
 Goal: zero-config swap for Angular developers.
 
+- [x] Angular linker for partially compiled npm packages (ɵɵngDeclare* → ɵɵdefine*)
 - [ ] npm binary distribution (platform-specific packages)
 - [ ] Angular builder adapter (speaks @angular-devkit builder protocol)
 - [ ] angular.json integration: swap builder, run ng build as normal
@@ -124,6 +125,9 @@ TsParser (oxc) ← crates/ts-parser [v0.2]
 │
 ▼
 TemplateCompiler ← crates/template-compiler [v0.4]
+│
+▼
+Linker ← crates/linker [v0.7.2]
 │
 ▼
 Bundler ← crates/bundler [v0.3]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -703,15 +703,29 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
+name = "ngc-linker"
+version = "0.7.2"
+dependencies = [
+ "insta",
+ "ngc-diagnostics",
+ "ngc-template-compiler",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "tracing",
+]
+
+[[package]]
 name = "ngc-npm-resolver"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -725,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "glob",
@@ -742,13 +756,14 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "clap",
  "colored",
  "glob",
  "ngc-bundler",
  "ngc-diagnostics",
+ "ngc-linker",
  "ngc-npm-resolver",
  "ngc-project-resolver",
  "ngc-template-compiler",
@@ -764,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -782,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 resolver = "2"
-members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver"]
+members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -289,6 +289,17 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMa
             let canonical = entry_path.canonicalize().unwrap_or(entry_path);
             if let Some(ns) = file_to_namespace.get(&canonical) {
                 specifier_to_namespace.insert(spec.clone(), ns.clone());
+                continue;
+            }
+        }
+        // Fallback: for vendored/synthetic modules (e.g., @oxc-project/runtime/helpers/decorate)
+        // that don't have a package.json, match by path suffix in the file_to_namespace map.
+        let spec_path_suffix = spec.replace('/', std::path::MAIN_SEPARATOR_STR);
+        for (path, ns) in &file_to_namespace {
+            let path_str = path.to_string_lossy();
+            if path_str.contains(&spec_path_suffix) {
+                specifier_to_namespace.insert(spec.clone(), ns.clone());
+                break;
             }
         }
     }

--- a/crates/bundler/src/npm_wrap.rs
+++ b/crates/bundler/src/npm_wrap.rs
@@ -235,10 +235,12 @@ where
     let mut export_lines = String::new();
     let unique_exports: BTreeSet<String> = exported_names.iter().cloned().collect();
     for name in &unique_exports {
-        // Skip "default" — it's a reserved word and can't be used as an identifier.
-        // Default exports are handled inline (expression → __exports.default = expr)
-        // or via the named function/class assignment below.
         if name == "default" {
+            // `export { X as default }` → use the local name for the assignment
+            if let Some(local_name) = renamed_exports.get(name) {
+                export_lines.push_str(&format!("  __exports.default = {local_name};\n"));
+            }
+            // Skip bare "default" without a rename — handled by has_default_export below
             continue;
         }
         // Use local name for renamed exports: export { getDefaulted as getActionCache }

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -2,7 +2,7 @@
 source: crates/bundler/tests/snapshot_tests.rs
 expression: bundle
 ---
-import { ɵɵStandaloneFeature, ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
+import { ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
 import { RouterOutlet, provideRouter } from '@angular/router';
 import { bootstrapApplication } from '@angular/platform-browser';
 
@@ -36,7 +36,6 @@ class AppComponent {
 		type: AppComponent,
 		selectors: [['app-root']],
 		standalone: true,
-		features: [ɵɵStandaloneFeature],
 		decls: 3,
 		vars: 1,
 		template: function AppComponent_Template(rf, ctx) {

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ ngc-ts-transform = { path = "../ts-transform" }
 ngc-bundler = { path = "../bundler" }
 ngc-template-compiler = { path = "../template-compiler" }
 ngc-npm-resolver = { path = "../npm-resolver" }
+ngc-linker = { path = "../linker" }
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -235,6 +235,15 @@ fn run_build(
         modules.insert(path.clone(), source.clone());
     }
 
+    // Step 6.6: Link partially compiled Angular npm packages
+    let linker_stats = ngc_linker::link_npm_modules(&mut modules, &config_dir)?;
+    if linker_stats.files_linked > 0 {
+        tracing::info!(
+            "linked {} Angular package file(s)",
+            linker_stats.files_linked
+        );
+    }
+
     // Inject vendored helpers for oxc runtime (not an npm dependency of the project)
     let injected_helpers = inject_oxc_runtime_helpers(&mut modules, &bare_specifiers, &config_dir);
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -288,15 +288,27 @@ fn run_build(
         }
     }
 
-    // Add injected helpers to resolved specifiers and connect edges
+    // Add injected helpers to resolved specifiers and connect dependency edges.
+    // We connect every project file that imports the helper (not just the entry point)
+    // so topological ordering places the helper before all files that use it.
     let mut bundled_specifiers = npm_resolution.resolved_specifiers;
     for (spec, helper_path) in &injected_helpers {
         bundled_specifiers.insert(spec.clone());
-        // Connect from the entry point to ensure the helper is reachable
-        if let (Some(&entry_idx), Some(&to_idx)) =
-            (path_index.get(&entry), path_index.get(helper_path))
-        {
-            graph.add_edge(entry_idx, to_idx, ngc_project_resolver::ImportKind::Static);
+        if let Some(&to_idx) = path_index.get(helper_path) {
+            // Find all project modules that import this specifier
+            for (module_path, module_source) in &modules {
+                if module_path
+                    .components()
+                    .any(|c| c.as_os_str() == "node_modules")
+                {
+                    continue;
+                }
+                if module_source.contains(spec.as_str()) {
+                    if let Some(&from_idx) = path_index.get(module_path) {
+                        graph.add_edge(from_idx, to_idx, ngc_project_resolver::ImportKind::Static);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -178,6 +178,15 @@ pub enum NgcError {
         /// Description of what went wrong.
         message: String,
     },
+
+    /// The Angular linker failed to process a partially compiled file.
+    #[error("linker error in {path}: {message}")]
+    LinkerError {
+        /// The path to the file that failed to link.
+        path: PathBuf,
+        /// Description of what went wrong.
+        message: String,
+    },
 }
 
 /// A type alias for Results using NgcError.

--- a/crates/linker/Cargo.toml
+++ b/crates/linker/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ngc-linker"
+description = "Angular linker for partially compiled npm packages"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+ngc-diagnostics = { path = "../diagnostics" }
+ngc-template-compiler = { path = "../template-compiler" }
+oxc_allocator = "0.122"
+oxc_parser = "0.122"
+oxc_ast = "0.122"
+oxc_span = "0.122"
+tracing = "0.1"
+
+[dev-dependencies]
+insta = { version = "1.46", features = ["glob"] }

--- a/crates/linker/src/class_metadata.rs
+++ b/crates/linker/src/class_metadata.rs
@@ -1,0 +1,80 @@
+//! Transform `ɵɵngDeclareClassMetadata` → `ɵsetClassMetadata`.
+//!
+//! ## Example
+//! ```js
+//! // Input:
+//! i0.ɵɵngDeclareClassMetadata({ type: MyService, decorators: [...] })
+//! // Output:
+//! (function() { i0.ɵsetClassMetadata(MyService, [...], null, null); })()
+//! ```
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::ObjectExpression;
+
+use crate::metadata;
+
+/// Transform a `ɵɵngDeclareClassMetadata` call into a `ɵsetClassMetadata` call.
+pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+    let set_fn = if ng_import.is_empty() {
+        "\u{0275}setClassMetadata".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}setClassMetadata")
+    };
+
+    let type_text = metadata::get_source_text(obj, "type", source).unwrap_or("Unknown");
+
+    let decorators = metadata::get_source_text(obj, "decorators", source).unwrap_or("[]");
+
+    let ctor_params = metadata::get_source_text(obj, "ctorParameters", source).unwrap_or("null");
+
+    let prop_decorators =
+        metadata::get_source_text(obj, "propDecorators", source).unwrap_or("null");
+
+    Ok(format!(
+        "(function() {{ {set_fn}({type_text}, {decorators}, {ctor_params}, {prop_decorators}); }})()"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::Expression;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0").unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_class_metadata_basic() {
+        let result = parse_and_transform(
+            "{ type: MyService, decorators: [{ type: Injectable, args: [{ providedIn: 'root' }] }] }",
+        );
+        assert!(result.contains("i0.\u{0275}setClassMetadata"));
+        assert!(result.contains("MyService"));
+        assert!(result.starts_with("(function()"));
+        assert!(result.ends_with("})()"));
+    }
+
+    #[test]
+    fn test_class_metadata_with_ctor_params() {
+        let result = parse_and_transform(
+            "{ type: MyService, decorators: [], ctorParameters: () => [{ type: HttpClient }] }",
+        );
+        assert!(result.contains("() => [{ type: HttpClient }]"));
+    }
+}

--- a/crates/linker/src/class_metadata.rs
+++ b/crates/linker/src/class_metadata.rs
@@ -50,10 +50,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0").unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0").unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -332,10 +332,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0", &PathBuf::from("test.mjs")).unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0", &PathBuf::from("test.mjs")).unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -1,0 +1,346 @@
+//! Transform `ɵɵngDeclareComponent` → `ɵɵdefineComponent`.
+//!
+//! This is the most complex transformation — it compiles the component's template
+//! string into a template function using the template compiler, then combines it
+//! with the directive-level metadata (selectors, inputs, outputs, host bindings).
+
+use std::path::Path;
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::{
+    ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+};
+use oxc_span::GetSpan;
+
+use crate::metadata;
+use crate::selector;
+
+/// Transform a `ɵɵngDeclareComponent` call into a `ɵɵdefineComponent` call.
+pub fn transform(
+    obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+    file_path: &Path,
+) -> NgcResult<String> {
+    let define_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}defineComponent".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}defineComponent")
+    };
+
+    let type_text = metadata::get_source_text(obj, "type", source).unwrap_or("Unknown");
+    let type_name =
+        metadata::get_identifier_prop(obj, "type").unwrap_or_else(|| type_text.to_string());
+
+    let mut props = Vec::new();
+    props.push(format!("type: {type_text}"));
+
+    // Parse selector into Angular array format
+    if let Some(sel) = metadata::get_string_prop(obj, "selector") {
+        props.push(format!("selectors: {}", selector::parse_selector(&sel)));
+    }
+
+    // Inputs (reuse directive logic)
+    if let Some(inputs) = build_inputs(obj, source) {
+        props.push(format!("inputs: {inputs}"));
+    }
+
+    // Outputs
+    if let Some(outputs) = build_outputs(obj, source) {
+        props.push(format!("outputs: {outputs}"));
+    }
+
+    // Standalone
+    let is_standalone = metadata::get_bool_prop(obj, "isStandalone") == Some(true)
+        || metadata::get_bool_prop(obj, "standalone") == Some(true);
+    if is_standalone {
+        props.push("standalone: true".to_string());
+    }
+
+    // Features
+    let mut features = Vec::new();
+    if metadata::get_bool_prop(obj, "usesInheritance") == Some(true) {
+        let feat = if ng_import.is_empty() {
+            "\u{0275}\u{0275}InheritDefinitionFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}InheritDefinitionFeature")
+        };
+        features.push(feat);
+    }
+    if is_standalone {
+        let feat = if ng_import.is_empty() {
+            "\u{0275}\u{0275}StandaloneFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}StandaloneFeature")
+        };
+        features.push(feat);
+    }
+    if !features.is_empty() {
+        props.push(format!("features: [{}]", features.join(", ")));
+    }
+
+    // Template compilation
+    if let Some(template_str) = metadata::get_string_prop(obj, "template") {
+        match compile_template(&template_str, &type_name, file_path) {
+            Ok((template_fn, decls, vars, child_fns)) => {
+                props.push(format!("decls: {decls}"));
+                props.push(format!("vars: {vars}"));
+                props.push(format!("template: {template_fn}"));
+                // Child template functions are prepended before the defineComponent call
+                // For now, we embed them in the template function directly
+                let _ = child_fns; // handled within template_fn already
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %file_path.display(),
+                    error = %e,
+                    "template compilation failed for npm component, using empty template"
+                );
+                // Fallback: empty template
+                props.push("decls: 0".to_string());
+                props.push("vars: 0".to_string());
+                props.push(format!(
+                    "template: function {type_name}_Template(rf, ctx) {{}}"
+                ));
+            }
+        }
+    } else {
+        // No template — empty
+        props.push("decls: 0".to_string());
+        props.push("vars: 0".to_string());
+        props.push(format!(
+            "template: function {type_name}_Template(rf, ctx) {{}}"
+        ));
+    }
+
+    // Dependencies — extract type references from the dependencies array
+    if let Some(deps_text) = build_dependencies(obj, source) {
+        props.push(format!("dependencies: {deps_text}"));
+    }
+
+    // Host bindings
+    if let Some(host_obj) = metadata::get_object_prop(obj, "host") {
+        let (host_attrs, host_bindings, host_vars) =
+            crate::directive::build_host_bindings(host_obj, source, ng_import);
+        if let Some(attrs) = host_attrs {
+            props.push(format!("hostAttrs: {attrs}"));
+        }
+        if host_vars > 0 {
+            props.push(format!("hostVars: {host_vars}"));
+        }
+        if let Some(bindings) = host_bindings {
+            props.push(format!("hostBindings: {bindings}"));
+        }
+    }
+
+    // Styles
+    if let Some(styles) = metadata::get_source_text(obj, "styles", source) {
+        props.push(format!("styles: {styles}"));
+    }
+
+    // Encapsulation
+    if let Some(encapsulation) = metadata::get_source_text(obj, "encapsulation", source) {
+        props.push(format!("encapsulation: {encapsulation}"));
+    }
+
+    // Change detection
+    if let Some(cd) = metadata::get_source_text(obj, "changeDetection", source) {
+        props.push(format!("changeDetection: {cd}"));
+    }
+
+    Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+}
+
+/// Compile a template string into a template function using the template compiler.
+///
+/// Returns `(template_function_code, decls, vars, child_template_functions)`.
+fn compile_template(
+    template: &str,
+    component_name: &str,
+    file_path: &Path,
+) -> NgcResult<(String, u32, u32, Vec<String>)> {
+    use ngc_template_compiler::{generate_template_fn, TemplateMetadata};
+
+    let meta = TemplateMetadata {
+        class_name: component_name.to_string(),
+        selector: String::new(),
+        standalone: false,
+        imports_source: None,
+        styles_source: None,
+    };
+
+    let result = generate_template_fn(template, &meta, file_path)?;
+
+    Ok((
+        result.template_function,
+        result.decls,
+        result.vars,
+        result.child_template_functions,
+    ))
+}
+
+/// Build the `dependencies` array from the declare format.
+///
+/// The declare format has objects like `{ kind: "directive", type: MyDir, selector: "..." }`.
+/// The runtime format just needs the type references: `[MyDir, MyPipe, ...]`.
+fn build_dependencies(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    // Find the dependencies array
+    let deps_arr = obj.properties.iter().find_map(|p| {
+        if let ObjectPropertyKind::ObjectProperty(prop) = p {
+            if matches!(&prop.key, PropertyKey::StaticIdentifier(id) if id.name.as_str() == "dependencies")
+            {
+                if let Expression::ArrayExpression(arr) = &prop.value {
+                    return Some(arr.as_ref());
+                }
+            }
+        }
+        None
+    })?;
+
+    let mut types = Vec::new();
+    for element in &deps_arr.elements {
+        match element {
+            ArrayExpressionElement::ObjectExpression(dep_obj) => {
+                // Extract the type reference from each dependency descriptor
+                if let Some(type_ref) = metadata::get_source_text(dep_obj, "type", source) {
+                    types.push(type_ref.to_string());
+                }
+            }
+            _ => {
+                // Direct reference (not a descriptor object)
+                let span = element.span();
+                types.push(source[span.start as usize..span.end as usize].to_string());
+            }
+        }
+    }
+
+    if types.is_empty() {
+        None
+    } else {
+        Some(format!("[{}]", types.join(", ")))
+    }
+}
+
+/// Build inputs from the declare format (shared with directive).
+fn build_inputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    let inputs_obj = metadata::get_object_prop(obj, "inputs")?;
+
+    let mut entries = Vec::new();
+    for prop in &inputs_obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            let key = prop_key_text(&p.key, source);
+
+            match &p.value {
+                Expression::StringLiteral(s) => {
+                    let alias = s.value.as_str();
+                    if alias == key {
+                        entries.push(format!("{key}: '{key}'"));
+                    } else {
+                        entries.push(format!("{key}: [0, '{alias}', '{key}']"));
+                    }
+                }
+                Expression::ObjectExpression(input_obj) => {
+                    let alias = metadata::get_string_prop(input_obj, "alias")
+                        .unwrap_or_else(|| key.clone());
+                    let required = metadata::get_bool_prop(input_obj, "required") == Some(true);
+                    let flags = if required { 1 } else { 0 };
+                    if required || alias != key {
+                        entries.push(format!("{key}: [{flags}, '{alias}', '{key}']"));
+                    } else {
+                        entries.push(format!("{key}: '{key}'"));
+                    }
+                }
+                _ => {
+                    let val = &source[p.value.span().start as usize..p.value.span().end as usize];
+                    entries.push(format!("{key}: {val}"));
+                }
+            }
+        }
+    }
+
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("{{ {} }}", entries.join(", ")))
+    }
+}
+
+/// Build outputs from the declare format.
+fn build_outputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    let outputs_obj = metadata::get_object_prop(obj, "outputs")?;
+
+    let mut entries = Vec::new();
+    for prop in &outputs_obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            let key = prop_key_text(&p.key, source);
+            if let Expression::StringLiteral(s) = &p.value {
+                entries.push(format!("{key}: '{}'", s.value));
+            } else {
+                let val = &source[p.value.span().start as usize..p.value.span().end as usize];
+                entries.push(format!("{key}: {val}"));
+            }
+        }
+    }
+
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("{{ {} }}", entries.join(", ")))
+    }
+}
+
+/// Extract the text of a property key.
+fn prop_key_text(key: &PropertyKey<'_>, source: &str) -> String {
+    match key {
+        PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+        PropertyKey::StringLiteral(s) => s.value.to_string(),
+        _ => {
+            let span = key.span();
+            source[span.start as usize..span.end as usize].to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+    use std::path::PathBuf;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0", &PathBuf::from("test.mjs")).unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_component_basic() {
+        let result = parse_and_transform(
+            "{ type: MyComp, selector: 'my-comp', isStandalone: true, template: '<div>hello</div>' }",
+        );
+        assert!(result.contains("i0.\u{0275}\u{0275}defineComponent"));
+        assert!(result.contains("type: MyComp"));
+        assert!(result.contains("selectors: [['my-comp']]"));
+        assert!(result.contains("standalone: true"));
+        assert!(result.contains("template:"));
+    }
+
+    #[test]
+    fn test_component_no_template() {
+        let result = parse_and_transform("{ type: MyComp, selector: 'my-comp' }");
+        assert!(result.contains("decls: 0"));
+        assert!(result.contains("vars: 0"));
+    }
+}

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -81,14 +81,23 @@ pub fn transform(
 
     // Template compilation
     if let Some(template_str) = metadata::get_string_prop(obj, "template") {
-        match compile_template(&template_str, &type_name, file_path) {
-            Ok((template_fn, decls, vars, child_fns)) => {
-                props.push(format!("decls: {decls}"));
-                props.push(format!("vars: {vars}"));
-                props.push(format!("template: {template_fn}"));
-                // Child template functions are prepended before the defineComponent call
-                // For now, we embed them in the template function directly
-                let _ = child_fns; // handled within template_fn already
+        let template_ok = match compile_template(&template_str, &type_name, file_path) {
+            Ok((template_fn, decls, vars, _child_fns)) => {
+                // Validate that the compiled template is valid JavaScript
+                // (the template parser may "succeed" on unsupported syntax like @let
+                // but produce output with literal newlines inside string literals)
+                if is_valid_js_function(&template_fn) {
+                    props.push(format!("decls: {decls}"));
+                    props.push(format!("vars: {vars}"));
+                    props.push(format!("template: {template_fn}"));
+                    true
+                } else {
+                    tracing::warn!(
+                        path = %file_path.display(),
+                        "compiled template produced invalid JS, using empty template"
+                    );
+                    false
+                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -96,13 +105,15 @@ pub fn transform(
                     error = %e,
                     "template compilation failed for npm component, using empty template"
                 );
-                // Fallback: empty template
-                props.push("decls: 0".to_string());
-                props.push("vars: 0".to_string());
-                props.push(format!(
-                    "template: function {type_name}_Template(rf, ctx) {{}}"
-                ));
+                false
             }
+        };
+        if !template_ok {
+            props.push("decls: 0".to_string());
+            props.push("vars: 0".to_string());
+            props.push(format!(
+                "template: function {type_name}_Template(rf, ctx) {{}}"
+            ));
         }
     } else {
         // No template — empty
@@ -149,6 +160,18 @@ pub fn transform(
     }
 
     Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+}
+
+/// Validate that a generated template function is valid JavaScript.
+///
+/// The template parser may produce output with unsupported Angular syntax
+/// (like `@let`) treated as raw text, resulting in multi-line string literals
+/// which are invalid JS.
+fn is_valid_js_function(code: &str) -> bool {
+    let wrapped = format!("var x = {code};");
+    let alloc = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&alloc, &wrapped, oxc_span::SourceType::mjs()).parse();
+    parsed.errors.is_empty()
 }
 
 /// Compile a template string into a template function using the template compiler.

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -57,21 +57,14 @@ pub fn transform(
         props.push("standalone: true".to_string());
     }
 
-    // Features
+    // Features — only emit features that exist in the Angular runtime.
+    // ɵɵStandaloneFeature was removed in Angular 19+; standalone is handled via property.
     let mut features = Vec::new();
     if metadata::get_bool_prop(obj, "usesInheritance") == Some(true) {
         let feat = if ng_import.is_empty() {
             "\u{0275}\u{0275}InheritDefinitionFeature".to_string()
         } else {
             format!("{ng_import}.\u{0275}\u{0275}InheritDefinitionFeature")
-        };
-        features.push(feat);
-    }
-    if is_standalone {
-        let feat = if ng_import.is_empty() {
-            "\u{0275}\u{0275}StandaloneFeature".to_string()
-        } else {
-            format!("{ng_import}.\u{0275}\u{0275}StandaloneFeature")
         };
         features.push(feat);
     }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -543,10 +543,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0", &PathBuf::from("test.mjs")).unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0", &PathBuf::from("test.mjs")).unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -268,7 +268,8 @@ pub fn build_host_bindings(
                     } else {
                         format!("{ng_import}.\u{0275}\u{0275}hostProperty")
                     };
-                    binding_stmts.push(format!("{prop_fn}(\"{key}\", ctx.{})", s.value));
+                    let expr = compile_host_expression(&s.value);
+                    binding_stmts.push(format!("{prop_fn}(\"{key}\", {expr})"));
                     host_vars += 1;
                 }
             }
@@ -286,9 +287,9 @@ pub fn build_host_bindings(
                     } else {
                         format!("{ng_import}.\u{0275}\u{0275}listener")
                     };
+                    let expr = compile_host_expression(&s.value);
                     listener_stmts.push(format!(
-                        "{listener_fn}(\"{key}\", function($event) {{ return ctx.{}; }})",
-                        s.value
+                        "{listener_fn}(\"{key}\", function($event) {{ return {expr}; }})"
                     ));
                 }
             }
@@ -339,6 +340,202 @@ fn prop_key_text(key: &PropertyKey<'_>, source: &str) -> String {
     }
 }
 
+/// Compile a host binding expression by prefixing component property references with `ctx.`
+/// and stripping TypeScript-specific syntax (like `!` non-null assertion).
+///
+/// Parses the expression as TypeScript, walks the AST to find standalone identifiers
+/// (not member expression properties or built-in values), and prefixes them with `ctx.`.
+///
+/// Examples:
+/// - `"checked"` → `ctx.checked`
+/// - `"!!checked"` → `!!ctx.checked`
+/// - `"disabled || null"` → `ctx.disabled || null`
+/// - `"_getMinDate() ? _dateAdapter.toIso8601(_getMinDate()!) : null"`
+///   → `ctx._getMinDate() ? ctx._dateAdapter.toIso8601(ctx._getMinDate()) : null`
+fn compile_host_expression(expr: &str) -> String {
+    let wrapper = format!("var __expr = {expr};");
+    let alloc = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&alloc, &wrapper, oxc_span::SourceType::tsx()).parse();
+
+    if !parsed.errors.is_empty() {
+        // If parsing fails, return the expression as-is (better than crashing)
+        tracing::warn!("failed to parse host expression: {expr}");
+        return expr.to_string();
+    }
+
+    // Extract the expression from `var __expr = <expr>;`
+    let init_expr = match &parsed.program.body.first() {
+        Some(oxc_ast::ast::Statement::VariableDeclaration(decl)) => {
+            decl.declarations.first().and_then(|d| d.init.as_ref())
+        }
+        _ => None,
+    };
+
+    let init_expr = match init_expr {
+        Some(e) => e,
+        None => return expr.to_string(),
+    };
+
+    // Collect byte offsets of identifiers that need `ctx.` prefix
+    // and byte ranges of `!` non-null assertions to remove
+    let mut ctx_inserts: Vec<u32> = Vec::new();
+    let mut remove_ranges: Vec<(u32, u32)> = Vec::new();
+
+    collect_ctx_rewrites(init_expr, &mut ctx_inserts, &mut remove_ranges, false);
+
+    // Apply modifications to the original expression string
+    // First, map wrapper offsets back to expression offsets
+    let expr_offset = "var __expr = ".len() as u32;
+
+    let mut result = expr.to_string();
+
+    // Sort insertions in reverse order to preserve offsets
+    ctx_inserts.sort_unstable();
+    ctx_inserts.dedup();
+
+    // Apply removals first (sorted reverse)
+    let mut sorted_removes: Vec<(u32, u32)> = remove_ranges
+        .iter()
+        .map(|(s, e)| (s - expr_offset, e - expr_offset))
+        .collect();
+    sorted_removes.sort_by(|a, b| b.0.cmp(&a.0));
+    for (s, e) in &sorted_removes {
+        let s = *s as usize;
+        let e = *e as usize;
+        if s <= result.len() && e <= result.len() {
+            result.replace_range(s..e, "");
+        }
+    }
+
+    // Apply ctx. insertions (sorted reverse)
+    let mut sorted_inserts: Vec<u32> = ctx_inserts.iter().map(|off| off - expr_offset).collect();
+    sorted_inserts.sort_unstable();
+    sorted_inserts.reverse();
+    for off in &sorted_inserts {
+        let off = *off as usize;
+        if off <= result.len() {
+            result.insert_str(off, "ctx.");
+        }
+    }
+
+    result
+}
+
+/// Recursively collect identifier positions that need `ctx.` prefix and
+/// TypeScript non-null assertion `!` positions to remove.
+fn collect_ctx_rewrites(
+    expr: &Expression<'_>,
+    ctx_inserts: &mut Vec<u32>,
+    remove_ranges: &mut Vec<(u32, u32)>,
+    is_member_property: bool,
+) {
+    use oxc_ast::ast::*;
+    use oxc_span::GetSpan;
+
+    /// Set of identifiers that should NOT get `ctx.` prefix.
+    fn is_builtin(name: &str) -> bool {
+        matches!(
+            name,
+            "null"
+                | "undefined"
+                | "true"
+                | "false"
+                | "NaN"
+                | "Infinity"
+                | "this"
+                | "Math"
+                | "Date"
+                | "JSON"
+                | "console"
+                | "window"
+                | "document"
+                | "Array"
+                | "Object"
+                | "String"
+                | "Number"
+                | "Boolean"
+                | "Error"
+                | "RegExp"
+                | "Symbol"
+                | "Promise"
+                | "Map"
+                | "Set"
+                | "$event"
+        )
+    }
+
+    match expr {
+        Expression::Identifier(id) => {
+            if !is_member_property && !is_builtin(&id.name) {
+                ctx_inserts.push(id.span.start);
+            }
+        }
+        Expression::CallExpression(call) => {
+            collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false);
+            for arg in &call.arguments {
+                if let Argument::SpreadElement(spread) = arg {
+                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
+                } else {
+                    collect_ctx_rewrites(arg.to_expression(), ctx_inserts, remove_ranges, false);
+                }
+            }
+        }
+        Expression::StaticMemberExpression(member) => {
+            // Object gets ctx. prefix, property does not
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+            // property is just an IdentifierName, no rewrite needed
+        }
+        Expression::ComputedMemberExpression(member) => {
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&member.expression, ctx_inserts, remove_ranges, false);
+        }
+        Expression::UnaryExpression(unary) => {
+            collect_ctx_rewrites(&unary.argument, ctx_inserts, remove_ranges, false);
+        }
+        Expression::BinaryExpression(binary) => {
+            collect_ctx_rewrites(&binary.left, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&binary.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::LogicalExpression(logical) => {
+            collect_ctx_rewrites(&logical.left, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&logical.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ConditionalExpression(cond) => {
+            collect_ctx_rewrites(&cond.test, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.consequent, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.alternate, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            collect_ctx_rewrites(&paren.expression, ctx_inserts, remove_ranges, false);
+        }
+        Expression::TSNonNullExpression(non_null) => {
+            // Process the inner expression, then mark the `!` for removal
+            collect_ctx_rewrites(
+                &non_null.expression,
+                ctx_inserts,
+                remove_ranges,
+                is_member_property,
+            );
+            // The `!` is at the end of the expression span, just before the closing
+            let inner_end = non_null.expression.span().end;
+            let outer_end = non_null.span.end;
+            if outer_end > inner_end {
+                remove_ranges.push((inner_end, outer_end));
+            }
+        }
+        Expression::TemplateLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_) => {
+            // Literals don't need rewriting
+        }
+        _ => {
+            // For other expression types, leave as-is
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,5 +577,57 @@ mod tests {
         );
         assert!(result.contains("inputs:"));
         assert!(result.contains("outputs:"));
+    }
+
+    #[test]
+    fn test_compile_host_expression_simple() {
+        assert_eq!(compile_host_expression("checked"), "ctx.checked");
+    }
+
+    #[test]
+    fn test_compile_host_expression_negation() {
+        assert_eq!(compile_host_expression("!!checked"), "!!ctx.checked");
+    }
+
+    #[test]
+    fn test_compile_host_expression_logical() {
+        assert_eq!(
+            compile_host_expression("disabled || null"),
+            "ctx.disabled || null"
+        );
+    }
+
+    #[test]
+    fn test_compile_host_expression_method_call() {
+        assert_eq!(
+            compile_host_expression("toastClasses()"),
+            "ctx.toastClasses()"
+        );
+    }
+
+    #[test]
+    fn test_compile_host_expression_member_chain() {
+        assert_eq!(
+            compile_host_expression("_rangeInput.rangePicker ? \"dialog\" : null"),
+            "ctx._rangeInput.rangePicker ? \"dialog\" : null"
+        );
+    }
+
+    #[test]
+    fn test_compile_host_expression_ts_non_null() {
+        assert_eq!(
+            compile_host_expression("_getMinDate()!"),
+            "ctx._getMinDate()"
+        );
+    }
+
+    #[test]
+    fn test_compile_host_expression_complex_ternary() {
+        let result = compile_host_expression(
+            "_getMinDate() ? _dateAdapter.toIso8601(_getMinDate()!) : null",
+        );
+        assert!(result.contains("ctx._getMinDate()"));
+        assert!(result.contains("ctx._dateAdapter.toIso8601"));
+        assert!(!result.contains("!)")); // non-null stripped
     }
 }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -1,0 +1,384 @@
+//! Transform `ɵɵngDeclareDirective` → `ɵɵdefineDirective`.
+//!
+//! Handles selector parsing, input/output mapping, host binding generation,
+//! and feature flags.
+
+use std::path::Path;
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_span::GetSpan;
+
+use crate::metadata;
+use crate::selector;
+
+/// Transform a `ɵɵngDeclareDirective` call into a `ɵɵdefineDirective` call.
+pub fn transform(
+    obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+    _file_path: &Path,
+) -> NgcResult<String> {
+    let define_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}defineDirective".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}defineDirective")
+    };
+
+    build_define_call(&define_fn, obj, source, ng_import)
+}
+
+/// Build the `ɵɵdefineDirective` (or `ɵɵdefineComponent`) call body.
+///
+/// This is shared between directive and component transformations.
+pub fn build_define_call(
+    define_fn: &str,
+    obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+) -> NgcResult<String> {
+    let type_text = metadata::get_source_text(obj, "type", source).unwrap_or("Unknown");
+
+    let mut props = Vec::new();
+    props.push(format!("type: {type_text}"));
+
+    // Parse selector into Angular array format
+    if let Some(sel) = metadata::get_string_prop(obj, "selector") {
+        props.push(format!("selectors: {}", selector::parse_selector(&sel)));
+    }
+
+    // Inputs
+    if let Some(inputs) = build_inputs(obj, source) {
+        props.push(format!("inputs: {inputs}"));
+    }
+
+    // Outputs
+    if let Some(outputs) = build_outputs(obj, source) {
+        props.push(format!("outputs: {outputs}"));
+    }
+
+    // Host bindings
+    if let Some(host_obj) = metadata::get_object_prop(obj, "host") {
+        let (host_attrs, host_bindings, host_vars) =
+            build_host_bindings(host_obj, source, ng_import);
+        if let Some(attrs) = host_attrs {
+            props.push(format!("hostAttrs: {attrs}"));
+        }
+        if host_vars > 0 {
+            props.push(format!("hostVars: {host_vars}"));
+        }
+        if let Some(bindings) = host_bindings {
+            props.push(format!("hostBindings: {bindings}"));
+        }
+    }
+
+    // Export as
+    if let Some(export_as) = metadata::get_string_prop(obj, "exportAs") {
+        let parts: Vec<&str> = export_as.split(',').map(|s| s.trim()).collect();
+        let arr = parts
+            .iter()
+            .map(|s| format!("\"{s}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        props.push(format!("exportAs: [{arr}]"));
+    }
+
+    // Standalone
+    if metadata::get_bool_prop(obj, "isStandalone") == Some(true)
+        || metadata::get_bool_prop(obj, "standalone") == Some(true)
+    {
+        props.push("standalone: true".to_string());
+    }
+
+    // Features
+    let mut features = Vec::new();
+    if metadata::get_bool_prop(obj, "usesInheritance") == Some(true) {
+        let feat = if ng_import.is_empty() {
+            "\u{0275}\u{0275}InheritDefinitionFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}InheritDefinitionFeature")
+        };
+        features.push(feat);
+    }
+    if metadata::get_bool_prop(obj, "usesOnChanges") == Some(true) {
+        let feat = if ng_import.is_empty() {
+            "\u{0275}\u{0275}NgOnChangesFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}NgOnChangesFeature")
+        };
+        features.push(feat);
+    }
+    if metadata::get_bool_prop(obj, "isStandalone") == Some(true)
+        || metadata::get_bool_prop(obj, "standalone") == Some(true)
+    {
+        let feat = if ng_import.is_empty() {
+            "\u{0275}\u{0275}StandaloneFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}StandaloneFeature")
+        };
+        features.push(feat);
+    }
+    if !features.is_empty() {
+        props.push(format!("features: [{}]", features.join(", ")));
+    }
+
+    // Providers
+    if let Some(providers) = metadata::get_source_text(obj, "providers", source) {
+        props.push(format!("providers: {providers}"));
+    }
+
+    // Queries
+    if let Some(queries) = metadata::get_source_text(obj, "queries", source) {
+        props.push(format!("contentQueries: {queries}"));
+    }
+    if let Some(view_queries) = metadata::get_source_text(obj, "viewQueries", source) {
+        props.push(format!("viewQuery: {view_queries}"));
+    }
+
+    Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+}
+
+/// Build the `inputs` property from the declare format to runtime format.
+///
+/// Declare format: `{ propName: { alias: 'aliasName', required: true } }` or `{ propName: 'aliasName' }`
+/// Runtime format: `{ propName: [flags, 'publicName', 'propName'] }` or `{ propName: 'propName' }`
+fn build_inputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    let inputs_obj = metadata::get_object_prop(obj, "inputs")?;
+
+    let mut entries = Vec::new();
+    for prop in &inputs_obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            let key = prop_key_text(&p.key, source);
+
+            match &p.value {
+                Expression::StringLiteral(s) => {
+                    // Simple alias: { propName: 'aliasName' }
+                    let alias = s.value.as_str();
+                    if alias == key {
+                        entries.push(format!("{key}: '{key}'"));
+                    } else {
+                        entries.push(format!("{key}: [0, '{alias}', '{key}']"));
+                    }
+                }
+                Expression::ObjectExpression(input_obj) => {
+                    // Complex input: { alias: '...', required: true, transform: ... }
+                    let alias = metadata::get_string_prop(input_obj, "alias")
+                        .unwrap_or_else(|| key.clone());
+                    let required = metadata::get_bool_prop(input_obj, "required") == Some(true);
+                    let has_transform =
+                        metadata::get_source_text(input_obj, "isSignal", source).is_some();
+
+                    let flags = if required { 1 } else { 0 };
+
+                    if has_transform || required || alias != key {
+                        entries.push(format!("{key}: [{flags}, '{alias}', '{key}']"));
+                    } else {
+                        entries.push(format!("{key}: '{key}'"));
+                    }
+                }
+                _ => {
+                    // Pass through as source text
+                    let val = &source[p.value.span().start as usize..p.value.span().end as usize];
+                    entries.push(format!("{key}: {val}"));
+                }
+            }
+        }
+    }
+
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("{{ {} }}", entries.join(", ")))
+    }
+}
+
+/// Build the `outputs` property from declare format to runtime format.
+fn build_outputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    let outputs_obj = metadata::get_object_prop(obj, "outputs")?;
+
+    let mut entries = Vec::new();
+    for prop in &outputs_obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            let key = prop_key_text(&p.key, source);
+            if let Expression::StringLiteral(s) = &p.value {
+                entries.push(format!("{key}: '{}'", s.value));
+            } else {
+                let val = &source[p.value.span().start as usize..p.value.span().end as usize];
+                entries.push(format!("{key}: {val}"));
+            }
+        }
+    }
+
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("{{ {} }}", entries.join(", ")))
+    }
+}
+
+/// Build host attributes and host bindings function from the `host` object.
+///
+/// Returns `(hostAttrs, hostBindings, hostVars)`.
+pub fn build_host_bindings(
+    host_obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+) -> (Option<String>, Option<String>, u32) {
+    let mut attrs = Vec::new();
+    let mut binding_stmts = Vec::new();
+    let mut listener_stmts = Vec::new();
+    let mut host_vars = 0u32;
+
+    // Static attributes
+    if let Some(attributes_obj) = metadata::get_object_prop(host_obj, "attributes") {
+        for prop in &attributes_obj.properties {
+            if let ObjectPropertyKind::ObjectProperty(p) = prop {
+                let key = prop_key_text(&p.key, source);
+                if let Expression::StringLiteral(s) = &p.value {
+                    attrs.push(format!("'{key}', '{}'", s.value));
+                }
+            }
+        }
+    }
+
+    // Class attribute
+    if let Some(class_attr) = metadata::get_string_prop(host_obj, "classAttribute") {
+        // 1 = AttributeMarker.Classes
+        attrs.push("1".to_string());
+        for class in class_attr.split_whitespace() {
+            attrs.push(format!("'{class}'"));
+        }
+    }
+
+    // Style attribute
+    if let Some(style_attr) = metadata::get_string_prop(host_obj, "styleAttribute") {
+        // 2 = AttributeMarker.Styles
+        attrs.push("2".to_string());
+        attrs.push(format!("'{style_attr}'"));
+    }
+
+    // Property bindings
+    if let Some(properties_obj) = metadata::get_object_prop(host_obj, "properties") {
+        for prop in &properties_obj.properties {
+            if let ObjectPropertyKind::ObjectProperty(p) = prop {
+                let key = prop_key_text(&p.key, source);
+                if let Expression::StringLiteral(s) = &p.value {
+                    let prop_fn = if ng_import.is_empty() {
+                        "\u{0275}\u{0275}hostProperty".to_string()
+                    } else {
+                        format!("{ng_import}.\u{0275}\u{0275}hostProperty")
+                    };
+                    binding_stmts.push(format!("{prop_fn}(\"{key}\", ctx.{})", s.value));
+                    host_vars += 1;
+                }
+            }
+        }
+    }
+
+    // Listeners
+    if let Some(listeners_obj) = metadata::get_object_prop(host_obj, "listeners") {
+        for prop in &listeners_obj.properties {
+            if let ObjectPropertyKind::ObjectProperty(p) = prop {
+                let key = prop_key_text(&p.key, source);
+                if let Expression::StringLiteral(s) = &p.value {
+                    let listener_fn = if ng_import.is_empty() {
+                        "\u{0275}\u{0275}listener".to_string()
+                    } else {
+                        format!("{ng_import}.\u{0275}\u{0275}listener")
+                    };
+                    listener_stmts.push(format!(
+                        "{listener_fn}(\"{key}\", function($event) {{ return ctx.{}; }})",
+                        s.value
+                    ));
+                }
+            }
+        }
+    }
+
+    let host_attrs = if attrs.is_empty() {
+        None
+    } else {
+        Some(format!("[{}]", attrs.join(", ")))
+    };
+
+    let host_bindings = if binding_stmts.is_empty() && listener_stmts.is_empty() {
+        None
+    } else {
+        let mut body = String::new();
+        if !listener_stmts.is_empty() {
+            body.push_str("if (rf & 1) { ");
+            for stmt in &listener_stmts {
+                body.push_str(stmt);
+                body.push_str("; ");
+            }
+            body.push_str("} ");
+        }
+        if !binding_stmts.is_empty() {
+            body.push_str("if (rf & 2) { ");
+            for stmt in &binding_stmts {
+                body.push_str(stmt);
+                body.push_str("; ");
+            }
+            body.push('}');
+        }
+        Some(format!("function(rf, ctx) {{ {body} }}"))
+    };
+
+    (host_attrs, host_bindings, host_vars)
+}
+
+/// Extract the text of a property key.
+fn prop_key_text(key: &PropertyKey<'_>, source: &str) -> String {
+    match key {
+        PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+        PropertyKey::StringLiteral(s) => s.value.to_string(),
+        _ => {
+            let span = key.span();
+            source[span.start as usize..span.end as usize].to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+    use std::path::PathBuf;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0", &PathBuf::from("test.mjs")).unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_directive_basic() {
+        let result =
+            parse_and_transform("{ type: MyDir, selector: '[myDir]', isStandalone: true }");
+        assert!(result.contains("i0.\u{0275}\u{0275}defineDirective"));
+        assert!(result.contains("type: MyDir"));
+        assert!(result.contains("selectors: [['', 'myDir', '']]"));
+        assert!(result.contains("standalone: true"));
+    }
+
+    #[test]
+    fn test_directive_with_inputs_outputs() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: 'value' }, outputs: { changed: 'changed' } }",
+        );
+        assert!(result.contains("inputs:"));
+        assert!(result.contains("outputs:"));
+    }
+}

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -90,7 +90,9 @@ pub fn build_define_call(
         props.push("standalone: true".to_string());
     }
 
-    // Features
+    // Features — only emit features that exist in the Angular runtime.
+    // Note: ɵɵStandaloneFeature was removed in Angular 19+; standalone is now
+    // handled via the `standalone: true` property on the definition (emitted above).
     let mut features = Vec::new();
     if metadata::get_bool_prop(obj, "usesInheritance") == Some(true) {
         let feat = if ng_import.is_empty() {
@@ -105,16 +107,6 @@ pub fn build_define_call(
             "\u{0275}\u{0275}NgOnChangesFeature".to_string()
         } else {
             format!("{ng_import}.\u{0275}\u{0275}NgOnChangesFeature")
-        };
-        features.push(feat);
-    }
-    if metadata::get_bool_prop(obj, "isStandalone") == Some(true)
-        || metadata::get_bool_prop(obj, "standalone") == Some(true)
-    {
-        let feat = if ng_import.is_empty() {
-            "\u{0275}\u{0275}StandaloneFeature".to_string()
-        } else {
-            format!("{ng_import}.\u{0275}\u{0275}StandaloneFeature")
         };
         features.push(feat);
     }

--- a/crates/linker/src/factory.rs
+++ b/crates/linker/src/factory.rs
@@ -1,0 +1,159 @@
+//! Transform `ɵɵngDeclareFactory` → factory function.
+//!
+//! Converts a partial factory declaration into a fully compiled factory function
+//! that Angular can use at runtime.
+//!
+//! ## Example
+//! ```js
+//! // Input:
+//! i0.ɵɵngDeclareFactory({ type: MyService, deps: [{ token: Dep }], target: ... })
+//! // Output:
+//! function MyService_Factory(ɵt) { return new (ɵt || MyService)(i0.ɵɵinject(Dep)); }
+//! ```
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::{
+    ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+};
+
+use crate::metadata;
+
+/// Transform a `ɵɵngDeclareFactory` call into a factory function.
+pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+    let type_name = metadata::get_identifier_prop(obj, "type")
+        .or_else(|| metadata::get_source_text(obj, "type", source).map(|s| s.to_string()))
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let deps = build_deps_args(obj, source, ng_import);
+
+    Ok(format!(
+        "function {type_name}_Factory(\u{0275}t) {{ return new (\u{0275}t || {type_name})({deps}); }}"
+    ))
+}
+
+/// Build the constructor arguments from the `deps` array.
+fn build_deps_args(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> String {
+    // Find the deps array property
+    let deps_array = obj.properties.iter().find_map(|p| {
+        if let ObjectPropertyKind::ObjectProperty(prop) = p {
+            if matches!(&prop.key, PropertyKey::StaticIdentifier(id) if id.name.as_str() == "deps")
+            {
+                if let Expression::ArrayExpression(arr) = &prop.value {
+                    return Some(arr.as_ref());
+                }
+            }
+        }
+        None
+    });
+
+    let arr = match deps_array {
+        Some(a) => a,
+        None => return String::new(),
+    };
+
+    let inject_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}inject".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}inject")
+    };
+
+    let mut args = Vec::new();
+    for element in &arr.elements {
+        if let ArrayExpressionElement::ObjectExpression(dep_obj) = element {
+            if let Some(arg) = transform_dep(dep_obj, source, ng_import, &inject_fn) {
+                args.push(arg);
+            }
+        }
+    }
+
+    args.join(", ")
+}
+
+/// Transform a single dependency descriptor object into an inject call.
+fn transform_dep(
+    dep_obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+    inject_fn: &str,
+) -> Option<String> {
+    // Check for attribute injection first
+    if let Some(attr_name) = metadata::get_string_prop(dep_obj, "attribute") {
+        let inject_attr = if ng_import.is_empty() {
+            format!("\u{0275}\u{0275}injectAttribute('{attr_name}')")
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}injectAttribute('{attr_name}')")
+        };
+        return Some(inject_attr);
+    }
+
+    let token = metadata::get_source_text(dep_obj, "token", source)?;
+
+    // Compute flags from optional/self/skipSelf/host
+    let mut flags = 0u32;
+    if metadata::get_bool_prop(dep_obj, "optional") == Some(true) {
+        flags |= 8;
+    }
+    if metadata::get_bool_prop(dep_obj, "self") == Some(true) {
+        flags |= 2;
+    }
+    if metadata::get_bool_prop(dep_obj, "skipSelf") == Some(true) {
+        flags |= 4;
+    }
+    if metadata::get_bool_prop(dep_obj, "host") == Some(true) {
+        flags |= 1;
+    }
+
+    if flags != 0 {
+        Some(format!("{inject_fn}({token}, {flags})"))
+    } else {
+        Some(format!("{inject_fn}({token})"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0").unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_factory_no_deps() {
+        let result = parse_and_transform("{ type: MyService, deps: [], target: 2 }");
+        assert_eq!(
+            result,
+            "function MyService_Factory(\u{0275}t) { return new (\u{0275}t || MyService)(); }"
+        );
+    }
+
+    #[test]
+    fn test_factory_with_deps() {
+        let result =
+            parse_and_transform("{ type: MyService, deps: [{ token: i0.DOCUMENT }], target: 2 }");
+        assert!(result.contains("i0.\u{0275}\u{0275}inject(i0.DOCUMENT)"));
+    }
+
+    #[test]
+    fn test_factory_with_optional_dep() {
+        let result = parse_and_transform(
+            "{ type: MyService, deps: [{ token: SomeDep, optional: true }], target: 2 }",
+        );
+        assert!(result.contains("i0.\u{0275}\u{0275}inject(SomeDep, 8)"));
+    }
+}

--- a/crates/linker/src/factory.rs
+++ b/crates/linker/src/factory.rs
@@ -124,10 +124,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0").unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0").unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/injectable.rs
+++ b/crates/linker/src/injectable.rs
@@ -1,0 +1,102 @@
+//! Transform `ɵɵngDeclareInjectable` → `ɵɵdefineInjectable`.
+//!
+//! ## Example
+//! ```js
+//! // Input:
+//! i0.ɵɵngDeclareInjectable({ type: MyService, providedIn: 'root' })
+//! // Output:
+//! i0.ɵɵdefineInjectable({ token: MyService, factory: MyService.ɵfac, providedIn: 'root' })
+//! ```
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::ObjectExpression;
+
+use crate::metadata;
+
+/// Transform a `ɵɵngDeclareInjectable` call into a `ɵɵdefineInjectable` call.
+pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+    let type_text = metadata::get_source_text(obj, "type", source).unwrap_or("Unknown");
+
+    let define_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}defineInjectable".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}defineInjectable")
+    };
+
+    // Determine the factory expression
+    let factory = if let Some(use_factory) = metadata::get_source_text(obj, "useFactory", source) {
+        use_factory.to_string()
+    } else if let Some(use_class) = metadata::get_source_text(obj, "useClass", source) {
+        format!("() => new {use_class}()")
+    } else if let Some(use_value) = metadata::get_source_text(obj, "useValue", source) {
+        format!("() => {use_value}")
+    } else if let Some(use_existing) = metadata::get_source_text(obj, "useExisting", source) {
+        let inject_fn = if ng_import.is_empty() {
+            "\u{0275}\u{0275}inject".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}inject")
+        };
+        format!("function() {{ return {inject_fn}({use_existing}); }}")
+    } else {
+        format!("{type_text}.\u{0275}fac")
+    };
+
+    // Build the output object
+    let mut props = Vec::new();
+    props.push(format!("token: {type_text}"));
+    props.push(format!("factory: {factory}"));
+
+    if let Some(provided_in) = metadata::get_source_text(obj, "providedIn", source) {
+        props.push(format!("providedIn: {provided_in}"));
+    }
+
+    Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::Expression;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0").unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_basic_injectable() {
+        let result = parse_and_transform("{ type: MyService, providedIn: 'root' }");
+        assert!(result.contains("i0.\u{0275}\u{0275}defineInjectable"));
+        assert!(result.contains("token: MyService"));
+        assert!(result.contains("factory: MyService.\u{0275}fac"));
+        assert!(result.contains("providedIn: 'root'"));
+    }
+
+    #[test]
+    fn test_injectable_with_use_factory() {
+        let result = parse_and_transform(
+            "{ type: MyService, providedIn: 'root', useFactory: createService }",
+        );
+        assert!(result.contains("factory: createService"));
+    }
+
+    #[test]
+    fn test_injectable_with_use_existing() {
+        let result = parse_and_transform("{ type: MyService, useExisting: OtherService }");
+        assert!(result.contains("i0.\u{0275}\u{0275}inject(OtherService)"));
+    }
+}

--- a/crates/linker/src/injectable.rs
+++ b/crates/linker/src/injectable.rs
@@ -68,10 +68,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0").unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0").unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/injector.rs
+++ b/crates/linker/src/injector.rs
@@ -53,10 +53,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0").unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0").unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/injector.rs
+++ b/crates/linker/src/injector.rs
@@ -1,0 +1,79 @@
+//! Transform `ɵɵngDeclareInjector` → `ɵɵdefineInjector`.
+//!
+//! ## Example
+//! ```js
+//! // Input:
+//! i0.ɵɵngDeclareInjector({ type: AppModule, providers: [...], imports: [...] })
+//! // Output:
+//! i0.ɵɵdefineInjector({ providers: [...], imports: [...] })
+//! ```
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::ObjectExpression;
+
+use crate::metadata;
+
+/// Transform a `ɵɵngDeclareInjector` call into a `ɵɵdefineInjector` call.
+pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+    let define_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}defineInjector".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}defineInjector")
+    };
+
+    let mut props = Vec::new();
+
+    if let Some(providers) = metadata::get_source_text(obj, "providers", source) {
+        props.push(format!("providers: {providers}"));
+    }
+
+    if let Some(imports) = metadata::get_source_text(obj, "imports", source) {
+        props.push(format!("imports: {imports}"));
+    }
+
+    if props.is_empty() {
+        Ok(format!("{define_fn}({{}})"))
+    } else {
+        Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::Expression;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0").unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_injector_with_providers_and_imports() {
+        let result =
+            parse_and_transform("{ type: AppModule, providers: [ServiceA], imports: [ModuleB] }");
+        assert!(result.contains("i0.\u{0275}\u{0275}defineInjector"));
+        assert!(result.contains("providers: [ServiceA]"));
+        assert!(result.contains("imports: [ModuleB]"));
+    }
+
+    #[test]
+    fn test_injector_empty() {
+        let result = parse_and_transform("{ type: AppModule }");
+        assert_eq!(result, "i0.\u{0275}\u{0275}defineInjector({})");
+    }
+}

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -26,7 +26,8 @@ mod metadata;
 mod ng_module;
 mod pipe;
 mod selector;
-mod transform;
+/// Low-level linking API for transforming a single source file.
+pub mod transform;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -1,0 +1,182 @@
+//! Angular linker for partially compiled npm packages.
+//!
+//! Angular npm packages ship in a "partially compiled" FESM format using
+//! `ɵɵngDeclare*` calls. This crate transforms those declarations into their
+//! fully AOT-compiled equivalents (`ɵɵdefine*` calls), which Angular's runtime
+//! can execute without JIT compilation.
+//!
+//! ## Usage
+//! ```ignore
+//! use std::collections::HashMap;
+//! use std::path::PathBuf;
+//!
+//! let mut modules: HashMap<PathBuf, String> = HashMap::new();
+//! // ... populate with npm module sources ...
+//! let stats = ngc_linker::link_npm_modules(&mut modules, &project_root)?;
+//! println!("Linked {} files", stats.files_linked);
+//! ```
+
+mod class_metadata;
+mod component;
+mod directive;
+mod factory;
+mod injectable;
+mod injector;
+mod metadata;
+mod ng_module;
+mod pipe;
+mod selector;
+mod transform;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use ngc_diagnostics::NgcResult;
+
+/// Statistics from the linking process.
+#[derive(Debug, Clone)]
+pub struct LinkerStats {
+    /// Number of npm files scanned for declarations.
+    pub files_scanned: usize,
+    /// Number of files that contained `ɵɵngDeclare*` calls and were linked.
+    pub files_linked: usize,
+}
+
+/// Link all partially compiled Angular npm modules in the modules map.
+///
+/// Scans all modules whose paths contain `node_modules` for `ɵɵngDeclare*`
+/// calls. Files that contain declarations are parsed, transformed, and their
+/// source is replaced in the map.
+///
+/// Files without `ɵɵngDeclare` are skipped with zero overhead (fast string check).
+pub fn link_npm_modules(
+    modules: &mut HashMap<PathBuf, String>,
+    _project_root: &Path,
+) -> NgcResult<LinkerStats> {
+    let mut files_scanned = 0;
+    let mut files_linked = 0;
+
+    // Collect paths that need linking (can't mutate while iterating)
+    let paths_to_link: Vec<PathBuf> = modules
+        .iter()
+        .filter(|(path, source)| {
+            if !is_npm_module(path) {
+                return false;
+            }
+            files_scanned += 1;
+            needs_linking(source)
+        })
+        .map(|(path, _)| path.clone())
+        .collect();
+
+    for path in paths_to_link {
+        if let Some(source) = modules.get(&path) {
+            let source = source.clone();
+            match transform::link_source(&source, &path)? {
+                Some(linked) => {
+                    modules.insert(path.clone(), linked);
+                    files_linked += 1;
+                    tracing::debug!(path = %path.display(), "linked Angular declarations");
+                }
+                None => {
+                    // Detection said yes but transform found nothing — shouldn't happen
+                    // but harmless
+                }
+            }
+        }
+    }
+
+    Ok(LinkerStats {
+        files_scanned,
+        files_linked,
+    })
+}
+
+/// Check whether a path is inside node_modules.
+fn is_npm_module(path: &Path) -> bool {
+    path.components().any(|c| c.as_os_str() == "node_modules")
+}
+
+/// Fast check whether a source file might contain Angular partial declarations.
+///
+/// Uses a simple substring check — much faster than parsing.
+fn needs_linking(source: &str) -> bool {
+    source.contains("\u{0275}\u{0275}ngDeclare")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_npm_module() {
+        assert!(is_npm_module(Path::new(
+            "/project/node_modules/@angular/core/fesm2022/core.mjs"
+        )));
+        assert!(!is_npm_module(Path::new(
+            "/project/src/app/app.component.ts"
+        )));
+    }
+
+    #[test]
+    fn test_needs_linking() {
+        assert!(needs_linking(
+            "static \u{0275}fac = i0.\u{0275}\u{0275}ngDeclareFactory({});"
+        ));
+        assert!(!needs_linking("export class MyService {}"));
+    }
+
+    #[test]
+    fn test_link_npm_modules_empty() {
+        let mut modules = HashMap::new();
+        modules.insert(
+            PathBuf::from("/project/src/app.ts"),
+            "export class App {}".to_string(),
+        );
+        let stats = link_npm_modules(&mut modules, Path::new("/project")).unwrap();
+        assert_eq!(stats.files_scanned, 0);
+        assert_eq!(stats.files_linked, 0);
+    }
+
+    #[test]
+    fn test_link_npm_modules_no_declarations() {
+        let mut modules = HashMap::new();
+        modules.insert(
+            PathBuf::from("/project/node_modules/lodash/lodash.mjs"),
+            "export function chunk() {}".to_string(),
+        );
+        let stats = link_npm_modules(&mut modules, Path::new("/project")).unwrap();
+        assert_eq!(stats.files_scanned, 1);
+        assert_eq!(stats.files_linked, 0);
+    }
+
+    #[test]
+    fn test_link_injectable() {
+        let mut modules = HashMap::new();
+        let source = r#"import * as i0 from '@angular/core';
+class MyService {}
+MyService.\u{0275}fac = i0.\u{0275}\u{0275}ngDeclareFactory({ minVersion: "12.0.0", version: "17.0.0", ngImport: i0, type: MyService, deps: [], target: 2 });
+MyService.\u{0275}prov = i0.\u{0275}\u{0275}ngDeclareInjectable({ minVersion: "12.0.0", version: "17.0.0", ngImport: i0, type: MyService, providedIn: 'root' });
+export { MyService };"#;
+        // Use actual unicode chars for the ɵ symbols
+        let source = source
+            .replace(r"\u{0275}\u{0275}", "\u{0275}\u{0275}")
+            .replace(r"\u{0275}fac", "\u{0275}fac")
+            .replace(r"\u{0275}prov", "\u{0275}prov");
+
+        modules.insert(
+            PathBuf::from("/project/node_modules/@test/pkg/index.mjs"),
+            source,
+        );
+
+        let stats = link_npm_modules(&mut modules, Path::new("/project")).unwrap();
+        assert_eq!(stats.files_linked, 1);
+
+        let linked = modules
+            .get(Path::new("/project/node_modules/@test/pkg/index.mjs"))
+            .unwrap();
+        assert!(!linked.contains("\u{0275}\u{0275}ngDeclare"));
+        assert!(linked.contains("_Factory"));
+        assert!(linked.contains("\u{0275}\u{0275}defineInjectable"));
+    }
+}

--- a/crates/linker/src/metadata.rs
+++ b/crates/linker/src/metadata.rs
@@ -1,0 +1,194 @@
+//! Helpers for extracting property values from oxc `ObjectExpression` AST nodes.
+//!
+//! These functions use source-text spans to extract values, avoiding the need
+//! to reconstruct code from AST nodes.
+
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_span::GetSpan;
+
+/// Extract the source text for a named property's value from an object literal.
+///
+/// Returns the raw source text of the value expression, suitable for
+/// pass-through into generated code.
+pub fn get_source_text<'a>(
+    obj: &ObjectExpression<'_>,
+    key: &str,
+    source: &'a str,
+) -> Option<&'a str> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if property_key_matches(&p.key, key) {
+                let span = p.value.span();
+                return Some(&source[span.start as usize..span.end as usize]);
+            }
+        }
+    }
+    None
+}
+
+/// Extract a string literal value for a named property.
+///
+/// Returns the string contents (without quotes) if the property exists
+/// and its value is a string literal.
+pub fn get_string_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<String> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if property_key_matches(&p.key, key) {
+                if let Expression::StringLiteral(s) = &p.value {
+                    return Some(s.value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract a boolean literal value for a named property.
+pub fn get_bool_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<bool> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if property_key_matches(&p.key, key) {
+                if let Expression::BooleanLiteral(b) = &p.value {
+                    return Some(b.value);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract an identifier name for a named property.
+///
+/// Returns the identifier text if the property exists and its value is
+/// a simple identifier (e.g., `type: MyService` → `"MyService"`).
+pub fn get_identifier_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<String> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if property_key_matches(&p.key, key) {
+                if let Expression::Identifier(id) = &p.value {
+                    return Some(id.name.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Get the `ObjectExpression` value for a named property.
+///
+/// Returns a reference to the inner object if the property exists and
+/// its value is an object literal.
+pub fn get_object_prop<'a>(
+    obj: &'a ObjectExpression<'_>,
+    key: &str,
+) -> Option<&'a ObjectExpression<'a>> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if property_key_matches(&p.key, key) {
+                if let Expression::ObjectExpression(inner) = &p.value {
+                    return Some(inner);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Check whether a `PropertyKey` matches a given key name.
+fn property_key_matches(pk: &PropertyKey<'_>, key: &str) -> bool {
+    match pk {
+        PropertyKey::StaticIdentifier(id) => id.name.as_str() == key,
+        PropertyKey::StringLiteral(s) => s.value.as_str() == key,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    #[test]
+    fn test_get_string_prop() {
+        let alloc = Allocator::default();
+        let code = "var x = { name: 'hello', count: 42 };";
+        let parsed = Parser::new(&alloc, code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        // Navigate to the object expression
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    assert_eq!(get_string_prop(obj, "name"), Some("hello".to_string()));
+                    assert_eq!(get_string_prop(obj, "count"), None); // not a string
+                    assert_eq!(get_string_prop(obj, "missing"), None);
+                    return;
+                }
+            }
+        }
+        panic!("failed to parse test object");
+    }
+
+    #[test]
+    fn test_get_source_text() {
+        let alloc = Allocator::default();
+        let code = "var x = { deps: [a, b, c], name: 'test' };";
+        let parsed = Parser::new(&alloc, code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    assert_eq!(get_source_text(obj, "deps", code), Some("[a, b, c]"));
+                    assert_eq!(get_source_text(obj, "name", code), Some("'test'"));
+                    return;
+                }
+            }
+        }
+        panic!("failed to parse test object");
+    }
+
+    #[test]
+    fn test_get_bool_prop() {
+        let alloc = Allocator::default();
+        let code = "var x = { standalone: true, pure: false };";
+        let parsed = Parser::new(&alloc, code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    assert_eq!(get_bool_prop(obj, "standalone"), Some(true));
+                    assert_eq!(get_bool_prop(obj, "pure"), Some(false));
+                    assert_eq!(get_bool_prop(obj, "missing"), None);
+                    return;
+                }
+            }
+        }
+        panic!("failed to parse test object");
+    }
+
+    #[test]
+    fn test_get_identifier_prop() {
+        let alloc = Allocator::default();
+        let code = "var x = { type: MyService, name: 'test' };";
+        let parsed = Parser::new(&alloc, code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    assert_eq!(
+                        get_identifier_prop(obj, "type"),
+                        Some("MyService".to_string())
+                    );
+                    assert_eq!(get_identifier_prop(obj, "name"), None); // string, not ident
+                    return;
+                }
+            }
+        }
+        panic!("failed to parse test object");
+    }
+}

--- a/crates/linker/src/metadata.rs
+++ b/crates/linker/src/metadata.rs
@@ -119,13 +119,11 @@ mod tests {
 
         // Navigate to the object expression
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    assert_eq!(get_string_prop(obj, "name"), Some("hello".to_string()));
-                    assert_eq!(get_string_prop(obj, "count"), None); // not a string
-                    assert_eq!(get_string_prop(obj, "missing"), None);
-                    return;
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                assert_eq!(get_string_prop(obj, "name"), Some("hello".to_string()));
+                assert_eq!(get_string_prop(obj, "count"), None); // not a string
+                assert_eq!(get_string_prop(obj, "missing"), None);
+                return;
             }
         }
         panic!("failed to parse test object");
@@ -139,12 +137,10 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    assert_eq!(get_source_text(obj, "deps", code), Some("[a, b, c]"));
-                    assert_eq!(get_source_text(obj, "name", code), Some("'test'"));
-                    return;
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                assert_eq!(get_source_text(obj, "deps", code), Some("[a, b, c]"));
+                assert_eq!(get_source_text(obj, "name", code), Some("'test'"));
+                return;
             }
         }
         panic!("failed to parse test object");
@@ -158,13 +154,11 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    assert_eq!(get_bool_prop(obj, "standalone"), Some(true));
-                    assert_eq!(get_bool_prop(obj, "pure"), Some(false));
-                    assert_eq!(get_bool_prop(obj, "missing"), None);
-                    return;
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                assert_eq!(get_bool_prop(obj, "standalone"), Some(true));
+                assert_eq!(get_bool_prop(obj, "pure"), Some(false));
+                assert_eq!(get_bool_prop(obj, "missing"), None);
+                return;
             }
         }
         panic!("failed to parse test object");
@@ -178,15 +172,13 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    assert_eq!(
-                        get_identifier_prop(obj, "type"),
-                        Some("MyService".to_string())
-                    );
-                    assert_eq!(get_identifier_prop(obj, "name"), None); // string, not ident
-                    return;
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                assert_eq!(
+                    get_identifier_prop(obj, "type"),
+                    Some("MyService".to_string())
+                );
+                assert_eq!(get_identifier_prop(obj, "name"), None); // string, not ident
+                return;
             }
         }
         panic!("failed to parse test object");

--- a/crates/linker/src/ng_module.rs
+++ b/crates/linker/src/ng_module.rs
@@ -50,10 +50,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0").unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0").unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/ng_module.rs
+++ b/crates/linker/src/ng_module.rs
@@ -1,0 +1,73 @@
+//! Transform `ɵɵngDeclareNgModule` → `ɵɵdefineNgModule`.
+//!
+//! ## Example
+//! ```js
+//! // Input:
+//! i0.ɵɵngDeclareNgModule({ type: AppModule, declarations: [A], imports: [B], exports: [C] })
+//! // Output:
+//! i0.ɵɵdefineNgModule({ type: AppModule, declarations: [A], imports: [B], exports: [C] })
+//! ```
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::ObjectExpression;
+
+use crate::metadata;
+
+/// Transform a `ɵɵngDeclareNgModule` call into a `ɵɵdefineNgModule` call.
+pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+    let define_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}defineNgModule".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}defineNgModule")
+    };
+
+    let type_text = metadata::get_source_text(obj, "type", source).unwrap_or("Unknown");
+
+    let mut props = Vec::new();
+    props.push(format!("type: {type_text}"));
+
+    for key in &["declarations", "imports", "exports", "bootstrap", "schemas"] {
+        if let Some(value) = metadata::get_source_text(obj, key, source) {
+            props.push(format!("{key}: {value}"));
+        }
+    }
+
+    Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::Expression;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0").unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_ng_module_basic() {
+        let result = parse_and_transform(
+            "{ type: AppModule, declarations: [CompA], imports: [ModB], exports: [CompA] }",
+        );
+        assert!(result.contains("i0.\u{0275}\u{0275}defineNgModule"));
+        assert!(result.contains("type: AppModule"));
+        assert!(result.contains("declarations: [CompA]"));
+        assert!(result.contains("imports: [ModB]"));
+        assert!(result.contains("exports: [CompA]"));
+    }
+}

--- a/crates/linker/src/pipe.rs
+++ b/crates/linker/src/pipe.rs
@@ -1,0 +1,81 @@
+//! Transform `ɵɵngDeclarePipe` → `ɵɵdefinePipe`.
+//!
+//! ## Example
+//! ```js
+//! // Input:
+//! i0.ɵɵngDeclarePipe({ type: AsyncPipe, name: 'async', pure: false, standalone: true })
+//! // Output:
+//! i0.ɵɵdefinePipe({ name: 'async', type: AsyncPipe, pure: false, standalone: true })
+//! ```
+
+use ngc_diagnostics::NgcResult;
+use oxc_ast::ast::ObjectExpression;
+
+use crate::metadata;
+
+/// Transform a `ɵɵngDeclarePipe` call into a `ɵɵdefinePipe` call.
+pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+    let define_fn = if ng_import.is_empty() {
+        "\u{0275}\u{0275}definePipe".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}definePipe")
+    };
+
+    let type_text = metadata::get_source_text(obj, "type", source).unwrap_or("Unknown");
+
+    let mut props = Vec::new();
+
+    // name comes first in the runtime format
+    if let Some(name) = metadata::get_source_text(obj, "name", source) {
+        props.push(format!("name: {name}"));
+    }
+
+    props.push(format!("type: {type_text}"));
+
+    if let Some(pure) = metadata::get_source_text(obj, "pure", source) {
+        props.push(format!("pure: {pure}"));
+    }
+
+    if metadata::get_bool_prop(obj, "standalone") == Some(true) {
+        props.push("standalone: true".to_string());
+    }
+
+    Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::Expression;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn parse_and_transform(input: &str) -> String {
+        let alloc = Allocator::default();
+        let code = format!("var x = {input};");
+        let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
+        let program = parsed.program;
+
+        if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
+            if let Some(init) = &decl.declarations[0].init {
+                if let Expression::ObjectExpression(obj) = init {
+                    return transform(obj, &code, "i0").unwrap();
+                }
+            }
+        }
+        panic!("failed to parse");
+    }
+
+    #[test]
+    fn test_pipe_basic() {
+        let result = parse_and_transform(
+            "{ type: AsyncPipe, name: 'async', pure: false, standalone: true }",
+        );
+        assert!(result.contains("i0.\u{0275}\u{0275}definePipe"));
+        assert!(result.contains("name: 'async'"));
+        assert!(result.contains("type: AsyncPipe"));
+        assert!(result.contains("pure: false"));
+        assert!(result.contains("standalone: true"));
+    }
+}

--- a/crates/linker/src/pipe.rs
+++ b/crates/linker/src/pipe.rs
@@ -58,10 +58,8 @@ mod tests {
         let program = parsed.program;
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
-            if let Some(init) = &decl.declarations[0].init {
-                if let Expression::ObjectExpression(obj) = init {
-                    return transform(obj, &code, "i0").unwrap();
-                }
+            if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
+                return transform(obj, &code, "i0").unwrap();
             }
         }
         panic!("failed to parse");

--- a/crates/linker/src/selector.rs
+++ b/crates/linker/src/selector.rs
@@ -1,0 +1,161 @@
+//! Parse CSS selector strings into Angular's internal selector array format.
+//!
+//! Angular selectors use a nested array format: `[['tag', 'attr', 'value', ...], ...]`
+//! where multiple top-level arrays represent comma-separated alternatives.
+//!
+//! ## Examples
+//! - `"my-comp"` → `[["my-comp"]]`
+//! - `"[myDir]"` → `[["", "myDir", ""]]`
+//! - `"[attr=value]"` → `[["", "attr", "value"]]`
+//! - `"my-comp, other"` → `[["my-comp"], ["other"]]`
+//! - `".my-class"` → `[["", 8, "my-class"]]`
+
+/// Parse a CSS selector string into Angular's selector array format.
+///
+/// Returns a JavaScript source string like `[['my-comp']]`.
+pub fn parse_selector(selector: &str) -> String {
+    let alternatives: Vec<&str> = selector.split(',').map(|s| s.trim()).collect();
+    let mut parts = Vec::new();
+
+    for alt in alternatives {
+        parts.push(parse_single_selector(alt));
+    }
+
+    format!("[{}]", parts.join(", "))
+}
+
+/// Parse a single selector (no commas) into its array representation.
+fn parse_single_selector(selector: &str) -> String {
+    let selector = selector.trim();
+
+    if selector.is_empty() {
+        return "['']".to_string();
+    }
+
+    let mut items: Vec<String> = Vec::new();
+    let mut tag = String::new();
+    let mut i = 0;
+    let chars: Vec<char> = selector.chars().collect();
+
+    // Parse tag name (if present at the start)
+    while i < chars.len() && chars[i] != '[' && chars[i] != '.' && chars[i] != ':' {
+        tag.push(chars[i]);
+        i += 1;
+    }
+
+    items.push(format!("'{}'", tag.trim()));
+
+    // Parse remaining parts (attributes, classes)
+    while i < chars.len() {
+        match chars[i] {
+            '[' => {
+                // Attribute selector: [name] or [name=value]
+                i += 1;
+                let mut attr_name = String::new();
+                let mut attr_value = String::new();
+                let mut has_value = false;
+
+                while i < chars.len() && chars[i] != ']' {
+                    if chars[i] == '=' {
+                        has_value = true;
+                        i += 1;
+                        // Skip optional quotes
+                        if i < chars.len() && (chars[i] == '\'' || chars[i] == '"') {
+                            let quote = chars[i];
+                            i += 1;
+                            while i < chars.len() && chars[i] != quote {
+                                attr_value.push(chars[i]);
+                                i += 1;
+                            }
+                            if i < chars.len() {
+                                i += 1; // skip closing quote
+                            }
+                        } else {
+                            while i < chars.len() && chars[i] != ']' {
+                                attr_value.push(chars[i]);
+                                i += 1;
+                            }
+                        }
+                    } else {
+                        attr_name.push(chars[i]);
+                        i += 1;
+                    }
+                }
+                if i < chars.len() {
+                    i += 1; // skip ']'
+                }
+
+                items.push(format!("'{}'", attr_name.trim()));
+                items.push(format!(
+                    "'{}'",
+                    if has_value { attr_value.trim() } else { "" }
+                ));
+            }
+            '.' => {
+                // Class selector
+                i += 1;
+                let mut class_name = String::new();
+                while i < chars.len() && chars[i] != '.' && chars[i] != '[' && chars[i] != ':' {
+                    class_name.push(chars[i]);
+                    i += 1;
+                }
+                // 8 = SelectorFlags.CLASS
+                items.push("8".to_string());
+                items.push(format!("'{}'", class_name.trim()));
+            }
+            ':' => {
+                // Pseudo-selector (skip for now)
+                i += 1;
+                while i < chars.len() && chars[i] != ' ' && chars[i] != '[' && chars[i] != '.' {
+                    i += 1;
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    format!("[{}]", items.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_element_selector() {
+        assert_eq!(parse_selector("my-comp"), "[['my-comp']]");
+    }
+
+    #[test]
+    fn test_attribute_selector() {
+        assert_eq!(parse_selector("[myDir]"), "[['', 'myDir', '']]");
+    }
+
+    #[test]
+    fn test_attribute_with_value() {
+        assert_eq!(parse_selector("[attr=value]"), "[['', 'attr', 'value']]");
+    }
+
+    #[test]
+    fn test_multiple_selectors() {
+        assert_eq!(
+            parse_selector("my-comp, other-comp"),
+            "[['my-comp'], ['other-comp']]"
+        );
+    }
+
+    #[test]
+    fn test_class_selector() {
+        assert_eq!(parse_selector(".my-class"), "[['', 8, 'my-class']]");
+    }
+
+    #[test]
+    fn test_element_with_attribute() {
+        assert_eq!(
+            parse_selector("button[type=submit]"),
+            "[['button', 'type', 'submit']]"
+        );
+    }
+}

--- a/crates/linker/src/transform.rs
+++ b/crates/linker/src/transform.rs
@@ -151,14 +151,27 @@ fn visit_statement(
             }
         }
         Statement::ExportNamedDeclaration(export) => {
-            if let Some(oxc_ast::ast::Declaration::VariableDeclaration(var_decl)) =
+            if let Some(ref decl) = export.declaration {
+                match decl {
+                    oxc_ast::ast::Declaration::VariableDeclaration(var_decl) => {
+                        for declarator in &var_decl.declarations {
+                            if let Some(init) = &declarator.init {
+                                visit_expression(init, source, file_path, replacements)?;
+                            }
+                        }
+                    }
+                    oxc_ast::ast::Declaration::ClassDeclaration(class) => {
+                        visit_class_body(class, source, file_path, replacements)?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Statement::ExportDefaultDeclaration(export) => {
+            if let oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class) =
                 &export.declaration
             {
-                for declarator in &var_decl.declarations {
-                    if let Some(init) = &declarator.init {
-                        visit_expression(init, source, file_path, replacements)?;
-                    }
-                }
+                visit_class_body(class, source, file_path, replacements)?;
             }
         }
         Statement::ClassDeclaration(class) => {
@@ -169,7 +182,8 @@ fn visit_statement(
     Ok(())
 }
 
-/// Visit class body looking for static property definitions with `ɵɵngDeclare*` initializers.
+/// Visit class body looking for static property definitions and static blocks
+/// with `ɵɵngDeclare*` initializers.
 fn visit_class_body(
     class: &oxc_ast::ast::Class<'_>,
     source: &str,
@@ -177,10 +191,19 @@ fn visit_class_body(
     replacements: &mut Vec<Replacement>,
 ) -> NgcResult<()> {
     for element in &class.body.body {
-        if let oxc_ast::ast::ClassElement::PropertyDefinition(prop) = element {
-            if let Some(ref init) = prop.value {
-                visit_expression(init, source, file_path, replacements)?;
+        match element {
+            oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
+                if let Some(ref init) = prop.value {
+                    visit_expression(init, source, file_path, replacements)?;
+                }
             }
+            oxc_ast::ast::ClassElement::StaticBlock(block) => {
+                // static { this.ɵfac = i0.ɵɵngDeclareFactory({...}); }
+                for stmt in &block.body {
+                    visit_statement(stmt, source, file_path, replacements)?;
+                }
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -206,6 +229,9 @@ fn visit_expression(
             for expr in &seq.expressions {
                 visit_expression(expr, source, file_path, replacements)?;
             }
+        }
+        Expression::ClassExpression(class) => {
+            visit_class_body(class, source, file_path, replacements)?;
         }
         _ => {}
     }

--- a/crates/linker/src/transform.rs
+++ b/crates/linker/src/transform.rs
@@ -1,0 +1,301 @@
+//! AST walking, declaration detection, and span-based replacement.
+//!
+//! Parses an npm module's JavaScript source with oxc, finds all `ɵɵngDeclare*`
+//! call expressions, transforms each one, and applies the replacements to the
+//! original source text.
+
+use std::path::Path;
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{CallExpression, Expression, Program, Statement};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+use crate::{class_metadata, component, directive, factory, injectable, injector, ng_module, pipe};
+
+/// A single text replacement to apply to the source.
+#[derive(Debug)]
+struct Replacement {
+    /// Start byte offset in the original source.
+    start: u32,
+    /// End byte offset in the original source.
+    end: u32,
+    /// The replacement text.
+    text: String,
+}
+
+/// The kind of `ɵɵngDeclare*` call found in the source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeclareKind {
+    Factory,
+    Injectable,
+    Injector,
+    NgModule,
+    Pipe,
+    Directive,
+    Component,
+    ClassMetadata,
+}
+
+/// Detect the `ɵɵngDeclare*` variant from a callee name suffix.
+fn detect_declare_kind(name: &str) -> Option<DeclareKind> {
+    // Handle both bare names and member-expression property names
+    if name.ends_with("ngDeclareFactory") {
+        Some(DeclareKind::Factory)
+    } else if name.ends_with("ngDeclareInjectable") {
+        Some(DeclareKind::Injectable)
+    } else if name.ends_with("ngDeclareInjector") {
+        Some(DeclareKind::Injector)
+    } else if name.ends_with("ngDeclareNgModule") {
+        Some(DeclareKind::NgModule)
+    } else if name.ends_with("ngDeclarePipe") {
+        Some(DeclareKind::Pipe)
+    } else if name.ends_with("ngDeclareDirective") {
+        Some(DeclareKind::Directive)
+    } else if name.ends_with("ngDeclareComponent") {
+        Some(DeclareKind::Component)
+    } else if name.ends_with("ngDeclareClassMetadata") {
+        Some(DeclareKind::ClassMetadata)
+    } else {
+        None
+    }
+}
+
+/// Extract the callee name from a call expression.
+///
+/// Handles both bare identifiers (`ɵɵngDeclareFactory(...)`) and member
+/// expressions (`i0.ɵɵngDeclareFactory(...)`).
+fn get_callee_name(call: &CallExpression<'_>) -> Option<String> {
+    match &call.callee {
+        Expression::Identifier(id) => Some(id.name.to_string()),
+        Expression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        _ => None,
+    }
+}
+
+/// Extract the `ngImport` alias (e.g., `"i0"`) from the callee of a declare call.
+///
+/// For `i0.ɵɵngDeclareFactory(...)`, returns `"i0"`.
+/// For bare `ɵɵngDeclareFactory(...)`, returns `None`.
+fn get_ng_import_alias(call: &CallExpression<'_>) -> Option<String> {
+    if let Expression::StaticMemberExpression(member) = &call.callee {
+        if let Expression::Identifier(id) = &member.object {
+            return Some(id.name.to_string());
+        }
+    }
+    None
+}
+
+/// Transform a single npm module source by linking all `ɵɵngDeclare*` calls.
+///
+/// Returns the transformed source, or `None` if no declarations were found.
+pub fn link_source(source: &str, file_path: &Path) -> NgcResult<Option<String>> {
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
+
+    if !parsed.errors.is_empty() {
+        return Err(NgcError::LinkerError {
+            path: file_path.to_path_buf(),
+            message: format!("parse error: {}", parsed.errors[0]),
+        });
+    }
+
+    let mut replacements = Vec::new();
+    collect_replacements(&parsed.program, source, file_path, &mut replacements)?;
+
+    if replacements.is_empty() {
+        return Ok(None);
+    }
+
+    // Sort by start offset descending so we can apply replacements from end to start
+    replacements.sort_by(|a, b| b.start.cmp(&a.start));
+
+    let mut result = source.to_string();
+    for r in &replacements {
+        result.replace_range(r.start as usize..r.end as usize, &r.text);
+    }
+
+    Ok(Some(result))
+}
+
+/// Walk the program AST and collect all replacements for `ɵɵngDeclare*` calls.
+fn collect_replacements(
+    program: &Program<'_>,
+    source: &str,
+    file_path: &Path,
+    replacements: &mut Vec<Replacement>,
+) -> NgcResult<()> {
+    for stmt in &program.body {
+        visit_statement(stmt, source, file_path, replacements)?;
+    }
+    Ok(())
+}
+
+/// Visit a statement, looking for `ɵɵngDeclare*` call expressions anywhere within.
+fn visit_statement(
+    stmt: &Statement<'_>,
+    source: &str,
+    file_path: &Path,
+    replacements: &mut Vec<Replacement>,
+) -> NgcResult<()> {
+    match stmt {
+        Statement::ExpressionStatement(expr_stmt) => {
+            visit_expression(&expr_stmt.expression, source, file_path, replacements)?;
+        }
+        Statement::VariableDeclaration(decl) => {
+            for declarator in &decl.declarations {
+                if let Some(init) = &declarator.init {
+                    visit_expression(init, source, file_path, replacements)?;
+                }
+            }
+        }
+        Statement::ExportNamedDeclaration(export) => {
+            if let Some(oxc_ast::ast::Declaration::VariableDeclaration(var_decl)) =
+                &export.declaration
+            {
+                for declarator in &var_decl.declarations {
+                    if let Some(init) = &declarator.init {
+                        visit_expression(init, source, file_path, replacements)?;
+                    }
+                }
+            }
+        }
+        Statement::ClassDeclaration(class) => {
+            visit_class_body(class, source, file_path, replacements)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Visit class body looking for static property definitions with `ɵɵngDeclare*` initializers.
+fn visit_class_body(
+    class: &oxc_ast::ast::Class<'_>,
+    source: &str,
+    file_path: &Path,
+    replacements: &mut Vec<Replacement>,
+) -> NgcResult<()> {
+    for element in &class.body.body {
+        if let oxc_ast::ast::ClassElement::PropertyDefinition(prop) = element {
+            if let Some(ref init) = prop.value {
+                visit_expression(init, source, file_path, replacements)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Visit an expression, looking for `ɵɵngDeclare*` call expressions.
+fn visit_expression(
+    expr: &Expression<'_>,
+    source: &str,
+    file_path: &Path,
+    replacements: &mut Vec<Replacement>,
+) -> NgcResult<()> {
+    match expr {
+        Expression::CallExpression(call) => {
+            if let Some(replacement) = try_transform_declare_call(call, source, file_path)? {
+                replacements.push(replacement);
+            }
+        }
+        Expression::AssignmentExpression(assign) => {
+            visit_expression(&assign.right, source, file_path, replacements)?;
+        }
+        Expression::SequenceExpression(seq) => {
+            for expr in &seq.expressions {
+                visit_expression(expr, source, file_path, replacements)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Try to transform a call expression if it's a `ɵɵngDeclare*` call.
+///
+/// Returns a `Replacement` if the call was recognized and transformed.
+fn try_transform_declare_call(
+    call: &CallExpression<'_>,
+    source: &str,
+    file_path: &Path,
+) -> NgcResult<Option<Replacement>> {
+    let callee_name = match get_callee_name(call) {
+        Some(name) => name,
+        None => return Ok(None),
+    };
+
+    let kind = match detect_declare_kind(&callee_name) {
+        Some(k) => k,
+        None => return Ok(None),
+    };
+
+    // The first argument should be an object expression
+    let obj = match call.arguments.first() {
+        Some(arg) => match &arg {
+            oxc_ast::ast::Argument::ObjectExpression(obj) => obj.as_ref(),
+            _ => {
+                return Err(NgcError::LinkerError {
+                    path: file_path.to_path_buf(),
+                    message: format!("{callee_name}: expected object literal argument"),
+                });
+            }
+        },
+        None => {
+            return Err(NgcError::LinkerError {
+                path: file_path.to_path_buf(),
+                message: format!("{callee_name}: missing argument"),
+            });
+        }
+    };
+
+    let ng_import = get_ng_import_alias(call).unwrap_or_default();
+
+    let replacement_text = match kind {
+        DeclareKind::Factory => factory::transform(obj, source, &ng_import)?,
+        DeclareKind::Injectable => injectable::transform(obj, source, &ng_import)?,
+        DeclareKind::Injector => injector::transform(obj, source, &ng_import)?,
+        DeclareKind::NgModule => ng_module::transform(obj, source, &ng_import)?,
+        DeclareKind::Pipe => pipe::transform(obj, source, &ng_import)?,
+        DeclareKind::Directive => directive::transform(obj, source, &ng_import, file_path)?,
+        DeclareKind::Component => component::transform(obj, source, &ng_import, file_path)?,
+        DeclareKind::ClassMetadata => class_metadata::transform(obj, source, &ng_import)?,
+    };
+
+    let span = call.span();
+    Ok(Some(Replacement {
+        start: span.start,
+        end: span.end,
+        text: replacement_text,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_detect_declare_kind() {
+        assert_eq!(
+            detect_declare_kind("\u{0275}\u{0275}ngDeclareFactory"),
+            Some(DeclareKind::Factory)
+        );
+        assert_eq!(
+            detect_declare_kind("\u{0275}\u{0275}ngDeclareInjectable"),
+            Some(DeclareKind::Injectable)
+        );
+        assert_eq!(
+            detect_declare_kind("\u{0275}\u{0275}ngDeclareComponent"),
+            Some(DeclareKind::Component)
+        );
+        assert_eq!(detect_declare_kind("someOtherFunction"), None);
+    }
+
+    #[test]
+    fn test_no_declarations_returns_none() {
+        let source = "export class Foo { bar() {} }";
+        let result = link_source(source, &PathBuf::from("test.mjs")).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -56,10 +56,6 @@ pub fn generate_ivy(
 
     gen.ivy_imports
         .insert("\u{0275}\u{0275}defineComponent".to_string());
-    if component.standalone {
-        gen.ivy_imports
-            .insert("\u{0275}\u{0275}StandaloneFeature".to_string());
-    }
 
     gen.generate_nodes(template_nodes);
 
@@ -100,7 +96,6 @@ pub fn generate_ivy(
     dc.push_str(&format!("    selectors: [['{}']],\n", component.selector));
     if component.standalone {
         dc.push_str("    standalone: true,\n");
-        dc.push_str("    features: [\u{0275}\u{0275}StandaloneFeature],\n");
     }
     dc.push_str(&format!("    decls: {decls},\n"));
     dc.push_str(&format!("    vars: {vars},\n"));

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -80,18 +80,27 @@ pub fn generate_template_fn(
     let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;
 
     // Extract just the template function from the defineComponent code
-    // The codegen produces: `static ɵcmp = ɵɵdefineComponent({ ..., template: function Name_Template(rf, ctx) { ... }, ... })`
-    // We need to extract just the template function part
     let template_fn = extract_template_fn_from_ivy(&ivy_output, &meta.class_name);
+
+    // Strip TypeScript type annotations — the codegen produces TS (`rf: number, ctx: ClassName`)
+    // but the linker outputs into .mjs files which must be plain JavaScript.
+    let template_fn = strip_ts_annotations(&template_fn, &meta.class_name);
 
     // Extract decls and vars from the defineComponent code
     let (decls, vars) = extract_decls_vars_from_ivy(&ivy_output);
+
+    // Strip TS annotations from child template functions too
+    let child_fns = ivy_output
+        .child_template_functions
+        .iter()
+        .map(|f| strip_ts_annotations(f, &meta.class_name))
+        .collect();
 
     Ok(TemplateFnOutput {
         template_function: template_fn,
         decls,
         vars,
-        child_template_functions: ivy_output.child_template_functions,
+        child_template_functions: child_fns,
     })
 }
 
@@ -145,6 +154,17 @@ fn extract_number_prop(code: &str, prefix: &str) -> Option<u32> {
     let remaining = &code[start..];
     let end = remaining.find(|c: char| !c.is_ascii_digit())?;
     remaining[..end].parse().ok()
+}
+
+/// Strip TypeScript type annotations from generated template functions.
+///
+/// The codegen produces TypeScript-flavored output like `(rf: number, ctx: ClassName)`
+/// which is valid TS but not valid JS. For the linker (which outputs into `.mjs` files),
+/// we need to strip these annotations.
+fn strip_ts_annotations(code: &str, class_name: &str) -> String {
+    code.replace(&format!("rf: number, ctx: {class_name}"), "rf, ctx")
+        .replace("rf: number, ctx: any", "rf, ctx")
+        .replace("t: any", "t")
 }
 
 /// Result of template compilation for a single file.

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -16,6 +16,137 @@ use ngc_diagnostics::{NgcError, NgcResult};
 use rayon::prelude::*;
 use tracing::debug;
 
+/// Lightweight metadata for template compilation without `ExtractedComponent`.
+///
+/// Used by the Angular linker to compile templates from `ɵɵngDeclareComponent`
+/// metadata without needing decorator extraction.
+#[derive(Debug, Clone)]
+pub struct TemplateMetadata {
+    /// The component class name.
+    pub class_name: String,
+    /// The component selector.
+    pub selector: String,
+    /// Whether the component is standalone.
+    pub standalone: bool,
+    /// Raw source text of the imports array.
+    pub imports_source: Option<String>,
+    /// Raw source text of the styles array.
+    pub styles_source: Option<String>,
+}
+
+/// Result of compiling just the template function (without full defineComponent).
+#[derive(Debug, Clone)]
+pub struct TemplateFnOutput {
+    /// The template function code: `function Name_Template(rf, ctx) { ... }`.
+    pub template_function: String,
+    /// Number of element/text slots used.
+    pub decls: u32,
+    /// Number of binding variables used.
+    pub vars: u32,
+    /// Child template functions (for @if, @for, @switch blocks).
+    pub child_template_functions: Vec<String>,
+}
+
+/// Compile a template string into a standalone template function.
+///
+/// This is the public API used by the Angular linker to compile templates
+/// from `ɵɵngDeclareComponent` calls in npm packages.
+pub fn generate_template_fn(
+    template: &str,
+    meta: &TemplateMetadata,
+    file_path: &Path,
+) -> NgcResult<TemplateFnOutput> {
+    // Parse the template
+    let template_ast = parser::parse_template(template, file_path)?;
+
+    // Convert to ExtractedComponent for codegen compatibility
+    let extracted = extract::ExtractedComponent {
+        class_name: meta.class_name.clone(),
+        selector: meta.selector.clone(),
+        template: Some(template.to_string()),
+        template_url: None,
+        standalone: meta.standalone,
+        imports_source: meta.imports_source.clone(),
+        imports_identifiers: Vec::new(),
+        decorator_span: (0, 0),
+        class_body_start: 0,
+        export_keyword_start: None,
+        class_keyword_start: 0,
+        angular_core_import_span: None,
+        other_angular_core_imports: Vec::new(),
+        styles_source: meta.styles_source.clone(),
+    };
+
+    let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;
+
+    // Extract just the template function from the defineComponent code
+    // The codegen produces: `static ɵcmp = ɵɵdefineComponent({ ..., template: function Name_Template(rf, ctx) { ... }, ... })`
+    // We need to extract just the template function part
+    let template_fn = extract_template_fn_from_ivy(&ivy_output, &meta.class_name);
+
+    // Extract decls and vars from the defineComponent code
+    let (decls, vars) = extract_decls_vars_from_ivy(&ivy_output);
+
+    Ok(TemplateFnOutput {
+        template_function: template_fn,
+        decls,
+        vars,
+        child_template_functions: ivy_output.child_template_functions,
+    })
+}
+
+/// Extract the template function from the IvyOutput's defineComponent code.
+fn extract_template_fn_from_ivy(ivy: &codegen::IvyOutput, class_name: &str) -> String {
+    let dc = &ivy.define_component_code;
+    let template_marker = format!("template: function {class_name}_Template");
+
+    if let Some(start) = dc.find(&template_marker) {
+        // Find the function start
+        let fn_start = start + "template: ".len();
+        // Find the matching closing brace by counting braces
+        let remaining = &dc[fn_start..];
+        let mut depth = 0;
+        let mut end = 0;
+        for (i, ch) in remaining.char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if end > 0 {
+            return remaining[..end].to_string();
+        }
+    }
+
+    // Fallback: empty template
+    format!("function {class_name}_Template(rf, ctx) {{}}")
+}
+
+/// Extract decls and vars from the IvyOutput's defineComponent code.
+fn extract_decls_vars_from_ivy(ivy: &codegen::IvyOutput) -> (u32, u32) {
+    let dc = &ivy.define_component_code;
+
+    let decls = extract_number_prop(dc, "decls: ").unwrap_or(0);
+    let vars = extract_number_prop(dc, "vars: ").unwrap_or(0);
+
+    (decls, vars)
+}
+
+/// Extract a numeric property value from generated code.
+fn extract_number_prop(code: &str, prefix: &str) -> Option<u32> {
+    let start = code.find(prefix)? + prefix.len();
+    let remaining = &code[start..];
+    let end = remaining.find(|c: char| !c.is_ascii_digit())?;
+    remaining[..end].parse().ok()
+}
+
 /// Result of template compilation for a single file.
 #[derive(Debug, Clone)]
 pub struct CompiledFile {


### PR DESCRIPTION
## Summary

Closes #12.

- Add native Rust `crates/linker/` that transforms Angular's partially compiled `ɵɵngDeclare*` calls into fully AOT-compiled `ɵɵdefine*` equivalents
- Handles all 8 declaration types: Factory, Injectable, Injector, NgModule, Pipe, Directive, Component, ClassMetadata
- Uses oxc for parsing + span-based text replacement (no Node.js/Babel dependency)
- Integrates into CLI pipeline between npm resolution and bundling
- Adds `generate_template_fn` public API to template-compiler for component template compilation from linker
- Bumps version to 0.7.2

## Declaration Types

| Input | Output |
|-------|--------|
| `ɵɵngDeclareFactory` | Factory function |
| `ɵɵngDeclareInjectable` | `ɵɵdefineInjectable` |
| `ɵɵngDeclareInjector` | `ɵɵdefineInjector` |
| `ɵɵngDeclareNgModule` | `ɵɵdefineNgModule` |
| `ɵɵngDeclarePipe` | `ɵɵdefinePipe` |
| `ɵɵngDeclareDirective` | `ɵɵdefineDirective` |
| `ɵɵngDeclareComponent` | `ɵɵdefineComponent` |
| `ɵɵngDeclareClassMetadata` | `ɵsetClassMetadata` |

## Test plan

- [x] 33 unit tests covering all declaration types, metadata extraction, selector parsing, and integration
- [x] Full workspace passes: `cargo test --workspace && cargo clippy -- -D warnings && cargo fmt --check`
- [ ] End-to-end: build a real Angular project and verify no JIT compilation errors in the browser