### PR TITLE
feat: AOT compilation for @Injectable, @Directive, @Pipe, @NgModule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Goal: file watching, incremental rebuilds, and ng serve support.
 Goal: zero-config swap for Angular developers.
 
 - [x] Angular linker for partially compiled npm packages (ɵɵngDeclare* → ɵɵdefine*)
+- [x] AOT compilation for @Injectable, @Directive, @Pipe, @NgModule in project files
 - [ ] npm binary distribution (platform-specific packages)
 - [ ] Angular builder adapter (speaks @angular-devkit builder protocol)
 - [ ] angular.json integration: swap builder, run ng build as normal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "criterion",
  "glob",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "clap",
  "colored",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -113,6 +113,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
             generate_source_maps: input.options.source_maps,
             unused_exports: &unused_exports,
             bundled_specifiers: &input.bundled_specifiers,
+            chunk_entry: &chunk.entry,
         })?;
         output_chunks.insert(chunk.filename.clone(), chunk_code);
         if let Some(map) = chunk_map {
@@ -248,6 +249,8 @@ struct ChunkBundleParams<'a> {
     generate_source_maps: bool,
     unused_exports: &'a HashMap<PathBuf, HashSet<String>>,
     bundled_specifiers: &'a HashSet<String>,
+    /// The chunk's entry module — exports from this module are preserved.
+    chunk_entry: &'a Path,
 }
 
 /// Bundle a single chunk's modules into an ESM string, optionally with a source map.
@@ -373,6 +376,7 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMa
         } else {
             // Project module: use existing rewriter with namespace map
             let module_unused = p.unused_exports.get(module_path);
+            let is_chunk_entry = module_path == p.chunk_entry;
             let rewritten = rewrite::rewrite_module_with_shaking(
                 js_code,
                 &file_name,
@@ -381,6 +385,7 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMa
                 module_unused,
                 p.bundled_specifiers,
                 &specifier_to_namespace,
+                is_chunk_entry,
             )?;
 
             all_externals.extend(rewritten.external_imports);

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -66,6 +66,7 @@ pub fn rewrite_module(
         None,
         &HashSet::new(),
         &HashMap::new(),
+        false,
     )
 }
 
@@ -73,6 +74,7 @@ pub fn rewrite_module(
 ///
 /// When `unused_exports` is provided, declarations of exports in that set
 /// are fully removed (not just the `export` keyword stripped).
+#[allow(clippy::too_many_arguments)]
 pub fn rewrite_module_with_shaking(
     js_code: &str,
     file_name: &str,
@@ -81,6 +83,7 @@ pub fn rewrite_module_with_shaking(
     unused_exports: Option<&HashSet<String>>,
     bundled_specifiers: &HashSet<String>,
     namespace_map: &HashMap<String, String>,
+    preserve_exports: bool,
 ) -> NgcResult<RewrittenModule> {
     let allocator = Allocator::new();
     let source_type = SourceType::mjs();
@@ -107,6 +110,7 @@ pub fn rewrite_module_with_shaking(
                 unused_exports,
                 bundled_specifiers,
                 namespace_map,
+                preserve_exports,
             );
         }
 
@@ -129,6 +133,7 @@ pub fn rewrite_module_with_shaking(
 }
 
 /// Process a top-level module declaration (import/export) and collect edits.
+#[allow(clippy::too_many_arguments)]
 fn collect_module_decl_edits(
     module_decl: &ModuleDeclaration,
     local_prefixes: &[&str],
@@ -137,6 +142,7 @@ fn collect_module_decl_edits(
     unused_exports: Option<&HashSet<String>>,
     bundled_specifiers: &HashSet<String>,
     namespace_map: &HashMap<String, String>,
+    preserve_exports: bool,
 ) {
     match module_decl {
         ModuleDeclaration::ImportDeclaration(import) => {
@@ -227,7 +233,9 @@ fn collect_module_decl_edits(
             }
         }
         ModuleDeclaration::ExportNamedDeclaration(export) => {
-            if export.source.is_some() {
+            if preserve_exports {
+                // Keep exports intact for lazy chunk entry modules
+            } else if export.source.is_some() {
                 edits.push(TextEdit {
                     start: export.span.start,
                     end: export.span.end,
@@ -255,7 +263,7 @@ fn collect_module_decl_edits(
                         replacement: None,
                     });
                 }
-            } else {
+            } else if !preserve_exports {
                 edits.push(TextEdit {
                     start: export.span.start,
                     end: export.span.end,
@@ -264,23 +272,27 @@ fn collect_module_decl_edits(
             }
         }
         ModuleDeclaration::ExportDefaultDeclaration(export) => {
-            match &export.declaration {
-                ExportDefaultDeclarationKind::FunctionDeclaration(_)
-                | ExportDefaultDeclarationKind::ClassDeclaration(_) => {
-                    edits.push(TextEdit {
-                        start: export.span.start,
-                        end: export.span.start + 15, // "export default "
-                        replacement: None,
-                    });
+            if preserve_exports {
+                // Keep exports intact for lazy chunk entry modules
+            } else {
+                match &export.declaration {
+                    ExportDefaultDeclarationKind::FunctionDeclaration(_)
+                    | ExportDefaultDeclarationKind::ClassDeclaration(_) => {
+                        edits.push(TextEdit {
+                            start: export.span.start,
+                            end: export.span.start + 15, // "export default "
+                            replacement: None,
+                        });
+                    }
+                    _ => {
+                        edits.push(TextEdit {
+                            start: export.span.start,
+                            end: export.span.end,
+                            replacement: None,
+                        });
+                    }
                 }
-                _ => {
-                    edits.push(TextEdit {
-                        start: export.span.start,
-                        end: export.span.end,
-                        replacement: None,
-                    });
-                }
-            }
+            } // close else block for preserve_exports
         }
         ModuleDeclaration::ExportAllDeclaration(export) => {
             if is_local(

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -2,7 +2,7 @@
 source: crates/bundler/tests/snapshot_tests.rs
 expression: bundle
 ---
-import { ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
+import { ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵgetComponentDepsFactory, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
 import { RouterOutlet, provideRouter } from '@angular/router';
 import { bootstrapApplication } from '@angular/platform-browser';
 
@@ -50,7 +50,7 @@ class AppComponent {
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},
-		dependencies: () => [RouterOutlet]
+		dependencies: ɵɵgetComponentDepsFactory(AppComponent, () => [RouterOutlet])
 	});
 	title = SharedUtils.appName();
 }

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -50,7 +50,7 @@ class AppComponent {
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},
-		imports: () => [RouterOutlet]
+		dependencies: () => [RouterOutlet]
 	});
 	title = SharedUtils.appName();
 }

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -50,7 +50,7 @@ class AppComponent {
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},
-		dependencies: () => [RouterOutlet]
+		imports: () => [RouterOutlet]
 	});
 	title = SharedUtils.appName();
 }

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -50,7 +50,7 @@ class AppComponent {
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},
-		dependencies: [RouterOutlet]
+		dependencies: () => [RouterOutlet]
 	});
 	title = SharedUtils.appName();
 }

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -50,7 +50,7 @@ class AppComponent {
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},
-		dependencies: ɵɵgetComponentDepsFactory(AppComponent, () => [RouterOutlet])
+		dependencies: ɵɵgetComponentDepsFactory(AppComponent, [RouterOutlet])
 	});
 	title = SharedUtils.appName();
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -342,6 +342,14 @@ fn run_build(
     for (filename, code) in &bundle_output.chunks {
         let mut final_code = code.clone();
 
+        // TEMPORARY DIAGNOSTIC: patch assertDefined to log what's null
+        if filename.starts_with("main") {
+            final_code = final_code.replace(
+                "'Array must be defined.'",
+                "(console.error('ASSERT_NULL:',new Error().stack),'Array must be defined.')",
+            );
+        }
+
         // Append source map reference if we have a map for this chunk
         if let Some(source_map) = bundle_output.chunk_source_maps.get(filename) {
             if bundle_options.source_maps {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -345,8 +345,8 @@ fn run_build(
         // TEMPORARY DIAGNOSTIC: patch assertDefined to log what's null
         if filename.starts_with("main") {
             final_code = final_code.replace(
-                "'Array must be defined.'",
-                "(console.error('ASSERT_NULL:',new Error().stack),'Array must be defined.')",
+                "`Array must be defined.`",
+                "(console.error('ASSERT_NULL:',new Error().stack),`Array must be defined.`)",
             );
         }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -342,14 +342,6 @@ fn run_build(
     for (filename, code) in &bundle_output.chunks {
         let mut final_code = code.clone();
 
-        // TEMPORARY DIAGNOSTIC: patch assertDefined to log what's null
-        if filename.starts_with("main") {
-            final_code = final_code.replace(
-                "`Array must be defined.`",
-                "(console.error('ASSERT_NULL:',new Error().stack),`Array must be defined.`)",
-            );
-        }
-
         // Append source map reference if we have a map for this chunk
         if let Some(source_map) = bundle_output.chunk_source_maps.get(filename) {
             if bundle_options.source_maps {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -165,9 +165,9 @@ fn run_build(
         })
         .unwrap_or_else(|| config_dir.join("dist"));
 
-    // Step 4: Compile templates
+    // Step 4: Compile Angular decorators (@Component, @Injectable, @Directive, @Pipe, @NgModule)
     let files: Vec<PathBuf> = file_graph.graph.node_weights().cloned().collect();
-    let compiled = ngc_template_compiler::compile_templates(&files)?;
+    let compiled = ngc_template_compiler::compile_all_decorators(&files)?;
 
     // Report any JIT fallbacks
     for cf in &compiled {

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -119,13 +119,10 @@ pub fn build_define_call(
         props.push(format!("providers: {providers}"));
     }
 
-    // Queries
-    if let Some(queries) = metadata::get_source_text(obj, "queries", source) {
-        props.push(format!("contentQueries: {queries}"));
-    }
-    if let Some(view_queries) = metadata::get_source_text(obj, "viewQueries", source) {
-        props.push(format!("viewQuery: {view_queries}"));
-    }
+    // Queries: contentQueries and viewQuery require compilation from declare format
+    // (array of descriptors) to runtime format (functions with ɵɵcontentQuery/ɵɵviewQuery calls).
+    // Skipped for now — the raw array format crashes the Angular runtime.
+    // TODO: compile query descriptors to query functions
 
     Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
 }

--- a/crates/linker/src/factory.rs
+++ b/crates/linker/src/factory.rs
@@ -76,7 +76,20 @@ fn transform_dep(
     ng_import: &str,
     inject_fn: &str,
 ) -> Option<String> {
-    // Check for attribute injection first
+    // Check for attribute injection: { token: 'attrName', attribute: true }
+    if metadata::get_bool_prop(dep_obj, "attribute") == Some(true) {
+        let attr_name = metadata::get_string_prop(dep_obj, "token")
+            .or_else(|| metadata::get_source_text(dep_obj, "token", source).map(|s| s.to_string()));
+        if let Some(attr_name) = attr_name {
+            let inject_attr = if ng_import.is_empty() {
+                format!("\u{0275}\u{0275}injectAttribute('{attr_name}')")
+            } else {
+                format!("{ng_import}.\u{0275}\u{0275}injectAttribute('{attr_name}')")
+            };
+            return Some(inject_attr);
+        }
+    }
+    // Legacy format: { attribute: 'attrName' }
     if let Some(attr_name) = metadata::get_string_prop(dep_obj, "attribute") {
         let inject_attr = if ng_import.is_empty() {
             format!("\u{0275}\u{0275}injectAttribute('{attr_name}')")

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1150,33 +1150,59 @@ fn ctx_expr(expr: &str) -> String {
     let mut remove_ranges: Vec<(u32, u32)> = Vec::new();
     collect_ctx_rewrites(init_expr, &mut ctx_inserts, &mut remove_ranges, false);
 
-    // Map wrapper offsets back to expression offsets
+    // Map wrapper byte offsets back to expression byte offsets
     let expr_offset = "var __expr = ".len() as u32;
-    let mut result = trimmed.to_string();
 
-    // Apply removals first (sorted reverse)
-    let mut sorted_removes: Vec<(usize, usize)> = remove_ranges
-        .iter()
-        .map(|(s, e)| ((s - expr_offset) as usize, (e - expr_offset) as usize))
-        .collect();
-    sorted_removes.sort_by(|a, b| b.0.cmp(&a.0));
-    for (s, e) in &sorted_removes {
-        if *s <= result.len() && *e <= result.len() {
-            result.replace_range(*s..*e, "");
-        }
+    // Build a unified list of edits (all with byte offsets into `trimmed`)
+    // sorted by position descending so we can apply them back-to-front
+    // without invalidating earlier positions.
+    enum Edit {
+        Insert(usize),        // insert "ctx." at this byte offset
+        Remove(usize, usize), // remove bytes [start..end)
     }
 
-    // Apply ctx. insertions (sorted reverse)
-    let mut sorted_inserts: Vec<usize> = ctx_inserts
-        .iter()
-        .map(|off| (off - expr_offset) as usize)
-        .collect();
-    sorted_inserts.sort_unstable();
-    sorted_inserts.dedup();
-    sorted_inserts.reverse();
-    for off in &sorted_inserts {
-        if *off <= result.len() {
-            result.insert_str(*off, "ctx.");
+    let mut edits: Vec<(usize, Edit)> = Vec::new();
+
+    for off in &ctx_inserts {
+        let pos = (*off - expr_offset) as usize;
+        edits.push((pos, Edit::Insert(pos)));
+    }
+    for (s, e) in &remove_ranges {
+        let start = (*s - expr_offset) as usize;
+        let end = (*e - expr_offset) as usize;
+        edits.push((start, Edit::Remove(start, end)));
+    }
+
+    // Sort by position descending; removals before insertions at same position
+    edits.sort_by(|a, b| {
+        b.0.cmp(&a.0).then_with(|| {
+            // Removals first at same position
+            let a_is_remove = matches!(a.1, Edit::Remove(..));
+            let b_is_remove = matches!(b.1, Edit::Remove(..));
+            b_is_remove.cmp(&a_is_remove)
+        })
+    });
+
+    // Deduplicate insertions at the same position
+    edits.dedup_by(|a, b| matches!((&a.1, &b.1), (Edit::Insert(_), Edit::Insert(_))) && a.0 == b.0);
+
+    let mut result = trimmed.to_string();
+    for (_pos, edit) in &edits {
+        match edit {
+            Edit::Insert(off) => {
+                if *off <= result.len() && result.is_char_boundary(*off) {
+                    result.insert_str(*off, "ctx.");
+                }
+            }
+            Edit::Remove(s, e) => {
+                if *s <= result.len()
+                    && *e <= result.len()
+                    && result.is_char_boundary(*s)
+                    && result.is_char_boundary(*e)
+                {
+                    result.replace_range(*s..*e, "");
+                }
+            }
         }
     }
 
@@ -1530,6 +1556,17 @@ mod tests {
         assert_eq!(split_top_level_pipe("foo || bar"), None,);
         // Pipe inside parens is not top-level
         assert_eq!(split_top_level_pipe("x ? ('A' | translate) : 'B'"), None,);
+    }
+
+    #[test]
+    fn test_ctx_expr_multiple_non_null_assertions() {
+        // Reproduces the pattern that caused the char boundary panic:
+        // removing `!` shifts byte offsets for subsequent insertions
+        let result = ctx_expr("getBadgeClass(subscription()!.tier, subscription()!.status)");
+        assert!(result.contains("ctx.getBadgeClass"));
+        assert!(result.contains("ctx.subscription().tier"));
+        assert!(result.contains("ctx.subscription().status"));
+        assert!(!result.contains('!'));
     }
 
     #[test]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -5,13 +5,13 @@ use ngc_diagnostics::NgcResult;
 use crate::ast::*;
 use crate::extract::ExtractedComponent;
 
-/// Generated Ivy output for a component.
+/// Generated Ivy output for any Angular decorator.
 #[derive(Debug, Clone)]
 pub struct IvyOutput {
     /// The `static ɵfac = ...` field code.
     pub factory_code: String,
-    /// The `static ɵcmp = ɵɵdefineComponent({...})` field code.
-    pub define_component_code: String,
+    /// Static definition fields (e.g. ɵcmp, ɵprov, ɵdir, ɵpipe, ɵmod + ɵinj).
+    pub static_fields: Vec<String>,
     /// Child template functions (for @if, @for, @switch blocks).
     pub child_template_functions: Vec<String>,
     /// Set of Ivy runtime symbols needed from `@angular/core`.
@@ -124,7 +124,7 @@ pub fn generate_ivy(
 
     Ok(IvyOutput {
         factory_code,
-        define_component_code: dc,
+        static_fields: vec![dc],
         child_template_functions: child_fns,
         ivy_imports: gen.ivy_imports,
     })

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -941,8 +941,8 @@ mod tests {
             is_void: true,
         })];
         let output = generate_ivy(&comp, &nodes).expect("should generate");
-        assert!(output.define_component_code.contains("decls: 1"));
-        assert!(output.define_component_code.contains("vars: 0"));
+        assert!(output.static_fields[0].contains("decls: 1"));
+        assert!(output.static_fields[0].contains("vars: 0"));
         assert!(output.ivy_imports.contains("\u{0275}\u{0275}element"));
     }
 
@@ -958,7 +958,7 @@ mod tests {
             is_void: false,
         })];
         let output = generate_ivy(&comp, &nodes).expect("should generate");
-        assert!(output.define_component_code.contains("decls: 2"));
+        assert!(output.static_fields[0].contains("decls: 2"));
         assert!(output.ivy_imports.contains("\u{0275}\u{0275}elementStart"));
         assert!(output.ivy_imports.contains("\u{0275}\u{0275}text"));
     }
@@ -971,10 +971,9 @@ mod tests {
             pipes: Vec::new(),
         })];
         let output = generate_ivy(&comp, &nodes).expect("should generate");
-        assert!(output.define_component_code.contains("decls: 1"));
-        assert!(output.define_component_code.contains("vars: 1"));
-        assert!(output
-            .define_component_code
+        assert!(output.static_fields[0].contains("decls: 1"));
+        assert!(output.static_fields[0].contains("vars: 1"));
+        assert!(output.static_fields[0]
             .contains("\u{0275}\u{0275}textInterpolate(ctx.title);"));
     }
 
@@ -994,7 +993,7 @@ mod tests {
         })];
         let output = generate_ivy(&comp, &nodes).expect("should generate");
         assert!(output.ivy_imports.contains("\u{0275}\u{0275}listener"));
-        assert!(output.define_component_code.contains("listener"));
+        assert!(output.static_fields[0].contains("listener"));
     }
 
     #[test]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -312,21 +312,17 @@ impl IvyCodegen {
                 TemplateAttribute::Property { name, expression } => {
                     self.ivy_imports
                         .insert("\u{0275}\u{0275}property".to_string());
-                    self.update.push(format!(
-                        "\u{0275}\u{0275}property('{}', {});",
-                        name,
-                        ctx_expr(expression)
-                    ));
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update
+                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
                     self.var_count += 1;
                 }
                 TemplateAttribute::TwoWayBinding { name, expression } => {
                     self.ivy_imports
                         .insert("\u{0275}\u{0275}property".to_string());
-                    self.update.push(format!(
-                        "\u{0275}\u{0275}property('{}', {});",
-                        name,
-                        ctx_expr(expression)
-                    ));
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update
+                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
                     self.var_count += 1;
                 }
                 TemplateAttribute::ClassBinding {
@@ -335,10 +331,10 @@ impl IvyCodegen {
                 } => {
                     self.ivy_imports
                         .insert("\u{0275}\u{0275}classProp".to_string());
+                    let compiled = self.compile_binding_expr(expression);
                     self.update.push(format!(
-                        "\u{0275}\u{0275}classProp('{}', {});",
+                        "\u{0275}\u{0275}classProp('{}', {compiled});",
                         class_name,
-                        ctx_expr(expression)
                     ));
                     self.var_count += 1;
                 }
@@ -348,20 +344,20 @@ impl IvyCodegen {
                 } => {
                     self.ivy_imports
                         .insert("\u{0275}\u{0275}styleProp".to_string());
+                    let compiled = self.compile_binding_expr(expression);
                     self.update.push(format!(
-                        "\u{0275}\u{0275}styleProp('{}', {});",
+                        "\u{0275}\u{0275}styleProp('{}', {compiled});",
                         property,
-                        ctx_expr(expression)
                     ));
                     self.var_count += 1;
                 }
                 TemplateAttribute::AttrBinding { name, expression } => {
                     self.ivy_imports
                         .insert("\u{0275}\u{0275}attribute".to_string());
+                    let compiled = self.compile_binding_expr(expression);
                     self.update.push(format!(
-                        "\u{0275}\u{0275}attribute('{}', {});",
+                        "\u{0275}\u{0275}attribute('{}', {compiled});",
                         name,
-                        ctx_expr(expression)
                     ));
                     self.var_count += 1;
                 }
@@ -844,6 +840,52 @@ impl IvyCodegen {
         expr
     }
 
+    /// Compile a binding expression, handling embedded Angular pipes at any depth.
+    ///
+    /// Scans for `expr | pipeName` patterns (Angular pipe syntax) anywhere in the
+    /// expression, compiles each to a `ɵɵpipeBind*` call, and applies `ctx.` prefixes.
+    fn compile_binding_expr(&mut self, expression: &str) -> String {
+        let segments = extract_all_pipe_segments(expression);
+        if segments.len() <= 1 {
+            // No pipes found — just compile with ctx. prefix
+            return ctx_expr(expression);
+        }
+
+        // First segment is the base expression, rest are pipe names
+        // But pipes can be nested in sub-expressions. We need to replace
+        // pipe segments bottom-up. For simplicity, handle the common pattern:
+        // the entire expression or sub-expressions of form `(expr | pipe)`.
+        self.replace_pipes_in_expr(expression)
+    }
+
+    /// Replace all `expr | pipeName` patterns in an expression with `ɵɵpipeBind*` calls.
+    fn replace_pipes_in_expr(&mut self, expression: &str) -> String {
+        let trimmed = expression.trim();
+
+        // Check for top-level pipe: `baseExpr | pipeName`
+        if let Some((base, pipe_name)) = split_top_level_pipe(trimmed) {
+            let compiled_base = self.replace_pipes_in_expr(&base);
+            let pipe_slot = self.slot_index;
+            self.slot_index += 1;
+            self.var_count += 1;
+            self.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}pipeBind1".to_string());
+            self.creation.push(format!(
+                "\u{0275}\u{0275}pipe({pipe_slot}, '{}');",
+                pipe_name
+            ));
+            let pipe_var_slot = self.var_count;
+            return format!(
+                "\u{0275}\u{0275}pipeBind1({pipe_slot}, {pipe_var_slot}, {compiled_base})"
+            );
+        }
+
+        // No top-level pipe — scan for `(expr | pipe)` sub-expressions and replace them
+        let result = replace_nested_pipe_parens(trimmed, self);
+        ctx_expr(&result)
+    }
+
     /// Add an `ɵɵadvance()` instruction to the update block if needed.
     fn add_advance(&mut self, _target_slot: u32) {
         self.ivy_imports
@@ -852,6 +894,212 @@ impl IvyCodegen {
         // A more sophisticated implementation would compute exact deltas
         self.update.push("\u{0275}\u{0275}advance();".to_string());
     }
+}
+
+/// Check if an expression has any Angular pipe segments.
+fn extract_all_pipe_segments(expr: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let chars: Vec<char> = expr.trim().chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        match chars[i] {
+            '\'' | '"' | '`' => {
+                let quote = chars[i];
+                i += 1;
+                while i < chars.len() && chars[i] != quote {
+                    if chars[i] == '\\' {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                if i < chars.len() {
+                    i += 1;
+                }
+            }
+            '|' => {
+                if i + 1 < chars.len() && chars[i + 1] == '|' {
+                    i += 2;
+                    continue;
+                }
+                // Possible pipe — check if followed by identifier
+                let mut j = i + 1;
+                while j < chars.len() && chars[j].is_whitespace() {
+                    j += 1;
+                }
+                let name_start = j;
+                while j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '_') {
+                    j += 1;
+                }
+                if j > name_start {
+                    let name: String = chars[name_start..j].iter().collect();
+                    segments.push(name);
+                }
+                i = j;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    segments
+}
+
+/// Split a top-level pipe from an expression: `baseExpr | pipeName` → `(baseExpr, pipeName)`.
+///
+/// Only splits on `|` at parenthesis depth 0 (not inside parens/brackets).
+fn split_top_level_pipe(expr: &str) -> Option<(String, String)> {
+    let chars: Vec<char> = expr.chars().collect();
+    let mut depth = 0i32;
+    let mut last_pipe_pos = None;
+
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '(' | '[' => {
+                depth += 1;
+                i += 1;
+            }
+            ')' | ']' => {
+                depth -= 1;
+                i += 1;
+            }
+            '\'' | '"' | '`' => {
+                let quote = chars[i];
+                i += 1;
+                while i < chars.len() && chars[i] != quote {
+                    if chars[i] == '\\' {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                if i < chars.len() {
+                    i += 1;
+                }
+            }
+            '|' if depth == 0 => {
+                if i + 1 < chars.len() && chars[i + 1] == '|' {
+                    i += 2;
+                    continue;
+                }
+                last_pipe_pos = Some(i);
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    let pos = last_pipe_pos?;
+    let base = expr[..pos].trim().to_string();
+    let rest = expr[pos + 1..].trim();
+
+    // Extract pipe name (first identifier in rest)
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+
+    if name.is_empty() {
+        return None;
+    }
+
+    Some((base, name))
+}
+
+/// Replace `(expr | pipeName)` sub-expressions with compiled pipe calls.
+///
+/// Scans for parenthesized expressions containing a single `|` pipe operator
+/// and replaces them with the compiled `ɵɵpipeBind1(...)` call.
+fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
+    let chars: Vec<char> = expr.chars().collect();
+    let mut result = String::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '(' {
+            // Find matching close paren
+            let start = i;
+            let mut depth = 1;
+            let mut j = i + 1;
+            while j < chars.len() && depth > 0 {
+                match chars[j] {
+                    '(' => depth += 1,
+                    ')' => depth -= 1,
+                    '\'' | '"' | '`' => {
+                        let q = chars[j];
+                        j += 1;
+                        while j < chars.len() && chars[j] != q {
+                            if chars[j] == '\\' {
+                                j += 1;
+                            }
+                            j += 1;
+                        }
+                    }
+                    _ => {}
+                }
+                j += 1;
+            }
+            // chars[start] = '(', chars[j-1] = ')'
+            let inner: String = chars[start + 1..j - 1].iter().collect();
+
+            // Check if the inner expression has a pipe
+            if let Some((base, pipe_name)) = split_top_level_pipe(&inner) {
+                // Compile the base expression recursively
+                let compiled_base = replace_nested_pipe_parens(&base, gen);
+                let compiled_base = ctx_expr(&compiled_base);
+
+                let pipe_slot = gen.slot_index;
+                gen.slot_index += 1;
+                gen.var_count += 1;
+                gen.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
+                gen.ivy_imports
+                    .insert("\u{0275}\u{0275}pipeBind1".to_string());
+                gen.creation
+                    .push(format!("\u{0275}\u{0275}pipe({pipe_slot}, '{pipe_name}');"));
+                let pipe_var_slot = gen.var_count;
+                result.push_str(&format!(
+                    "\u{0275}\u{0275}pipeBind1({pipe_slot}, {pipe_var_slot}, {compiled_base})"
+                ));
+            } else {
+                // No pipe inside — recurse on inner, keep parens
+                let compiled_inner = replace_nested_pipe_parens(&inner, gen);
+                result.push('(');
+                result.push_str(&compiled_inner);
+                result.push(')');
+            }
+            i = j;
+        } else if chars[i] == '\'' || chars[i] == '"' || chars[i] == '`' {
+            // Copy string literals verbatim
+            let q = chars[i];
+            result.push(q);
+            i += 1;
+            while i < chars.len() && chars[i] != q {
+                if chars[i] == '\\' {
+                    result.push(chars[i]);
+                    i += 1;
+                    if i < chars.len() {
+                        result.push(chars[i]);
+                        i += 1;
+                    }
+                } else {
+                    result.push(chars[i]);
+                    i += 1;
+                }
+            }
+            if i < chars.len() {
+                result.push(chars[i]);
+                i += 1;
+            }
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    result
 }
 
 /// Wrap a template expression with `ctx.` if it's a simple property path.
@@ -1258,5 +1506,58 @@ mod tests {
             ctx_expr("isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'"),
             "ctx.isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'"
         );
+    }
+
+    #[test]
+    fn test_extract_all_pipe_segments() {
+        let segments = extract_all_pipe_segments("'NAV.UPGRADE' | translate");
+        assert_eq!(segments, vec!["translate"]);
+
+        let segments = extract_all_pipe_segments("foo || bar");
+        assert!(segments.is_empty(), "|| should not be treated as pipe");
+
+        let segments =
+            extract_all_pipe_segments("x === 'a' ? ('B' | translate) : ('C' | translate)");
+        assert_eq!(segments, vec!["translate", "translate"]);
+    }
+
+    #[test]
+    fn test_split_top_level_pipe() {
+        assert_eq!(
+            split_top_level_pipe("'NAV.UPGRADE' | translate"),
+            Some(("'NAV.UPGRADE'".to_string(), "translate".to_string()))
+        );
+        assert_eq!(split_top_level_pipe("foo || bar"), None,);
+        // Pipe inside parens is not top-level
+        assert_eq!(split_top_level_pipe("x ? ('A' | translate) : 'B'"), None,);
+    }
+
+    #[test]
+    fn test_compile_binding_expr_with_nested_pipes() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "div".to_string(),
+            attributes: vec![TemplateAttribute::AttrBinding {
+                name: "title".to_string(),
+                expression:
+                    "x === 'free' ? ('NAV.UPGRADE' | translate) : ('NAV.BILLING' | translate)"
+                        .to_string(),
+            }],
+            children: vec![],
+            is_void: false,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        let dc = &output.static_fields[0];
+        // Should have pipeBind1 calls instead of raw | translate
+        assert!(
+            dc.contains("pipeBind1"),
+            "should compile pipes to pipeBind1: {dc}"
+        );
+        assert!(
+            !dc.contains("| translate"),
+            "should not have raw pipe syntax: {dc}"
+        );
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}pipe"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}pipeBind1"));
     }
 }

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -28,6 +28,8 @@ struct IvyCodegen {
     child_templates: Vec<ChildTemplate>,
     ivy_imports: BTreeSet<String>,
     child_counter: u32,
+    /// Collected static attribute arrays for the `consts` field.
+    consts: Vec<String>,
 }
 
 struct ChildTemplate {
@@ -52,6 +54,7 @@ pub fn generate_ivy(
         child_templates: Vec::new(),
         ivy_imports: BTreeSet::new(),
         child_counter: 0,
+        consts: Vec::new(),
     };
 
     gen.ivy_imports
@@ -96,6 +99,9 @@ pub fn generate_ivy(
     dc.push_str(&format!("    selectors: [['{}']],\n", component.selector));
     if component.standalone {
         dc.push_str("    standalone: true,\n");
+    }
+    if !gen.consts.is_empty() {
+        dc.push_str(&format!("    consts: [{}],\n", gen.consts.join(", ")));
     }
     dc.push_str(&format!("    decls: {decls},\n"));
     dc.push_str(&format!("    vars: {vars},\n"));
@@ -238,9 +244,9 @@ impl IvyCodegen {
                 self.creation
                     .push(format!("{instr}({slot}, '{}');", el.tag));
             } else {
-                let attrs_str = format_static_attrs(&static_attrs);
+                let const_idx = self.register_const(&static_attrs);
                 self.creation
-                    .push(format!("{instr}({slot}, '{}', {attrs_str});", el.tag));
+                    .push(format!("{instr}({slot}, '{}', {const_idx});", el.tag));
             }
         } else {
             let (start_instr, end_instr) = if is_ng_container {
@@ -257,9 +263,9 @@ impl IvyCodegen {
                 self.creation
                     .push(format!("{start_instr}({slot}, '{}');", el.tag));
             } else {
-                let attrs_str = format_static_attrs(&static_attrs);
+                let const_idx = self.register_const(&static_attrs);
                 self.creation
-                    .push(format!("{start_instr}({slot}, '{}', {attrs_str});", el.tag));
+                    .push(format!("{start_instr}({slot}, '{}', {const_idx});", el.tag));
             }
 
             // Event listeners and two-way binding listeners in creation block
@@ -447,6 +453,7 @@ impl IvyCodegen {
         let parent_var = self.var_count;
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
+        let parent_consts = std::mem::take(&mut self.consts);
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -481,6 +488,7 @@ impl IvyCodegen {
         self.var_count = parent_var;
         self.creation = parent_creation;
         self.update = parent_update;
+        self.consts = parent_consts;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -709,6 +717,7 @@ impl IvyCodegen {
         let parent_var = self.var_count;
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
+        let parent_consts = std::mem::take(&mut self.consts);
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -744,6 +753,7 @@ impl IvyCodegen {
         self.var_count = parent_var;
         self.creation = parent_creation;
         self.update = parent_update;
+        self.consts = parent_consts;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -764,6 +774,7 @@ impl IvyCodegen {
         let parent_var = self.var_count;
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
+        let parent_consts = std::mem::take(&mut self.consts);
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -800,6 +811,7 @@ impl IvyCodegen {
         self.var_count = parent_var;
         self.creation = parent_creation;
         self.update = parent_update;
+        self.consts = parent_consts;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -898,6 +910,14 @@ impl IvyCodegen {
         // from ctx. prefixing by is_builtin().
         let result = replace_nested_pipe_parens(trimmed, self);
         ctx_expr(&result)
+    }
+
+    /// Register a static attribute array in the `consts` table and return its index.
+    fn register_const(&mut self, attrs: &[(&str, &str)]) -> usize {
+        let formatted = format_static_attrs(attrs);
+        let idx = self.consts.len();
+        self.consts.push(formatted);
+        idx
     }
 
     /// Add an `ɵɵadvance()` instruction to the update block if needed.

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -112,13 +112,9 @@ pub fn generate_ivy(
     dc.push_str(&template_body);
     dc.push_str("    }");
 
-    // Add imports for standalone component scope resolution
+    // Add dependencies for component scope resolution
     if let Some(ref imports_src) = component.imports_source {
-        if component.standalone {
-            dc.push_str(&format!(",\n    imports: () => {imports_src}"));
-        } else {
-            dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
-        }
+        dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
     }
     if let Some(ref styles_src) = component.styles_source {
         dc.push_str(&format!(",\n    styles: {styles_src}"));

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -858,13 +858,81 @@ impl IvyCodegen {
 ///
 /// Simple paths like `title` or `foo.bar` become `ctx.title` / `ctx.foo.bar`.
 /// Complex expressions like `'text' + prop` or `fn()` are left as-is.
+/// Compile an Angular template expression to JavaScript by adding `ctx.` prefixes
+/// to component property references and stripping TypeScript non-null assertions.
+///
+/// Uses oxc to parse the expression AST and walk it, ensuring all standalone
+/// identifiers (not member properties, not builtins) get the `ctx.` prefix.
 fn ctx_expr(expr: &str) -> String {
     let trimmed = expr.trim();
-    if is_simple_property_path(trimmed) {
-        format!("ctx.{trimmed}")
-    } else {
-        trimmed.to_string()
+    if trimmed.is_empty() {
+        return String::new();
     }
+
+    // Fast path for simple property paths
+    if is_simple_property_path(trimmed) {
+        return format!("ctx.{trimmed}");
+    }
+
+    // Parse expression with oxc for proper AST-based rewriting
+    let wrapper = format!("var __expr = {trimmed};");
+    let alloc = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&alloc, &wrapper, oxc_span::SourceType::tsx()).parse();
+
+    if !parsed.errors.is_empty() || parsed.panicked {
+        // If parsing fails, fall back to simple heuristic
+        return trimmed.to_string();
+    }
+
+    // Extract the initializer expression
+    let init_expr = match parsed.program.body.first() {
+        Some(oxc_ast::ast::Statement::VariableDeclaration(decl)) => {
+            decl.declarations.first().and_then(|d| d.init.as_ref())
+        }
+        _ => None,
+    };
+
+    let init_expr = match init_expr {
+        Some(e) => e,
+        None => return trimmed.to_string(),
+    };
+
+    // Collect positions of identifiers that need `ctx.` prefix and `!` to remove
+    let mut ctx_inserts: Vec<u32> = Vec::new();
+    let mut remove_ranges: Vec<(u32, u32)> = Vec::new();
+    collect_ctx_rewrites(init_expr, &mut ctx_inserts, &mut remove_ranges, false);
+
+    // Map wrapper offsets back to expression offsets
+    let expr_offset = "var __expr = ".len() as u32;
+    let mut result = trimmed.to_string();
+
+    // Apply removals first (sorted reverse)
+    let mut sorted_removes: Vec<(usize, usize)> = remove_ranges
+        .iter()
+        .map(|(s, e)| ((s - expr_offset) as usize, (e - expr_offset) as usize))
+        .collect();
+    sorted_removes.sort_by(|a, b| b.0.cmp(&a.0));
+    for (s, e) in &sorted_removes {
+        if *s <= result.len() && *e <= result.len() {
+            result.replace_range(*s..*e, "");
+        }
+    }
+
+    // Apply ctx. insertions (sorted reverse)
+    let mut sorted_inserts: Vec<usize> = ctx_inserts
+        .iter()
+        .map(|off| (off - expr_offset) as usize)
+        .collect();
+    sorted_inserts.sort_unstable();
+    sorted_inserts.dedup();
+    sorted_inserts.reverse();
+    for off in &sorted_inserts {
+        if *off <= result.len() {
+            result.insert_str(*off, "ctx.");
+        }
+    }
+
+    result
 }
 
 /// Check if a string is a simple property path (e.g. `foo`, `foo.bar`, `$data`).
@@ -875,6 +943,136 @@ fn is_simple_property_path(s: &str) -> bool {
             .is_some_and(|c| c.is_alphabetic() || c == '_' || c == '$')
         && s.chars()
             .all(|c| c.is_alphanumeric() || c == '_' || c == '.' || c == '$')
+}
+
+/// Recursively collect identifier positions that need `ctx.` prefix and
+/// TypeScript non-null assertion `!` positions to remove.
+fn collect_ctx_rewrites(
+    expr: &oxc_ast::ast::Expression<'_>,
+    ctx_inserts: &mut Vec<u32>,
+    remove_ranges: &mut Vec<(u32, u32)>,
+    is_member_property: bool,
+) {
+    use oxc_ast::ast::*;
+    use oxc_span::GetSpan;
+
+    fn is_builtin(name: &str) -> bool {
+        matches!(
+            name,
+            "null"
+                | "undefined"
+                | "true"
+                | "false"
+                | "NaN"
+                | "Infinity"
+                | "this"
+                | "Math"
+                | "Date"
+                | "JSON"
+                | "console"
+                | "window"
+                | "document"
+                | "Array"
+                | "Object"
+                | "String"
+                | "Number"
+                | "Boolean"
+                | "Error"
+                | "RegExp"
+                | "Symbol"
+                | "Promise"
+                | "Map"
+                | "Set"
+                | "$event"
+        )
+    }
+
+    match expr {
+        Expression::Identifier(id) => {
+            if !is_member_property && !is_builtin(&id.name) {
+                ctx_inserts.push(id.span.start);
+            }
+        }
+        Expression::CallExpression(call) => {
+            collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false);
+            for arg in &call.arguments {
+                if let Argument::SpreadElement(spread) = arg {
+                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
+                } else {
+                    collect_ctx_rewrites(arg.to_expression(), ctx_inserts, remove_ranges, false);
+                }
+            }
+        }
+        Expression::StaticMemberExpression(member) => {
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ComputedMemberExpression(member) => {
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&member.expression, ctx_inserts, remove_ranges, false);
+        }
+        Expression::UnaryExpression(unary) => {
+            collect_ctx_rewrites(&unary.argument, ctx_inserts, remove_ranges, false);
+        }
+        Expression::BinaryExpression(binary) => {
+            collect_ctx_rewrites(&binary.left, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&binary.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::LogicalExpression(logical) => {
+            collect_ctx_rewrites(&logical.left, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&logical.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ConditionalExpression(cond) => {
+            collect_ctx_rewrites(&cond.test, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.consequent, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.alternate, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            collect_ctx_rewrites(&paren.expression, ctx_inserts, remove_ranges, false);
+        }
+        Expression::AssignmentExpression(assign) => {
+            if let AssignmentTarget::AssignmentTargetIdentifier(id) = &assign.left {
+                if !is_builtin(&id.name) {
+                    ctx_inserts.push(id.span.start);
+                }
+            }
+            collect_ctx_rewrites(&assign.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::TSNonNullExpression(non_null) => {
+            collect_ctx_rewrites(
+                &non_null.expression,
+                ctx_inserts,
+                remove_ranges,
+                is_member_property,
+            );
+            let inner_end = non_null.expression.span().end;
+            let outer_end = non_null.span.end;
+            if outer_end > inner_end {
+                remove_ranges.push((inner_end, outer_end));
+            }
+        }
+        Expression::ObjectExpression(obj) => {
+            for prop in &obj.properties {
+                if let ObjectPropertyKind::ObjectProperty(p) = prop {
+                    collect_ctx_rewrites(&p.value, ctx_inserts, remove_ranges, false);
+                }
+            }
+        }
+        Expression::ArrayExpression(arr) => {
+            for elem in &arr.elements {
+                if let ArrayExpressionElement::SpreadElement(spread) = elem {
+                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
+                } else if !elem.is_elision() {
+                    collect_ctx_rewrites(elem.to_expression(), ctx_inserts, remove_ranges, false);
+                }
+            }
+        }
+        Expression::TemplateLiteral(tpl) => {
+            for expr in &tpl.expressions {
+                collect_ctx_rewrites(expr, ctx_inserts, remove_ranges, false);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Build a conditional expression for @if chains.
@@ -973,8 +1171,7 @@ mod tests {
         let output = generate_ivy(&comp, &nodes).expect("should generate");
         assert!(output.static_fields[0].contains("decls: 1"));
         assert!(output.static_fields[0].contains("vars: 1"));
-        assert!(output.static_fields[0]
-            .contains("\u{0275}\u{0275}textInterpolate(ctx.title);"));
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}textInterpolate(ctx.title);"));
     }
 
     #[test]
@@ -1003,5 +1200,63 @@ mod tests {
         let output = generate_ivy(&comp, &nodes).expect("should generate");
         assert!(output.factory_code.contains("TestComponent_Factory"));
         assert!(output.factory_code.contains("new (t || TestComponent)()"));
+    }
+
+    #[test]
+    fn test_ctx_expr_simple() {
+        assert_eq!(ctx_expr("title"), "ctx.title");
+        assert_eq!(ctx_expr("foo.bar"), "ctx.foo.bar");
+    }
+
+    #[test]
+    fn test_ctx_expr_negation() {
+        assert_eq!(ctx_expr("!isCollapsed"), "!ctx.isCollapsed");
+    }
+
+    #[test]
+    fn test_ctx_expr_logical_or() {
+        assert_eq!(
+            ctx_expr("!isCollapsed || mobileMenu.isMobileMenuOpen()"),
+            "!ctx.isCollapsed || ctx.mobileMenu.isMobileMenuOpen()"
+        );
+    }
+
+    #[test]
+    fn test_ctx_expr_method_call() {
+        assert_eq!(
+            ctx_expr("getBadgeClass(subscription().tier)"),
+            "ctx.getBadgeClass(ctx.subscription().tier)"
+        );
+    }
+
+    #[test]
+    fn test_ctx_expr_ternary() {
+        assert_eq!(
+            ctx_expr("isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"),
+            "ctx.isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        );
+    }
+
+    #[test]
+    fn test_ctx_expr_ts_non_null_stripped() {
+        assert_eq!(ctx_expr("subscription()!.tier"), "ctx.subscription().tier");
+    }
+
+    #[test]
+    fn test_ctx_expr_object_literal() {
+        assert_eq!(ctx_expr("{ exact: true }"), "{ exact: true }");
+    }
+
+    #[test]
+    fn test_ctx_expr_negation_of_member() {
+        assert_eq!(ctx_expr("!auth.token"), "!ctx.auth.token");
+    }
+
+    #[test]
+    fn test_ctx_expr_style_transform() {
+        assert_eq!(
+            ctx_expr("isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'"),
+            "ctx.isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'"
+        );
     }
 }

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -112,9 +112,19 @@ pub fn generate_ivy(
     dc.push_str(&template_body);
     dc.push_str("    }");
 
-    // Add dependencies for component scope resolution
+    // For standalone components, use getComponentDepsFactory to resolve NgModule imports
+    // to their exported directives/pipes at runtime. This matches what Angular's AOT compiler does.
     if let Some(ref imports_src) = component.imports_source {
-        dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
+        if component.standalone {
+            gen.ivy_imports
+                .insert("\u{0275}\u{0275}getComponentDepsFactory".to_string());
+            dc.push_str(&format!(
+                ",\n    dependencies: \u{0275}\u{0275}getComponentDepsFactory({}, () => {imports_src})",
+                component.class_name
+            ));
+        } else {
+            dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
+        }
     }
     if let Some(ref styles_src) = component.styles_source {
         dc.push_str(&format!(",\n    styles: {styles_src}"));

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -268,9 +268,10 @@ impl IvyCodegen {
                     TemplateAttribute::Event { name, handler } => {
                         self.ivy_imports
                             .insert("\u{0275}\u{0275}listener".to_string());
+                        let compiled_handler = compile_event_handler(handler);
                         self.creation.push(format!(
-                            "\u{0275}\u{0275}listener('{}', function() {{ return ctx.{}; }});",
-                            name, handler
+                            "\u{0275}\u{0275}listener('{}', function($event) {{ {compiled_handler} }});",
+                            name,
                         ));
                     }
                     TemplateAttribute::TwoWayBinding { name, expression } => {
@@ -510,9 +511,9 @@ impl IvyCodegen {
 
         self.creation.push(format!("\u{0275}\u{0275}text({slot});"));
 
-        // Build the expression with pipe wrapping
+        // Build the expression with pipe wrapping and nested pipe compilation
         let expr = if interp.pipes.is_empty() {
-            ctx_expr(&interp.expression)
+            self.compile_binding_expr(&interp.expression)
         } else {
             self.wrap_with_pipes(&interp.expression, &interp.pipes)
         };
@@ -809,7 +810,7 @@ impl IvyCodegen {
     }
 
     fn wrap_with_pipes(&mut self, base_expr: &str, pipes: &[PipeCall]) -> String {
-        let mut expr = ctx_expr(base_expr);
+        let mut expr = self.compile_binding_expr(base_expr);
         for pipe in pipes {
             let pipe_slot = self.slot_index;
             self.slot_index += 1;
@@ -846,7 +847,7 @@ impl IvyCodegen {
     /// expression, compiles each to a `ɵɵpipeBind*` call, and applies `ctx.` prefixes.
     fn compile_binding_expr(&mut self, expression: &str) -> String {
         let segments = extract_all_pipe_segments(expression);
-        if segments.len() <= 1 {
+        if segments.is_empty() {
             // No pipes found — just compile with ctx. prefix
             return ctx_expr(expression);
         }
@@ -862,22 +863,33 @@ impl IvyCodegen {
     fn replace_pipes_in_expr(&mut self, expression: &str) -> String {
         let trimmed = expression.trim();
 
-        // Check for top-level pipe: `baseExpr | pipeName`
-        if let Some((base, pipe_name)) = split_top_level_pipe(trimmed) {
+        // Check for top-level pipe: `baseExpr | pipeName : arg1 : arg2`
+        if let Some((base, pipe_name, args)) = split_top_level_pipe_with_args(trimmed) {
             let compiled_base = self.replace_pipes_in_expr(&base);
             let pipe_slot = self.slot_index;
             self.slot_index += 1;
-            self.var_count += 1;
+            self.var_count += 1 + args.len() as u32;
             self.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
-            self.ivy_imports
-                .insert("\u{0275}\u{0275}pipeBind1".to_string());
+
+            let bind_fn = match args.len() {
+                0 => "\u{0275}\u{0275}pipeBind1",
+                1 => "\u{0275}\u{0275}pipeBind2",
+                2 => "\u{0275}\u{0275}pipeBind3",
+                _ => "\u{0275}\u{0275}pipeBindV",
+            };
+            self.ivy_imports.insert(bind_fn.to_string());
             self.creation.push(format!(
                 "\u{0275}\u{0275}pipe({pipe_slot}, '{}');",
                 pipe_name
             ));
             let pipe_var_slot = self.var_count;
+            if args.is_empty() {
+                return format!("{bind_fn}({pipe_slot}, {pipe_var_slot}, {compiled_base})");
+            }
+            let compiled_args: Vec<String> = args.iter().map(|a| ctx_expr(a)).collect();
             return format!(
-                "\u{0275}\u{0275}pipeBind1({pipe_slot}, {pipe_var_slot}, {compiled_base})"
+                "{bind_fn}({pipe_slot}, {pipe_var_slot}, {compiled_base}, {})",
+                compiled_args.join(", ")
             );
         }
 
@@ -1011,6 +1023,70 @@ fn split_top_level_pipe(expr: &str) -> Option<(String, String)> {
     Some((base, name))
 }
 
+/// Split a top-level pipe from an expression, including pipe arguments.
+///
+/// Returns `(base_expression, pipe_name, vec_of_args)`.
+/// Pipe arguments are separated by `:` after the pipe name.
+fn split_top_level_pipe_with_args(expr: &str) -> Option<(String, String, Vec<String>)> {
+    let (base, name) = split_top_level_pipe(expr)?;
+
+    // Find where the pipe name ends in the original expression
+    let pipe_pos = base.len(); // position of `|`
+    let rest = expr[pipe_pos + 1..].trim();
+    let after_name = &rest[name.len()..];
+
+    // Parse colon-separated arguments
+    let mut args = Vec::new();
+    let mut remaining = after_name.trim();
+    while remaining.starts_with(':') {
+        remaining = remaining[1..].trim();
+        // Extract the argument (up to next `:` at depth 0, or end)
+        let mut depth = 0i32;
+        let mut end = 0;
+        let chars: Vec<char> = remaining.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            match chars[i] {
+                '(' | '[' => {
+                    depth += 1;
+                    i += 1;
+                }
+                ')' | ']' => {
+                    depth -= 1;
+                    i += 1;
+                }
+                '\'' | '"' | '`' => {
+                    let q = chars[i];
+                    i += 1;
+                    while i < chars.len() && chars[i] != q {
+                        if chars[i] == '\\' {
+                            i += 1;
+                        }
+                        i += 1;
+                    }
+                    if i < chars.len() {
+                        i += 1;
+                    }
+                }
+                ':' if depth == 0 => {
+                    break;
+                }
+                _ => {
+                    i += 1;
+                }
+            }
+            end = i;
+        }
+        let arg = remaining[..end].trim().to_string();
+        if !arg.is_empty() {
+            args.push(arg);
+        }
+        remaining = &remaining[end..];
+    }
+
+    Some((base, name, args))
+}
+
 /// Replace `(expr | pipeName)` sub-expressions with compiled pipe calls.
 ///
 /// Scans for parenthesized expressions containing a single `|` pipe operator
@@ -1047,24 +1123,38 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
             // chars[start] = '(', chars[j-1] = ')'
             let inner: String = chars[start + 1..j - 1].iter().collect();
 
-            // Check if the inner expression has a pipe
-            if let Some((base, pipe_name)) = split_top_level_pipe(&inner) {
+            // Check if the inner expression has a pipe (with optional arguments)
+            if let Some((base, pipe_name, args)) = split_top_level_pipe_with_args(&inner) {
                 // Compile the base expression recursively
                 let compiled_base = replace_nested_pipe_parens(&base, gen);
                 let compiled_base = ctx_expr(&compiled_base);
 
                 let pipe_slot = gen.slot_index;
                 gen.slot_index += 1;
-                gen.var_count += 1;
+                gen.var_count += 1 + args.len() as u32;
                 gen.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
-                gen.ivy_imports
-                    .insert("\u{0275}\u{0275}pipeBind1".to_string());
+
+                let bind_fn = match args.len() {
+                    0 => "\u{0275}\u{0275}pipeBind1",
+                    1 => "\u{0275}\u{0275}pipeBind2",
+                    2 => "\u{0275}\u{0275}pipeBind3",
+                    _ => "\u{0275}\u{0275}pipeBindV",
+                };
+                gen.ivy_imports.insert(bind_fn.to_string());
                 gen.creation
                     .push(format!("\u{0275}\u{0275}pipe({pipe_slot}, '{pipe_name}');"));
                 let pipe_var_slot = gen.var_count;
-                result.push_str(&format!(
-                    "\u{0275}\u{0275}pipeBind1({pipe_slot}, {pipe_var_slot}, {compiled_base})"
-                ));
+                if args.is_empty() {
+                    result.push_str(&format!(
+                        "{bind_fn}({pipe_slot}, {pipe_var_slot}, {compiled_base})"
+                    ));
+                } else {
+                    let compiled_args: Vec<String> = args.iter().map(|a| ctx_expr(a)).collect();
+                    result.push_str(&format!(
+                        "{bind_fn}({pipe_slot}, {pipe_var_slot}, {compiled_base}, {})",
+                        compiled_args.join(", ")
+                    ));
+                }
             } else {
                 // No pipe inside — recurse on inner, keep parens
                 let compiled_inner = replace_nested_pipe_parens(&inner, gen);
@@ -1388,6 +1478,37 @@ fn format_static_attrs(attrs: &[(&str, &str)]) -> String {
         })
         .collect();
     format!("[{}]", pairs.join(", "))
+}
+
+/// Compile an Angular event handler expression.
+///
+/// Handles multi-statement handlers like `$event.stopPropagation(); doSomething()`
+/// by splitting on `;`, applying `ctx.` to each statement, and adding `return` to
+/// the last statement.
+fn compile_event_handler(handler: &str) -> String {
+    let trimmed = handler.trim();
+    // Split on semicolons (respecting strings and parens)
+    let statements: Vec<&str> = trimmed
+        .split(';')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if statements.is_empty() {
+        return String::new();
+    }
+
+    let mut parts = Vec::new();
+    for (i, stmt) in statements.iter().enumerate() {
+        let compiled = ctx_expr(stmt);
+        if i == statements.len() - 1 {
+            parts.push(format!("return {compiled};"));
+        } else {
+            parts.push(format!("{compiled};"));
+        }
+    }
+
+    parts.join(" ")
 }
 
 /// Escape a string for use inside a single-quoted JavaScript string literal.

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -113,13 +113,14 @@ pub fn generate_ivy(
     dc.push_str("    }");
 
     // For standalone components, use getComponentDepsFactory to resolve NgModule imports
-    // to their exported directives/pipes at runtime. This matches what Angular's AOT compiler does.
+    // to their exported directives/pipes at runtime via the depsTracker.
+    // rawImports must be the direct array, not wrapped in a function.
     if let Some(ref imports_src) = component.imports_source {
         if component.standalone {
             gen.ivy_imports
                 .insert("\u{0275}\u{0275}getComponentDepsFactory".to_string());
             dc.push_str(&format!(
-                ",\n    dependencies: \u{0275}\u{0275}getComponentDepsFactory({}, () => {imports_src})",
+                ",\n    dependencies: \u{0275}\u{0275}getComponentDepsFactory({}, {imports_src})",
                 component.class_name
             ));
         } else {

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -112,9 +112,9 @@ pub fn generate_ivy(
     dc.push_str(&template_body);
     dc.push_str("    }");
 
-    // Add dependencies if imports exist
+    // Add dependencies if imports exist (wrapped in function for forward reference support)
     if let Some(ref imports_src) = component.imports_source {
-        dc.push_str(&format!(",\n    dependencies: {imports_src}"));
+        dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
     }
     if let Some(ref styles_src) = component.styles_source {
         dc.push_str(&format!(",\n    styles: {styles_src}"));

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -494,12 +494,7 @@ impl IvyCodegen {
         self.slot_index += 1;
         self.ivy_imports.insert("\u{0275}\u{0275}text".to_string());
 
-        let escaped = text
-            .value
-            .replace('\\', "\\\\")
-            .replace('\'', "\\'")
-            .replace('\n', "\\n")
-            .replace('\r', "\\r");
+        let escaped = escape_js_string(&text.value);
         self.creation
             .push(format!("\u{0275}\u{0275}text({slot}, '{escaped}');"));
     }
@@ -1385,9 +1380,22 @@ fn build_conditional_expr(
 fn format_static_attrs(attrs: &[(&str, &str)]) -> String {
     let pairs: Vec<String> = attrs
         .iter()
-        .flat_map(|(k, v)| vec![format!("'{k}'"), format!("'{v}'")])
+        .flat_map(|(k, v)| {
+            vec![
+                format!("'{}'", escape_js_string(k)),
+                format!("'{}'", escape_js_string(v)),
+            ]
+        })
         .collect();
     format!("[{}]", pairs.join(", "))
+}
+
+/// Escape a string for use inside a single-quoted JavaScript string literal.
+fn escape_js_string(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
 }
 
 #[cfg(test)]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -112,9 +112,13 @@ pub fn generate_ivy(
     dc.push_str(&template_body);
     dc.push_str("    }");
 
-    // Add dependencies if imports exist (wrapped in function for forward reference support)
+    // Add imports for standalone component scope resolution
     if let Some(ref imports_src) = component.imports_source {
-        dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
+        if component.standalone {
+            dc.push_str(&format!(",\n    imports: () => {imports_src}"));
+        } else {
+            dc.push_str(&format!(",\n    dependencies: () => {imports_src}"));
+        }
     }
     if let Some(ref styles_src) = component.styles_source {
         dc.push_str(&format!(",\n    styles: {styles_src}"));

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -494,7 +494,12 @@ impl IvyCodegen {
         self.slot_index += 1;
         self.ivy_imports.insert("\u{0275}\u{0275}text".to_string());
 
-        let escaped = text.value.replace('\'', "\\'");
+        let escaped = text
+            .value
+            .replace('\\', "\\\\")
+            .replace('\'', "\\'")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r");
         self.creation
             .push(format!("\u{0275}\u{0275}text({slot}, '{escaped}');"));
     }
@@ -881,7 +886,9 @@ impl IvyCodegen {
             );
         }
 
-        // No top-level pipe — scan for `(expr | pipe)` sub-expressions and replace them
+        // No top-level pipe — scan for `(expr | pipe)` sub-expressions and replace them.
+        // Apply ctx_expr after pipe replacement; ɵɵ-prefixed symbols are excluded
+        // from ctx. prefixing by is_builtin().
         let result = replace_nested_pipe_parens(trimmed, self);
         ctx_expr(&result)
     }
@@ -1231,6 +1238,10 @@ fn collect_ctx_rewrites(
     use oxc_span::GetSpan;
 
     fn is_builtin(name: &str) -> bool {
+        // Angular runtime symbols (ɵɵ-prefixed) are not component properties
+        if name.starts_with('\u{0275}') {
+            return true;
+        }
         matches!(
             name,
             "null"

--- a/crates/template-compiler/src/directive_codegen.rs
+++ b/crates/template-compiler/src/directive_codegen.rs
@@ -1,0 +1,161 @@
+//! AOT codegen for `@Directive` decorators.
+//!
+//! Generates `ɵfac` (factory) and `ɵdir` (`ɵɵdefineDirective`) static fields.
+//!
+//! ## Example
+//! ```text
+//! // Input:
+//! @Directive({ selector: '[appHighlight]', standalone: true })
+//! export class HighlightDirective {}
+//!
+//! // Output:
+//! export class HighlightDirective {
+//!   static ɵfac = function HighlightDirective_Factory(t: any) { return new (t || HighlightDirective)(); };
+//!   static ɵdir = ɵɵdefineDirective({ type: HighlightDirective, selectors: [['', 'appHighlight', '']], standalone: true });
+//! }
+//! ```
+
+use std::collections::BTreeSet;
+
+use ngc_diagnostics::NgcResult;
+
+use crate::codegen::IvyOutput;
+use crate::extract::ExtractedDirective;
+use crate::factory_codegen;
+use crate::selector;
+
+/// Generate Ivy output for a `@Directive` decorator.
+pub fn generate_directive_ivy(extracted: &ExtractedDirective) -> NgcResult<IvyOutput> {
+    let name = &extracted.class_name;
+    let mut ivy_imports = BTreeSet::new();
+
+    ivy_imports.insert("\u{0275}\u{0275}defineDirective".to_string());
+
+    // Generate factory with DI
+    let (factory_code, inject_imports) =
+        factory_codegen::generate_factory(name, &extracted.constructor_params);
+    for imp in inject_imports {
+        ivy_imports.insert(imp);
+    }
+
+    // Build ɵdir definition
+    let mut props = Vec::new();
+    props.push(format!("type: {name}"));
+
+    if let Some(ref sel) = extracted.selector {
+        props.push(format!("selectors: {}", selector::parse_selector(sel)));
+    }
+
+    if let Some(ref inputs_src) = extracted.inputs_source {
+        props.push(format!("inputs: {inputs_src}"));
+    }
+
+    if let Some(ref outputs_src) = extracted.outputs_source {
+        props.push(format!("outputs: {outputs_src}"));
+    }
+
+    if let Some(ref export_as) = extracted.export_as {
+        let parts: Vec<&str> = export_as.split(',').map(|s| s.trim()).collect();
+        let arr = parts
+            .iter()
+            .map(|s| format!("\"{s}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        props.push(format!("exportAs: [{arr}]"));
+    }
+
+    if extracted.standalone {
+        props.push("standalone: true".to_string());
+    }
+
+    let define_code = format!(
+        "static \u{0275}dir = \u{0275}\u{0275}defineDirective({{ {} }})",
+        props.join(", ")
+    );
+
+    Ok(IvyOutput {
+        factory_code,
+        static_fields: vec![define_code],
+        child_template_functions: Vec::new(),
+        ivy_imports,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::{ConstructorParam, DecoratorCommon};
+
+    fn make_directive(
+        class_name: &str,
+        selector: Option<&str>,
+        standalone: bool,
+    ) -> ExtractedDirective {
+        ExtractedDirective {
+            class_name: class_name.to_string(),
+            selector: selector.map(|s| s.to_string()),
+            standalone,
+            inputs_source: None,
+            outputs_source: None,
+            export_as: None,
+            constructor_params: Vec::new(),
+            common: DecoratorCommon {
+                decorator_span: (0, 0),
+                class_body_start: 0,
+                angular_core_import_span: None,
+                other_angular_core_imports: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_directive_basic() {
+        let extracted = make_directive("HighlightDirective", Some("[appHighlight]"), true);
+        let output = generate_directive_ivy(&extracted).unwrap();
+        assert!(output.factory_code.contains("HighlightDirective_Factory"));
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}defineDirective"));
+        assert!(output.static_fields[0].contains("type: HighlightDirective"));
+        assert!(output.static_fields[0].contains("selectors: [['', 'appHighlight', '']]"));
+        assert!(output.static_fields[0].contains("standalone: true"));
+    }
+
+    #[test]
+    fn test_directive_element_selector() {
+        let extracted = make_directive("MyComp", Some("my-comp"), false);
+        let output = generate_directive_ivy(&extracted).unwrap();
+        assert!(output.static_fields[0].contains("selectors: [['my-comp']]"));
+        assert!(!output.static_fields[0].contains("standalone"));
+    }
+
+    #[test]
+    fn test_directive_no_selector() {
+        let extracted = make_directive("AbstractDir", None, false);
+        let output = generate_directive_ivy(&extracted).unwrap();
+        assert!(!output.static_fields[0].contains("selectors"));
+    }
+
+    #[test]
+    fn test_directive_with_deps() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.constructor_params = vec![ConstructorParam {
+            type_name: Some("ElementRef".to_string()),
+            inject_token: None,
+            optional: false,
+            self_: false,
+            skip_self: false,
+            host: false,
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        assert!(output
+            .factory_code
+            .contains("\u{0275}\u{0275}inject(ElementRef)"));
+    }
+
+    #[test]
+    fn test_directive_with_export_as() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.export_as = Some("myDir".to_string());
+        let output = generate_directive_ivy(&extracted).unwrap();
+        assert!(output.static_fields[0].contains("exportAs: [\"myDir\"]"));
+    }
+}

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -389,10 +389,7 @@ pub fn extract_injectable(
 /// Extract `@Directive` metadata from a TypeScript source file.
 ///
 /// Returns `None` if no `@Directive` decorator is found.
-pub fn extract_directive(
-    source: &str,
-    file_path: &Path,
-) -> NgcResult<Option<ExtractedDirective>> {
+pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<ExtractedDirective>> {
     let allocator = Allocator::new();
     let source_type =
         SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {
@@ -590,10 +587,7 @@ pub fn extract_pipe(source: &str, file_path: &Path) -> NgcResult<Option<Extracte
 /// Extract `@NgModule` metadata from a TypeScript source file.
 ///
 /// Returns `None` if no `@NgModule` decorator is found.
-pub fn extract_ng_module(
-    source: &str,
-    file_path: &Path,
-) -> NgcResult<Option<ExtractedNgModule>> {
+pub fn extract_ng_module(source: &str, file_path: &Path) -> NgcResult<Option<ExtractedNgModule>> {
     let allocator = Allocator::new();
     let source_type =
         SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -2,7 +2,10 @@ use std::path::Path;
 
 use ngc_diagnostics::{NgcError, NgcResult};
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, Decorator, Expression, ObjectPropertyKind, PropertyKey, Statement};
+use oxc_ast::ast::{
+    Argument, Class, Decorator, Expression, FormalParameter, FormalParameters,
+    MethodDefinitionKind, ObjectPropertyKind, PropertyKey, Statement, TSTypeAnnotation,
+};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 
@@ -161,14 +164,667 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
 
 /// Find the `@Component(...)` decorator in a list of decorators.
 fn find_component_decorator<'a>(decorators: &'a [Decorator<'a>]) -> Option<&'a Decorator<'a>> {
+    find_decorator_by_name(decorators, "Component")
+}
+
+/// Find a decorator by name in a list of decorators.
+fn find_decorator_by_name<'a>(
+    decorators: &'a [Decorator<'a>],
+    name: &str,
+) -> Option<&'a Decorator<'a>> {
     decorators.iter().find(|d| {
         if let Expression::CallExpression(call) = &d.expression {
             if let Expression::Identifier(ident) = &call.callee {
-                return ident.name.as_str() == "Component";
+                return ident.name.as_str() == name;
             }
         }
         false
     })
+}
+
+/// A constructor parameter with dependency injection metadata.
+#[derive(Debug, Clone)]
+pub struct ConstructorParam {
+    /// The TypeScript type annotation name (injection token).
+    pub type_name: Option<String>,
+    /// Explicit `@Inject(TOKEN)` token override.
+    pub inject_token: Option<String>,
+    /// Whether `@Optional()` is present.
+    pub optional: bool,
+    /// Whether `@Self()` is present.
+    pub self_: bool,
+    /// Whether `@SkipSelf()` is present.
+    pub skip_self: bool,
+    /// Whether `@Host()` is present.
+    pub host: bool,
+}
+
+/// Common fields shared by all Angular decorator extractions for rewriting.
+#[derive(Debug, Clone)]
+pub struct DecoratorCommon {
+    /// Byte offset range of the full decorator (from `@` to closing `)`).
+    pub decorator_span: (u32, u32),
+    /// Byte offset of the class body opening `{`.
+    pub class_body_start: u32,
+    /// The source text span of the `@angular/core` import declaration.
+    pub angular_core_import_span: Option<(u32, u32)>,
+    /// Named imports from `@angular/core` other than the decorator itself.
+    pub other_angular_core_imports: Vec<String>,
+}
+
+/// Metadata extracted from an `@Injectable` decorator.
+#[derive(Debug, Clone)]
+pub struct ExtractedInjectable {
+    /// The class name (e.g. `AuthService`).
+    pub class_name: String,
+    /// The `providedIn` value as raw source text (e.g. `'root'`).
+    pub provided_in: Option<String>,
+    /// The `useFactory` expression as raw source text.
+    pub use_factory: Option<String>,
+    /// The `useClass` expression as raw source text.
+    pub use_class: Option<String>,
+    /// The `useValue` expression as raw source text.
+    pub use_value: Option<String>,
+    /// The `useExisting` expression as raw source text.
+    pub use_existing: Option<String>,
+    /// Constructor parameters for DI-aware factory generation.
+    pub constructor_params: Vec<ConstructorParam>,
+    /// Common decorator fields for rewriting.
+    pub common: DecoratorCommon,
+}
+
+/// Metadata extracted from a `@Directive` decorator.
+#[derive(Debug, Clone)]
+pub struct ExtractedDirective {
+    /// The class name (e.g. `HighlightDirective`).
+    pub class_name: String,
+    /// The directive selector (e.g. `[appHighlight]`).
+    pub selector: Option<String>,
+    /// Whether the directive is standalone.
+    pub standalone: bool,
+    /// Raw source text of the `inputs` object/array.
+    pub inputs_source: Option<String>,
+    /// Raw source text of the `outputs` object/array.
+    pub outputs_source: Option<String>,
+    /// The `exportAs` value.
+    pub export_as: Option<String>,
+    /// Constructor parameters for DI-aware factory generation.
+    pub constructor_params: Vec<ConstructorParam>,
+    /// Common decorator fields for rewriting.
+    pub common: DecoratorCommon,
+}
+
+/// Metadata extracted from a `@Pipe` decorator.
+#[derive(Debug, Clone)]
+pub struct ExtractedPipe {
+    /// The class name (e.g. `DateFormatPipe`).
+    pub class_name: String,
+    /// The pipe name (e.g. `dateFormat`).
+    pub pipe_name: String,
+    /// The `pure` flag value.
+    pub pure: Option<bool>,
+    /// Whether the pipe is standalone.
+    pub standalone: bool,
+    /// Constructor parameters for DI-aware factory generation.
+    pub constructor_params: Vec<ConstructorParam>,
+    /// Common decorator fields for rewriting.
+    pub common: DecoratorCommon,
+}
+
+/// Metadata extracted from an `@NgModule` decorator.
+#[derive(Debug, Clone)]
+pub struct ExtractedNgModule {
+    /// The class name (e.g. `AppModule`).
+    pub class_name: String,
+    /// Raw source text of the `declarations` array.
+    pub declarations_source: Option<String>,
+    /// Raw source text of the `imports` array.
+    pub imports_source: Option<String>,
+    /// Raw source text of the `exports` array.
+    pub exports_source: Option<String>,
+    /// Raw source text of the `providers` array.
+    pub providers_source: Option<String>,
+    /// Raw source text of the `bootstrap` array.
+    pub bootstrap_source: Option<String>,
+    /// Common decorator fields for rewriting.
+    pub common: DecoratorCommon,
+}
+
+/// Extract `@Injectable` metadata from a TypeScript source file.
+///
+/// Returns `None` if no `@Injectable` decorator is found.
+pub fn extract_injectable(
+    source: &str,
+    file_path: &Path,
+) -> NgcResult<Option<ExtractedInjectable>> {
+    let allocator = Allocator::new();
+    let source_type =
+        SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "unsupported file extension".to_string(),
+        })?;
+
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked {
+        return Err(NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "parser panicked".to_string(),
+        });
+    }
+
+    let (angular_core_import_span, other_imports) =
+        find_angular_core_imports(&parsed.program.body, "Injectable");
+
+    for stmt in &parsed.program.body {
+        let (class, export_start) = match_class_statement(stmt);
+        let class = match class {
+            Some(c) => c,
+            None => continue,
+        };
+        let _ = export_start;
+
+        let decorator = match find_decorator_by_name(&class.decorators, "Injectable") {
+            Some(d) => d,
+            None => continue,
+        };
+
+        let class_name = class
+            .id
+            .as_ref()
+            .map(|id| id.name.to_string())
+            .unwrap_or_else(|| "Anonymous".to_string());
+
+        let class_body_start = class.body.span.start;
+        let constructor_params = extract_constructor_params(source, &class.body);
+
+        // Extract metadata from decorator arguments
+        let mut provided_in = None;
+        let mut use_factory = None;
+        let mut use_class = None;
+        let mut use_value = None;
+        let mut use_existing = None;
+
+        if let Expression::CallExpression(call) = &decorator.expression {
+            if let Some(Argument::ObjectExpression(obj)) = call.arguments.first() {
+                for prop in &obj.properties {
+                    if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                        let key_name = match &prop.key {
+                            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                            _ => continue,
+                        };
+                        let val_src = source_text_of(source, &prop.value);
+                        match key_name.as_str() {
+                            "providedIn" => provided_in = val_src,
+                            "useFactory" => use_factory = val_src,
+                            "useClass" => use_class = val_src,
+                            "useValue" => use_value = val_src,
+                            "useExisting" => use_existing = val_src,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(Some(ExtractedInjectable {
+            class_name,
+            provided_in,
+            use_factory,
+            use_class,
+            use_value,
+            use_existing,
+            constructor_params,
+            common: DecoratorCommon {
+                decorator_span: (decorator.span.start, decorator.span.end),
+                class_body_start,
+                angular_core_import_span,
+                other_angular_core_imports: other_imports,
+            },
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Extract `@Directive` metadata from a TypeScript source file.
+///
+/// Returns `None` if no `@Directive` decorator is found.
+pub fn extract_directive(
+    source: &str,
+    file_path: &Path,
+) -> NgcResult<Option<ExtractedDirective>> {
+    let allocator = Allocator::new();
+    let source_type =
+        SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "unsupported file extension".to_string(),
+        })?;
+
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked {
+        return Err(NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "parser panicked".to_string(),
+        });
+    }
+
+    let (angular_core_import_span, other_imports) =
+        find_angular_core_imports(&parsed.program.body, "Directive");
+
+    for stmt in &parsed.program.body {
+        let (class, _) = match_class_statement(stmt);
+        let class = match class {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let decorator = match find_decorator_by_name(&class.decorators, "Directive") {
+            Some(d) => d,
+            None => continue,
+        };
+
+        let class_name = class
+            .id
+            .as_ref()
+            .map(|id| id.name.to_string())
+            .unwrap_or_else(|| "Anonymous".to_string());
+
+        let class_body_start = class.body.span.start;
+        let constructor_params = extract_constructor_params(source, &class.body);
+
+        let mut selector = None;
+        let mut standalone = false;
+        let mut inputs_source = None;
+        let mut outputs_source = None;
+        let mut export_as = None;
+
+        if let Expression::CallExpression(call) = &decorator.expression {
+            if let Some(Argument::ObjectExpression(obj)) = call.arguments.first() {
+                for prop in &obj.properties {
+                    if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                        let key_name = match &prop.key {
+                            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                            _ => continue,
+                        };
+                        match key_name.as_str() {
+                            "selector" => {
+                                if let Expression::StringLiteral(s) = &prop.value {
+                                    selector = Some(s.value.to_string());
+                                }
+                            }
+                            "standalone" => {
+                                if let Expression::BooleanLiteral(b) = &prop.value {
+                                    standalone = b.value;
+                                }
+                            }
+                            "inputs" => inputs_source = source_text_of(source, &prop.value),
+                            "outputs" => outputs_source = source_text_of(source, &prop.value),
+                            "exportAs" => {
+                                if let Expression::StringLiteral(s) = &prop.value {
+                                    export_as = Some(s.value.to_string());
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(Some(ExtractedDirective {
+            class_name,
+            selector,
+            standalone,
+            inputs_source,
+            outputs_source,
+            export_as,
+            constructor_params,
+            common: DecoratorCommon {
+                decorator_span: (decorator.span.start, decorator.span.end),
+                class_body_start,
+                angular_core_import_span,
+                other_angular_core_imports: other_imports,
+            },
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Extract `@Pipe` metadata from a TypeScript source file.
+///
+/// Returns `None` if no `@Pipe` decorator is found.
+pub fn extract_pipe(source: &str, file_path: &Path) -> NgcResult<Option<ExtractedPipe>> {
+    let allocator = Allocator::new();
+    let source_type =
+        SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "unsupported file extension".to_string(),
+        })?;
+
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked {
+        return Err(NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "parser panicked".to_string(),
+        });
+    }
+
+    let (angular_core_import_span, other_imports) =
+        find_angular_core_imports(&parsed.program.body, "Pipe");
+
+    for stmt in &parsed.program.body {
+        let (class, _) = match_class_statement(stmt);
+        let class = match class {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let decorator = match find_decorator_by_name(&class.decorators, "Pipe") {
+            Some(d) => d,
+            None => continue,
+        };
+
+        let class_name = class
+            .id
+            .as_ref()
+            .map(|id| id.name.to_string())
+            .unwrap_or_else(|| "Anonymous".to_string());
+
+        let class_body_start = class.body.span.start;
+        let constructor_params = extract_constructor_params(source, &class.body);
+
+        let mut pipe_name = String::new();
+        let mut pure = None;
+        let mut standalone = false;
+
+        if let Expression::CallExpression(call) = &decorator.expression {
+            if let Some(Argument::ObjectExpression(obj)) = call.arguments.first() {
+                for prop in &obj.properties {
+                    if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                        let key_name = match &prop.key {
+                            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                            _ => continue,
+                        };
+                        match key_name.as_str() {
+                            "name" => {
+                                if let Expression::StringLiteral(s) = &prop.value {
+                                    pipe_name = s.value.to_string();
+                                }
+                            }
+                            "pure" => {
+                                if let Expression::BooleanLiteral(b) = &prop.value {
+                                    pure = Some(b.value);
+                                }
+                            }
+                            "standalone" => {
+                                if let Expression::BooleanLiteral(b) = &prop.value {
+                                    standalone = b.value;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(Some(ExtractedPipe {
+            class_name,
+            pipe_name,
+            pure,
+            standalone,
+            constructor_params,
+            common: DecoratorCommon {
+                decorator_span: (decorator.span.start, decorator.span.end),
+                class_body_start,
+                angular_core_import_span,
+                other_angular_core_imports: other_imports,
+            },
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Extract `@NgModule` metadata from a TypeScript source file.
+///
+/// Returns `None` if no `@NgModule` decorator is found.
+pub fn extract_ng_module(
+    source: &str,
+    file_path: &Path,
+) -> NgcResult<Option<ExtractedNgModule>> {
+    let allocator = Allocator::new();
+    let source_type =
+        SourceType::from_path(file_path).map_err(|_| NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "unsupported file extension".to_string(),
+        })?;
+
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked {
+        return Err(NgcError::TemplateCompileError {
+            path: file_path.to_path_buf(),
+            message: "parser panicked".to_string(),
+        });
+    }
+
+    let (angular_core_import_span, other_imports) =
+        find_angular_core_imports(&parsed.program.body, "NgModule");
+
+    for stmt in &parsed.program.body {
+        let (class, _) = match_class_statement(stmt);
+        let class = match class {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let decorator = match find_decorator_by_name(&class.decorators, "NgModule") {
+            Some(d) => d,
+            None => continue,
+        };
+
+        let class_name = class
+            .id
+            .as_ref()
+            .map(|id| id.name.to_string())
+            .unwrap_or_else(|| "Anonymous".to_string());
+
+        let class_body_start = class.body.span.start;
+
+        let mut declarations_source = None;
+        let mut imports_source = None;
+        let mut exports_source = None;
+        let mut providers_source = None;
+        let mut bootstrap_source = None;
+
+        if let Expression::CallExpression(call) = &decorator.expression {
+            if let Some(Argument::ObjectExpression(obj)) = call.arguments.first() {
+                for prop in &obj.properties {
+                    if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                        let key_name = match &prop.key {
+                            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                            _ => continue,
+                        };
+                        let val_src = source_text_of(source, &prop.value);
+                        match key_name.as_str() {
+                            "declarations" => declarations_source = val_src,
+                            "imports" => imports_source = val_src,
+                            "exports" => exports_source = val_src,
+                            "providers" => providers_source = val_src,
+                            "bootstrap" => bootstrap_source = val_src,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(Some(ExtractedNgModule {
+            class_name,
+            declarations_source,
+            imports_source,
+            exports_source,
+            providers_source,
+            bootstrap_source,
+            common: DecoratorCommon {
+                decorator_span: (decorator.span.start, decorator.span.end),
+                class_body_start,
+                angular_core_import_span,
+                other_angular_core_imports: other_imports,
+            },
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Extract a class declaration from a statement, handling export wrappers.
+fn match_class_statement<'a>(stmt: &'a Statement<'a>) -> (Option<&'a Class<'a>>, Option<u32>) {
+    match stmt {
+        Statement::ExportDefaultDeclaration(export) => {
+            if let oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class) =
+                &export.declaration
+            {
+                (Some(class), Some(export.span.start))
+            } else {
+                (None, None)
+            }
+        }
+        Statement::ExportNamedDeclaration(export) => {
+            if let Some(oxc_ast::ast::Declaration::ClassDeclaration(class)) = &export.declaration {
+                (Some(class), Some(export.span.start))
+            } else {
+                (None, None)
+            }
+        }
+        Statement::ClassDeclaration(class) => (Some(class), None),
+        _ => (None, None),
+    }
+}
+
+/// Find `@angular/core` import span and non-decorator imports.
+fn find_angular_core_imports(
+    body: &[Statement<'_>],
+    decorator_name: &str,
+) -> (Option<(u32, u32)>, Vec<String>) {
+    let mut span = None;
+    let mut others = Vec::new();
+
+    for stmt in body {
+        if let Statement::ImportDeclaration(import) = stmt {
+            if import.source.value.as_str() == "@angular/core" {
+                span = Some((import.span.start, import.span.end));
+                if let Some(specifiers) = &import.specifiers {
+                    for spec in specifiers {
+                        if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(s) = spec {
+                            let name = s.local.name.as_str();
+                            if name != decorator_name {
+                                others.push(name.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (span, others)
+}
+
+/// Get the raw source text of an expression.
+fn source_text_of(source: &str, expr: &Expression<'_>) -> Option<String> {
+    let start = expr.span().start as usize;
+    let end = expr.span().end as usize;
+    if start < source.len() && end <= source.len() {
+        Some(source[start..end].to_string())
+    } else {
+        None
+    }
+}
+
+/// Extract constructor parameters from a class body for DI-aware factory generation.
+fn extract_constructor_params(
+    source: &str,
+    class_body: &oxc_ast::ast::ClassBody<'_>,
+) -> Vec<ConstructorParam> {
+    for element in &class_body.body {
+        if let oxc_ast::ast::ClassElement::MethodDefinition(method) = element {
+            if method.kind == MethodDefinitionKind::Constructor {
+                return extract_params_from_formal(source, &method.value.params);
+            }
+        }
+    }
+    Vec::new()
+}
+
+/// Extract DI metadata from formal parameters.
+fn extract_params_from_formal(
+    source: &str,
+    params: &FormalParameters<'_>,
+) -> Vec<ConstructorParam> {
+    params
+        .items
+        .iter()
+        .map(|param| extract_single_param(source, param))
+        .collect()
+}
+
+/// Extract DI metadata from a single formal parameter.
+fn extract_single_param(source: &str, param: &FormalParameter<'_>) -> ConstructorParam {
+    let type_name = param
+        .type_annotation
+        .as_ref()
+        .and_then(|ann| extract_type_name(source, ann));
+
+    let mut inject_token = None;
+    let mut optional = false;
+    let mut self_ = false;
+    let mut skip_self = false;
+    let mut host = false;
+
+    for decorator in &param.decorators {
+        if let Expression::CallExpression(call) = &decorator.expression {
+            if let Expression::Identifier(ident) = &call.callee {
+                match ident.name.as_str() {
+                    "Inject" => {
+                        if let Some(arg) = call.arguments.first() {
+                            let start = arg.span().start as usize;
+                            let end = arg.span().end as usize;
+                            if start < source.len() && end <= source.len() {
+                                inject_token = Some(source[start..end].to_string());
+                            }
+                        }
+                    }
+                    "Optional" => optional = true,
+                    "Self" => self_ = true,
+                    "SkipSelf" => skip_self = true,
+                    "Host" => host = true,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    ConstructorParam {
+        type_name,
+        inject_token,
+        optional,
+        self_,
+        skip_self,
+        host,
+    }
+}
+
+/// Extract the type name from a TypeScript type annotation.
+fn extract_type_name(source: &str, annotation: &TSTypeAnnotation<'_>) -> Option<String> {
+    let start = annotation.type_annotation.span().start as usize;
+    let end = annotation.type_annotation.span().end as usize;
+    if start < source.len() && end <= source.len() {
+        Some(source[start..end].to_string())
+    } else {
+        None
+    }
 }
 
 /// Metadata extracted from the decorator's argument object.
@@ -423,5 +1079,139 @@ export class AppComponent implements OnInit {
             .expect("should find component");
         assert!(result.angular_core_import_span.is_some());
         assert_eq!(result.other_angular_core_imports, vec!["OnInit"]);
+    }
+
+    #[test]
+    fn test_extract_injectable_basic() {
+        let source = r#"import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+}
+"#;
+        let result = extract_injectable(source, &test_path())
+            .expect("should extract")
+            .expect("should find injectable");
+        assert_eq!(result.class_name, "AuthService");
+        assert_eq!(result.provided_in.as_deref(), Some("'root'"));
+        assert!(result.constructor_params.is_empty());
+    }
+
+    #[test]
+    fn test_extract_injectable_with_deps() {
+        let source = r#"import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class DataService {
+  constructor(private http: HttpClient) {}
+}
+"#;
+        let result = extract_injectable(source, &test_path())
+            .expect("should extract")
+            .expect("should find injectable");
+        assert_eq!(result.class_name, "DataService");
+        assert_eq!(result.constructor_params.len(), 1);
+        assert_eq!(
+            result.constructor_params[0].type_name.as_deref(),
+            Some("HttpClient")
+        );
+    }
+
+    #[test]
+    fn test_extract_injectable_with_inject_decorator() {
+        let source = r#"import { Injectable, Inject, Optional } from '@angular/core';
+
+@Injectable()
+export class MyService {
+  constructor(@Inject('API_URL') private url: string, @Optional() private dep: SomeDep) {}
+}
+"#;
+        let result = extract_injectable(source, &test_path())
+            .expect("should extract")
+            .expect("should find injectable");
+        assert_eq!(result.constructor_params.len(), 2);
+        assert_eq!(
+            result.constructor_params[0].inject_token.as_deref(),
+            Some("'API_URL'")
+        );
+        assert!(result.constructor_params[1].optional);
+    }
+
+    #[test]
+    fn test_extract_directive() {
+        let source = r#"import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[appHighlight]',
+  standalone: true
+})
+export class HighlightDirective {
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.class_name, "HighlightDirective");
+        assert_eq!(result.selector.as_deref(), Some("[appHighlight]"));
+        assert!(result.standalone);
+    }
+
+    #[test]
+    fn test_extract_pipe() {
+        let source = r#"import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'dateFormat',
+  standalone: true,
+  pure: false
+})
+export class DateFormatPipe implements PipeTransform {
+  transform(value: any): string { return ''; }
+}
+"#;
+        let result = extract_pipe(source, &test_path())
+            .expect("should extract")
+            .expect("should find pipe");
+        assert_eq!(result.class_name, "DateFormatPipe");
+        assert_eq!(result.pipe_name, "dateFormat");
+        assert_eq!(result.pure, Some(false));
+        assert!(result.standalone);
+        // PipeTransform should be in other imports
+        assert!(result
+            .common
+            .other_angular_core_imports
+            .contains(&"PipeTransform".to_string()));
+    }
+
+    #[test]
+    fn test_extract_ng_module() {
+        let source = r#"import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [CommonModule],
+  exports: [AppComponent],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+"#;
+        let result = extract_ng_module(source, &test_path())
+            .expect("should extract")
+            .expect("should find ng module");
+        assert_eq!(result.class_name, "AppModule");
+        assert!(result.declarations_source.is_some());
+        assert!(result.imports_source.is_some());
+        assert!(result.exports_source.is_some());
+        assert!(result.bootstrap_source.is_some());
+    }
+
+    #[test]
+    fn test_no_injectable_returns_none() {
+        let source = "export class PlainClass { x = 1; }\n";
+        let result = extract_injectable(source, &test_path()).expect("should not error");
+        assert!(result.is_none());
     }
 }

--- a/crates/template-compiler/src/factory_codegen.rs
+++ b/crates/template-compiler/src/factory_codegen.rs
@@ -1,0 +1,157 @@
+//! Shared factory function generation for Angular AOT compilation.
+//!
+//! Generates `static ɵfac = function ClassName_Factory(t: any) { ... }` code
+//! with dependency injection support via `ɵɵinject()` calls.
+
+use std::collections::BTreeSet;
+
+use crate::extract::ConstructorParam;
+
+/// Generate a factory function with DI inject calls for constructor parameters.
+///
+/// Returns the factory code string and a set of Ivy import symbols needed.
+pub fn generate_factory(
+    class_name: &str,
+    params: &[ConstructorParam],
+) -> (String, BTreeSet<String>) {
+    let mut imports = BTreeSet::new();
+
+    if params.is_empty() {
+        let code = format!(
+            "static \u{0275}fac = function {class_name}_Factory(t: any) {{ return new (t || {class_name})(); }}"
+        );
+        return (code, imports);
+    }
+
+    let args: Vec<String> = params
+        .iter()
+        .filter_map(|p| {
+            let token = p.inject_token.as_deref().or(p.type_name.as_deref())?;
+
+            imports.insert("\u{0275}\u{0275}inject".to_string());
+
+            let mut flags = 0u32;
+            if p.optional {
+                flags |= 8;
+            }
+            if p.self_ {
+                flags |= 2;
+            }
+            if p.skip_self {
+                flags |= 4;
+            }
+            if p.host {
+                flags |= 1;
+            }
+
+            if flags != 0 {
+                Some(format!("\u{0275}\u{0275}inject({token}, {flags})"))
+            } else {
+                Some(format!("\u{0275}\u{0275}inject({token})"))
+            }
+        })
+        .collect();
+
+    let args_str = args.join(", ");
+    let code = format!(
+        "static \u{0275}fac = function {class_name}_Factory(t: any) {{ return new (t || {class_name})({args_str}); }}"
+    );
+
+    (code, imports)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_factory_no_params() {
+        let (code, imports) = generate_factory("MyService", &[]);
+        assert!(code.contains("MyService_Factory"));
+        assert!(code.contains("new (t || MyService)()"));
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn test_factory_with_type_param() {
+        let params = vec![ConstructorParam {
+            type_name: Some("HttpClient".to_string()),
+            inject_token: None,
+            optional: false,
+            self_: false,
+            skip_self: false,
+            host: false,
+        }];
+        let (code, imports) = generate_factory("DataService", &params);
+        assert!(code.contains("\u{0275}\u{0275}inject(HttpClient)"));
+        assert!(imports.contains("\u{0275}\u{0275}inject"));
+    }
+
+    #[test]
+    fn test_factory_with_inject_token() {
+        let params = vec![ConstructorParam {
+            type_name: Some("string".to_string()),
+            inject_token: Some("'API_URL'".to_string()),
+            optional: false,
+            self_: false,
+            skip_self: false,
+            host: false,
+        }];
+        let (code, _) = generate_factory("MyService", &params);
+        // @Inject token takes precedence over type
+        assert!(code.contains("\u{0275}\u{0275}inject('API_URL')"));
+    }
+
+    #[test]
+    fn test_factory_with_optional_flag() {
+        let params = vec![ConstructorParam {
+            type_name: Some("SomeDep".to_string()),
+            inject_token: None,
+            optional: true,
+            self_: false,
+            skip_self: false,
+            host: false,
+        }];
+        let (code, _) = generate_factory("MyService", &params);
+        assert!(code.contains("\u{0275}\u{0275}inject(SomeDep, 8)"));
+    }
+
+    #[test]
+    fn test_factory_with_multiple_flags() {
+        let params = vec![ConstructorParam {
+            type_name: Some("SomeDep".to_string()),
+            inject_token: None,
+            optional: true,
+            self_: false,
+            skip_self: true,
+            host: false,
+        }];
+        let (code, _) = generate_factory("MyService", &params);
+        // optional=8, skip_self=4 → 12
+        assert!(code.contains("\u{0275}\u{0275}inject(SomeDep, 12)"));
+    }
+
+    #[test]
+    fn test_factory_multiple_params() {
+        let params = vec![
+            ConstructorParam {
+                type_name: Some("HttpClient".to_string()),
+                inject_token: None,
+                optional: false,
+                self_: false,
+                skip_self: false,
+                host: false,
+            },
+            ConstructorParam {
+                type_name: Some("Router".to_string()),
+                inject_token: None,
+                optional: false,
+                self_: false,
+                skip_self: false,
+                host: false,
+            },
+        ];
+        let (code, _) = generate_factory("AuthService", &params);
+        assert!(code.contains("\u{0275}\u{0275}inject(HttpClient), \u{0275}\u{0275}inject(Router)"));
+    }
+}

--- a/crates/template-compiler/src/injectable_codegen.rs
+++ b/crates/template-compiler/src/injectable_codegen.rs
@@ -1,0 +1,155 @@
+//! AOT codegen for `@Injectable` decorators.
+//!
+//! Generates `ɵfac` (factory) and `ɵprov` (`ɵɵdefineInjectable`) static fields.
+//!
+//! ## Example
+//! ```text
+//! // Input:
+//! @Injectable({ providedIn: 'root' })
+//! export class AuthService { constructor(private http: HttpClient) {} }
+//!
+//! // Output:
+//! export class AuthService {
+//!   static ɵfac = function AuthService_Factory(t: any) { return new (t || AuthService)(ɵɵinject(HttpClient)); };
+//!   static ɵprov = ɵɵdefineInjectable({ token: AuthService, factory: AuthService.ɵfac, providedIn: 'root' });
+//! }
+//! ```
+
+use std::collections::BTreeSet;
+
+use ngc_diagnostics::NgcResult;
+
+use crate::codegen::IvyOutput;
+use crate::extract::ExtractedInjectable;
+use crate::factory_codegen;
+
+/// Generate Ivy output for an `@Injectable` decorator.
+pub fn generate_injectable_ivy(extracted: &ExtractedInjectable) -> NgcResult<IvyOutput> {
+    let name = &extracted.class_name;
+    let mut ivy_imports = BTreeSet::new();
+
+    ivy_imports.insert("\u{0275}\u{0275}defineInjectable".to_string());
+
+    // Generate factory with DI
+    let (factory_code, inject_imports) =
+        factory_codegen::generate_factory(name, &extracted.constructor_params);
+    for imp in inject_imports {
+        ivy_imports.insert(imp);
+    }
+
+    // Determine the factory expression for defineInjectable
+    let factory_expr = if extracted.use_factory.is_some()
+        || extracted.use_class.is_some()
+        || extracted.use_value.is_some()
+        || extracted.use_existing.is_some()
+    {
+        // Provider override — use the specified factory instead of ɵfac
+        if let Some(ref use_factory) = extracted.use_factory {
+            use_factory.clone()
+        } else if let Some(ref use_class) = extracted.use_class {
+            format!("() => new {use_class}()")
+        } else if let Some(ref use_value) = extracted.use_value {
+            format!("() => {use_value}")
+        } else if let Some(ref use_existing) = extracted.use_existing {
+            ivy_imports.insert("\u{0275}\u{0275}inject".to_string());
+            format!("function() {{ return \u{0275}\u{0275}inject({use_existing}); }}")
+        } else {
+            format!("{name}.\u{0275}fac")
+        }
+    } else {
+        format!("{name}.\u{0275}fac")
+    };
+
+    // Build ɵprov definition
+    let mut props = Vec::new();
+    props.push(format!("token: {name}"));
+    props.push(format!("factory: {factory_expr}"));
+
+    if let Some(ref provided_in) = extracted.provided_in {
+        props.push(format!("providedIn: {provided_in}"));
+    }
+
+    let define_code = format!(
+        "static \u{0275}prov = \u{0275}\u{0275}defineInjectable({{ {} }})",
+        props.join(", ")
+    );
+
+    Ok(IvyOutput {
+        factory_code,
+        static_fields: vec![define_code],
+        child_template_functions: Vec::new(),
+        ivy_imports,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::{ConstructorParam, DecoratorCommon};
+
+    fn make_injectable(
+        class_name: &str,
+        provided_in: Option<&str>,
+        params: Vec<ConstructorParam>,
+    ) -> ExtractedInjectable {
+        ExtractedInjectable {
+            class_name: class_name.to_string(),
+            provided_in: provided_in.map(|s| s.to_string()),
+            use_factory: None,
+            use_class: None,
+            use_value: None,
+            use_existing: None,
+            constructor_params: params,
+            common: DecoratorCommon {
+                decorator_span: (0, 0),
+                class_body_start: 0,
+                angular_core_import_span: None,
+                other_angular_core_imports: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_injectable_basic() {
+        let extracted = make_injectable("AuthService", Some("'root'"), vec![]);
+        let output = generate_injectable_ivy(&extracted).unwrap();
+        assert!(output.factory_code.contains("AuthService_Factory"));
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}defineInjectable"));
+        assert!(output.static_fields[0].contains("token: AuthService"));
+        assert!(output.static_fields[0].contains("factory: AuthService.\u{0275}fac"));
+        assert!(output.static_fields[0].contains("providedIn: 'root'"));
+    }
+
+    #[test]
+    fn test_injectable_with_deps() {
+        let params = vec![ConstructorParam {
+            type_name: Some("HttpClient".to_string()),
+            inject_token: None,
+            optional: false,
+            self_: false,
+            skip_self: false,
+            host: false,
+        }];
+        let extracted = make_injectable("DataService", Some("'root'"), params);
+        let output = generate_injectable_ivy(&extracted).unwrap();
+        assert!(output
+            .factory_code
+            .contains("\u{0275}\u{0275}inject(HttpClient)"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}inject"));
+    }
+
+    #[test]
+    fn test_injectable_no_provided_in() {
+        let extracted = make_injectable("MyService", None, vec![]);
+        let output = generate_injectable_ivy(&extracted).unwrap();
+        assert!(!output.static_fields[0].contains("providedIn"));
+    }
+
+    #[test]
+    fn test_injectable_use_existing() {
+        let mut extracted = make_injectable("MyService", Some("'root'"), vec![]);
+        extracted.use_existing = Some("OtherService".to_string());
+        let output = generate_injectable_ivy(&extracted).unwrap();
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}inject(OtherService)"));
+    }
+}

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -1,14 +1,21 @@
-//! Angular template compiler for ngc-rs.
+//! Angular Ivy compiler for ngc-rs.
 //!
-//! Compiles `@Component` templates to Angular Ivy instructions. Parses template
-//! HTML with pest, generates Ivy codegen (ɵɵdefineComponent, template function),
-//! and rewrites TypeScript source to replace the decorator with static Ivy metadata.
+//! AOT-compiles Angular decorators (`@Component`, `@Injectable`, `@Directive`,
+//! `@Pipe`, `@NgModule`) to Ivy static fields. Parses template HTML with pest,
+//! generates Ivy codegen, and rewrites TypeScript source to replace decorators
+//! with static Ivy metadata.
 
 mod ast;
 mod codegen;
+mod directive_codegen;
 mod extract;
+mod factory_codegen;
+mod injectable_codegen;
+mod ng_module_codegen;
 mod parser;
+mod pipe_codegen;
 mod rewrite;
+mod selector;
 
 use std::path::{Path, PathBuf};
 
@@ -180,15 +187,15 @@ pub struct CompiledFile {
     pub jit_fallback: bool,
 }
 
-/// Compile Angular component templates in the given TypeScript source files.
+/// Compile all Angular decorators in the given TypeScript source files.
 ///
-/// For each file that contains an `@Component` decorator with an inline `template`,
-/// parses the template, generates Ivy instructions, and rewrites the source to
-/// replace the decorator with static Ivy metadata. Files without `@Component`
-/// decorators are returned unchanged.
+/// Handles `@Component`, `@Injectable`, `@Directive`, `@Pipe`, and `@NgModule`.
+/// For each file, extracts Angular decorators, generates Ivy instructions, and
+/// rewrites the source to replace decorators with static Ivy metadata.
+/// Files without Angular decorators are returned unchanged.
 ///
 /// Files are processed in parallel using rayon.
-pub fn compile_templates(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
+pub fn compile_all_decorators(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
     let results: Vec<NgcResult<CompiledFile>> = files
         .par_iter()
         .map(|file_path| {
@@ -197,11 +204,89 @@ pub fn compile_templates(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
                 source: e,
             })?;
 
-            compile_component(&source, file_path)
+            compile_file(&source, file_path)
         })
         .collect();
 
     results.into_iter().collect()
+}
+
+/// Backward-compatible alias for `compile_all_decorators`.
+pub fn compile_templates(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
+    compile_all_decorators(files)
+}
+
+/// Compile a single TypeScript source file, handling all Angular decorator types.
+///
+/// Tries `@Component` first, then falls through to `@Injectable`, `@Directive`,
+/// `@Pipe`, and `@NgModule`. Returns the source unchanged if no Angular decorator
+/// is found.
+fn compile_file(source: &str, file_path: &Path) -> NgcResult<CompiledFile> {
+    // Try @Component first (most complex, has template compilation)
+    let component_result = compile_component(source, file_path)?;
+    if component_result.compiled || component_result.jit_fallback {
+        return Ok(component_result);
+    }
+
+    // Try @Injectable
+    if let Some(extracted) = extract::extract_injectable(source, file_path)? {
+        let ivy_output = injectable_codegen::generate_injectable_ivy(&extracted)?;
+        let rewritten = rewrite::rewrite_source_generic(source, &extracted.common, &ivy_output)?;
+        debug!(path = %file_path.display(), "compiled @Injectable to Ivy");
+        return Ok(CompiledFile {
+            source_path: file_path.to_path_buf(),
+            source: rewritten,
+            compiled: true,
+            jit_fallback: false,
+        });
+    }
+
+    // Try @Directive
+    if let Some(extracted) = extract::extract_directive(source, file_path)? {
+        let ivy_output = directive_codegen::generate_directive_ivy(&extracted)?;
+        let rewritten = rewrite::rewrite_source_generic(source, &extracted.common, &ivy_output)?;
+        debug!(path = %file_path.display(), "compiled @Directive to Ivy");
+        return Ok(CompiledFile {
+            source_path: file_path.to_path_buf(),
+            source: rewritten,
+            compiled: true,
+            jit_fallback: false,
+        });
+    }
+
+    // Try @Pipe
+    if let Some(extracted) = extract::extract_pipe(source, file_path)? {
+        let ivy_output = pipe_codegen::generate_pipe_ivy(&extracted)?;
+        let rewritten = rewrite::rewrite_source_generic(source, &extracted.common, &ivy_output)?;
+        debug!(path = %file_path.display(), "compiled @Pipe to Ivy");
+        return Ok(CompiledFile {
+            source_path: file_path.to_path_buf(),
+            source: rewritten,
+            compiled: true,
+            jit_fallback: false,
+        });
+    }
+
+    // Try @NgModule
+    if let Some(extracted) = extract::extract_ng_module(source, file_path)? {
+        let ivy_output = ng_module_codegen::generate_ng_module_ivy(&extracted)?;
+        let rewritten = rewrite::rewrite_source_generic(source, &extracted.common, &ivy_output)?;
+        debug!(path = %file_path.display(), "compiled @NgModule to Ivy");
+        return Ok(CompiledFile {
+            source_path: file_path.to_path_buf(),
+            source: rewritten,
+            compiled: true,
+            jit_fallback: false,
+        });
+    }
+
+    // No Angular decorator found
+    Ok(CompiledFile {
+        source_path: file_path.to_path_buf(),
+        source: source.to_string(),
+        compiled: false,
+        jit_fallback: false,
+    })
 }
 
 /// Compile a single TypeScript source string containing an Angular component.
@@ -301,5 +386,152 @@ mod tests {
             js.err(),
             result.source
         );
+    }
+
+    #[test]
+    fn test_injectable_roundtrip() {
+        let source = r#"import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  isLoggedIn = false;
+}
+"#;
+        let path = PathBuf::from("auth.service.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(result.compiled, "should be compiled");
+        assert!(result.source.contains("\u{0275}prov"));
+        assert!(result.source.contains("\u{0275}\u{0275}defineInjectable"));
+        assert!(!result.source.contains("@Injectable"));
+
+        let js = ngc_ts_transform::transform_source(&result.source, "auth.service.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\nCompiled source:\n{}",
+            js.err(),
+            result.source
+        );
+    }
+
+    #[test]
+    fn test_injectable_with_deps_roundtrip() {
+        let source = r#"import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class DataService {
+  constructor(private http: HttpClient, private router: Router) {}
+}
+"#;
+        let path = PathBuf::from("data.service.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(result.source.contains("\u{0275}\u{0275}inject(HttpClient)"));
+        assert!(result.source.contains("\u{0275}\u{0275}inject(Router)"));
+
+        let js = ngc_ts_transform::transform_source(&result.source, "data.service.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\nCompiled source:\n{}",
+            js.err(),
+            result.source
+        );
+    }
+
+    #[test]
+    fn test_directive_roundtrip() {
+        let source = r#"import { Directive, ElementRef } from '@angular/core';
+
+@Directive({
+  selector: '[appHighlight]',
+  standalone: true
+})
+export class HighlightDirective {
+  constructor(private el: ElementRef) {}
+}
+"#;
+        let path = PathBuf::from("highlight.directive.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(result.source.contains("\u{0275}dir"));
+        assert!(result.source.contains("\u{0275}\u{0275}defineDirective"));
+        assert!(result.source.contains("\u{0275}\u{0275}inject(ElementRef)"));
+        assert!(!result.source.contains("@Directive"));
+
+        let js = ngc_ts_transform::transform_source(&result.source, "highlight.directive.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\nCompiled source:\n{}",
+            js.err(),
+            result.source
+        );
+    }
+
+    #[test]
+    fn test_pipe_roundtrip() {
+        let source = r#"import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'dateFormat',
+  standalone: true
+})
+export class DateFormatPipe implements PipeTransform {
+  transform(value: any): string { return ''; }
+}
+"#;
+        let path = PathBuf::from("date-format.pipe.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(result.source.contains("\u{0275}pipe"));
+        assert!(result.source.contains("\u{0275}\u{0275}definePipe"));
+        assert!(result.source.contains("name: 'dateFormat'"));
+        assert!(!result.source.contains("@Pipe"));
+
+        let js = ngc_ts_transform::transform_source(&result.source, "date-format.pipe.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\nCompiled source:\n{}",
+            js.err(),
+            result.source
+        );
+    }
+
+    #[test]
+    fn test_ng_module_roundtrip() {
+        let source = r#"import { NgModule } from '@angular/core';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [CommonModule],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+"#;
+        let path = PathBuf::from("app.module.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(result.source.contains("\u{0275}mod"));
+        assert!(result.source.contains("\u{0275}inj"));
+        assert!(result.source.contains("\u{0275}\u{0275}defineNgModule"));
+        assert!(result.source.contains("\u{0275}\u{0275}defineInjector"));
+        assert!(!result.source.contains("@NgModule"));
+
+        let js = ngc_ts_transform::transform_source(&result.source, "app.module.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\nCompiled source:\n{}",
+            js.err(),
+            result.source
+        );
+    }
+
+    #[test]
+    fn test_plain_class_unchanged() {
+        let source = "export class PlainClass { x = 1; }\n";
+        let path = PathBuf::from("plain.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(!result.compiled);
+        assert_eq!(result.source, source);
     }
 }

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -106,7 +106,7 @@ pub fn generate_template_fn(
 
 /// Extract the template function from the IvyOutput's defineComponent code.
 fn extract_template_fn_from_ivy(ivy: &codegen::IvyOutput, class_name: &str) -> String {
-    let dc = &ivy.define_component_code;
+    let dc = ivy.static_fields.first().map(|s| s.as_str()).unwrap_or("");
     let template_marker = format!("template: function {class_name}_Template");
 
     if let Some(start) = dc.find(&template_marker) {
@@ -140,7 +140,7 @@ fn extract_template_fn_from_ivy(ivy: &codegen::IvyOutput, class_name: &str) -> S
 
 /// Extract decls and vars from the IvyOutput's defineComponent code.
 fn extract_decls_vars_from_ivy(ivy: &codegen::IvyOutput) -> (u32, u32) {
-    let dc = &ivy.define_component_code;
+    let dc = ivy.static_fields.first().map(|s| s.as_str()).unwrap_or("");
 
     let decls = extract_number_prop(dc, "decls: ").unwrap_or(0);
     let vars = extract_number_prop(dc, "vars: ").unwrap_or(0);

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -389,6 +389,200 @@ mod tests {
     }
 
     #[test]
+    fn test_complex_component_roundtrip() {
+        // Exact reproduction of SidenavComponent patterns including:
+        // - HTML comments, multi-line attribute bindings, pipes in ternary sub-expressions
+        // - non-null assertions, complex class/style/attr bindings, routerLink directives
+        // - CSS styles in template literal array
+        let source = r#"import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-side-nav',
+  standalone: true,
+  imports: [RouterModule, TranslateModule],
+  template: `
+    <!-- Mobile Overlay Backdrop -->
+    @if (mobileMenu.isMobileMenuOpen() && auth.token) {
+      <div
+        class="fixed inset-0 bg-neutral-900/60 backdrop-blur-sm z-40 md:hidden animate-fade-in"
+        (click)="mobileMenu.close()"
+        aria-hidden="true"
+      ></div>
+    }
+
+    <nav
+      class="sidebar"
+      [class.w-64]="!isCollapsed || mobileMenu.isMobileMenuOpen()"
+      [class.w-20]="isCollapsed && !mobileMenu.isMobileMenuOpen()"
+      [class.translate-x-0]="mobileMenu.isMobileMenuOpen()"
+      [hidden]="!auth.token"
+    >
+      <div class="flex items-center justify-between p-4">
+        <div [class.hidden]="isCollapsed && !mobileMenu.isMobileMenuOpen()">
+          <span class="text-xl font-bold">Treasr</span>
+        </div>
+
+        @if (isCollapsed && !mobileMenu.isMobileMenuOpen()) {
+          <div class="mx-auto">
+            <span class="material-icons text-white text-xl">trending_up</span>
+          </div>
+        }
+
+        <button
+          type="button"
+          class="p-2 cursor-pointer hidden md:block"
+          [class.ml-auto]="!isCollapsed"
+          [class.hidden]="isCollapsed && !mobileMenu.isMobileMenuOpen()"
+          (click)="toggleSidebar()"
+          [attr.aria-expanded]="!isCollapsed"
+          [attr.aria-label]="
+            isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
+          "
+        >
+          <span
+            class="material-icons"
+            [style.transform]="isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'"
+          >
+            chevron_left
+          </span>
+        </button>
+      </div>
+
+      @if (subscription() && (!isCollapsed || mobileMenu.isMobileMenuOpen())) {
+        <a
+          routerLink="/billing"
+          (click)="mobileMenu.close()"
+          class="mx-3 mb-4 px-3 py-2.5 rounded-xl block cursor-pointer"
+          [class]="getBadgeClass(subscription()!.tier, subscription()!.status)"
+          [attr.title]="
+            subscription()!.tier === 'free'
+              ? ('NAV.UPGRADE' | translate)
+              : ('NAV.BILLING' | translate)
+          "
+        >
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-xs font-semibold">
+                {{ getTierDisplayName(subscription()!.tier) | translate }}
+              </div>
+              @if (subscription()!.status === 'trialing') {
+                <div class="text-xs opacity-80">
+                  {{ 'NAV.TRIAL' | translate }}
+                </div>
+              }
+              @if (subscription()!.status === 'canceled') {
+                <div class="text-xs opacity-80">
+                  {{ 'NAV.EXPIRING' | translate }}
+                </div>
+              }
+            </div>
+            @if (subscription()!.tier === 'free') {
+              <span class="material-icons text-sm opacity-80">arrow_upward</span>
+            } @else {
+              <span class="material-icons text-sm opacity-60">chevron_right</span>
+            }
+          </div>
+        </a>
+      }
+
+      <ul class="flex-1 space-y-1 px-3">
+        <li>
+          <a
+            routerLink="/portfolio"
+            (click)="mobileMenu.close()"
+            class="sidebar-nav-item"
+            routerLinkActive="active"
+            [routerLinkActiveOptions]="{ exact: true }"
+            [class.justify-center]="isCollapsed && !mobileMenu.isMobileMenuOpen()"
+            title="Portfolio"
+          >
+            <span class="material-icons text-xl">account_balance</span>
+            <span
+              class="font-medium"
+              [class.hidden]="isCollapsed && !mobileMenu.isMobileMenuOpen()"
+            >{{ 'NAV.PORTFOLIO' | translate }}</span>
+          </a>
+        </li>
+      </ul>
+
+      <div class="px-3 pb-2">
+        <div
+          class="border-t my-3"
+          [class.hidden]="isCollapsed && !mobileMenu.isMobileMenuOpen()"
+        ></div>
+        <div
+          class="px-3 mb-2 text-xs"
+          [class.hidden]="isCollapsed && !mobileMenu.isMobileMenuOpen()"
+        >
+          {{ 'NAV.ACCOUNT' | translate }}
+        </div>
+      </div>
+
+      @if (isCollapsed && !mobileMenu.isMobileMenuOpen()) {
+        <div class="px-3 pb-4">
+          <button
+            type="button"
+            class="w-full p-2 cursor-pointer flex items-center justify-center"
+            (click)="toggleSidebar()"
+            aria-label="Expand sidebar"
+          >
+            <span class="material-icons">chevron_right</span>
+          </button>
+        </div>
+      }
+    </nav>
+  `,
+  styles: [
+    `
+      .sidebar {
+        background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+        border-right: 1px solid rgba(0, 0, 0, 0.08);
+      }
+      .sidebar-nav-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+      }
+    `,
+  ],
+})
+export class SidenavComponent implements OnInit {
+  isCollapsed = false;
+  subscription = signal<any>(null);
+
+  protected auth = inject(AuthService);
+  protected mobileMenu = inject(MobileMenuService);
+
+  ngOnInit() {}
+  toggleSidebar() { this.isCollapsed = !this.isCollapsed; }
+  getTierDisplayName(tier: string): string { return tier; }
+  getBadgeClass(tier: string, status: string): string { return ''; }
+}
+"#;
+        let path = PathBuf::from("test.component.ts");
+        let result = compile_file(source, &path).expect("should compile");
+        assert!(result.compiled, "should be compiled");
+        assert!(
+            !result.source.contains("@Component"),
+            "decorator should be removed"
+        );
+
+        // The compiled source must be parseable by oxc ts-transform
+        let js = ngc_ts_transform::transform_source(&result.source, "test.component.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\nCompiled source:\n{}",
+            js.err(),
+            result.source
+        );
+        let js = js.unwrap();
+        assert!(js.contains("\u{0275}cmp"), "ɵcmp should survive transform");
+    }
+
+    #[test]
     fn test_injectable_roundtrip() {
         let source = r#"import { Injectable } from '@angular/core';
 

--- a/crates/template-compiler/src/ng_module_codegen.rs
+++ b/crates/template-compiler/src/ng_module_codegen.rs
@@ -1,0 +1,165 @@
+//! AOT codegen for `@NgModule` decorators.
+//!
+//! Generates `ɵfac` (factory), `ɵmod` (`ɵɵdefineNgModule`), and `ɵinj`
+//! (`ɵɵdefineInjector`) static fields.
+//!
+//! ## Example
+//! ```text
+//! // Input:
+//! @NgModule({ declarations: [AppComponent], imports: [CommonModule], bootstrap: [AppComponent] })
+//! export class AppModule {}
+//!
+//! // Output:
+//! export class AppModule {
+//!   static ɵfac = function AppModule_Factory(t: any) { return new (t || AppModule)(); };
+//!   static ɵmod = ɵɵdefineNgModule({ type: AppModule, declarations: [AppComponent], imports: [CommonModule], bootstrap: [AppComponent] });
+//!   static ɵinj = ɵɵdefineInjector({ imports: [CommonModule] });
+//! }
+//! ```
+
+use std::collections::BTreeSet;
+
+use ngc_diagnostics::NgcResult;
+
+use crate::codegen::IvyOutput;
+use crate::extract::ExtractedNgModule;
+use crate::factory_codegen;
+
+/// Generate Ivy output for an `@NgModule` decorator.
+pub fn generate_ng_module_ivy(extracted: &ExtractedNgModule) -> NgcResult<IvyOutput> {
+    let name = &extracted.class_name;
+    let mut ivy_imports = BTreeSet::new();
+
+    ivy_imports.insert("\u{0275}\u{0275}defineNgModule".to_string());
+    ivy_imports.insert("\u{0275}\u{0275}defineInjector".to_string());
+
+    // Generate factory (NgModules typically have no constructor params)
+    let (factory_code, inject_imports) = factory_codegen::generate_factory(name, &[]);
+    for imp in inject_imports {
+        ivy_imports.insert(imp);
+    }
+
+    // Build ɵmod = ɵɵdefineNgModule({...})
+    let mut mod_props = Vec::new();
+    mod_props.push(format!("type: {name}"));
+
+    if let Some(ref declarations) = extracted.declarations_source {
+        mod_props.push(format!("declarations: {declarations}"));
+    }
+    if let Some(ref imports) = extracted.imports_source {
+        mod_props.push(format!("imports: {imports}"));
+    }
+    if let Some(ref exports) = extracted.exports_source {
+        mod_props.push(format!("exports: {exports}"));
+    }
+    if let Some(ref bootstrap) = extracted.bootstrap_source {
+        mod_props.push(format!("bootstrap: {bootstrap}"));
+    }
+
+    let mod_code = format!(
+        "static \u{0275}mod = \u{0275}\u{0275}defineNgModule({{ {} }})",
+        mod_props.join(", ")
+    );
+
+    // Build ɵinj = ɵɵdefineInjector({...})
+    let mut inj_props = Vec::new();
+
+    if let Some(ref providers) = extracted.providers_source {
+        inj_props.push(format!("providers: {providers}"));
+    }
+    if let Some(ref imports) = extracted.imports_source {
+        inj_props.push(format!("imports: {imports}"));
+    }
+
+    let inj_code = if inj_props.is_empty() {
+        "static \u{0275}inj = \u{0275}\u{0275}defineInjector({})".to_string()
+    } else {
+        format!(
+            "static \u{0275}inj = \u{0275}\u{0275}defineInjector({{ {} }})",
+            inj_props.join(", ")
+        )
+    };
+
+    Ok(IvyOutput {
+        factory_code,
+        static_fields: vec![mod_code, inj_code],
+        child_template_functions: Vec::new(),
+        ivy_imports,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::DecoratorCommon;
+
+    fn make_ng_module(class_name: &str) -> ExtractedNgModule {
+        ExtractedNgModule {
+            class_name: class_name.to_string(),
+            declarations_source: None,
+            imports_source: None,
+            exports_source: None,
+            providers_source: None,
+            bootstrap_source: None,
+            common: DecoratorCommon {
+                decorator_span: (0, 0),
+                class_body_start: 0,
+                angular_core_import_span: None,
+                other_angular_core_imports: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_ng_module_basic() {
+        let mut extracted = make_ng_module("AppModule");
+        extracted.declarations_source = Some("[AppComponent]".to_string());
+        extracted.imports_source = Some("[CommonModule]".to_string());
+        extracted.bootstrap_source = Some("[AppComponent]".to_string());
+
+        let output = generate_ng_module_ivy(&extracted).unwrap();
+        assert!(output.factory_code.contains("AppModule_Factory"));
+
+        // Should have two static fields: ɵmod and ɵinj
+        assert_eq!(output.static_fields.len(), 2);
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}defineNgModule"));
+        assert!(output.static_fields[0].contains("type: AppModule"));
+        assert!(output.static_fields[0].contains("declarations: [AppComponent]"));
+        assert!(output.static_fields[0].contains("imports: [CommonModule]"));
+        assert!(output.static_fields[0].contains("bootstrap: [AppComponent]"));
+
+        assert!(output.static_fields[1].contains("\u{0275}\u{0275}defineInjector"));
+        assert!(output.static_fields[1].contains("imports: [CommonModule]"));
+    }
+
+    #[test]
+    fn test_ng_module_empty() {
+        let extracted = make_ng_module("EmptyModule");
+        let output = generate_ng_module_ivy(&extracted).unwrap();
+        assert_eq!(output.static_fields.len(), 2);
+        assert!(output.static_fields[1].contains("\u{0275}\u{0275}defineInjector({})"));
+    }
+
+    #[test]
+    fn test_ng_module_with_providers() {
+        let mut extracted = make_ng_module("AppModule");
+        extracted.providers_source = Some("[AuthService]".to_string());
+        extracted.imports_source = Some("[HttpClientModule]".to_string());
+
+        let output = generate_ng_module_ivy(&extracted).unwrap();
+        assert!(output.static_fields[1].contains("providers: [AuthService]"));
+        assert!(output.static_fields[1].contains("imports: [HttpClientModule]"));
+    }
+
+    #[test]
+    fn test_ng_module_ivy_imports() {
+        let extracted = make_ng_module("AppModule");
+        let output = generate_ng_module_ivy(&extracted).unwrap();
+        assert!(output
+            .ivy_imports
+            .contains("\u{0275}\u{0275}defineNgModule"));
+        assert!(output
+            .ivy_imports
+            .contains("\u{0275}\u{0275}defineInjector"));
+    }
+}

--- a/crates/template-compiler/src/pipe_codegen.rs
+++ b/crates/template-compiler/src/pipe_codegen.rs
@@ -1,0 +1,117 @@
+//! AOT codegen for `@Pipe` decorators.
+//!
+//! Generates `ɵfac` (factory) and `ɵpipe` (`ɵɵdefinePipe`) static fields.
+//!
+//! ## Example
+//! ```text
+//! // Input:
+//! @Pipe({ name: 'dateFormat', standalone: true })
+//! export class DateFormatPipe implements PipeTransform { ... }
+//!
+//! // Output:
+//! export class DateFormatPipe {
+//!   static ɵfac = function DateFormatPipe_Factory(t: any) { return new (t || DateFormatPipe)(); };
+//!   static ɵpipe = ɵɵdefinePipe({ name: 'dateFormat', type: DateFormatPipe, pure: true, standalone: true });
+//! }
+//! ```
+
+use std::collections::BTreeSet;
+
+use ngc_diagnostics::NgcResult;
+
+use crate::codegen::IvyOutput;
+use crate::extract::ExtractedPipe;
+use crate::factory_codegen;
+
+/// Generate Ivy output for a `@Pipe` decorator.
+pub fn generate_pipe_ivy(extracted: &ExtractedPipe) -> NgcResult<IvyOutput> {
+    let name = &extracted.class_name;
+    let mut ivy_imports = BTreeSet::new();
+
+    ivy_imports.insert("\u{0275}\u{0275}definePipe".to_string());
+
+    // Generate factory with DI
+    let (factory_code, inject_imports) =
+        factory_codegen::generate_factory(name, &extracted.constructor_params);
+    for imp in inject_imports {
+        ivy_imports.insert(imp);
+    }
+
+    // Build ɵpipe definition
+    let mut props = Vec::new();
+    props.push(format!("name: '{}'", extracted.pipe_name));
+    props.push(format!("type: {name}"));
+
+    // Angular pipes are pure by default
+    let pure = extracted.pure.unwrap_or(true);
+    props.push(format!("pure: {pure}"));
+
+    if extracted.standalone {
+        props.push("standalone: true".to_string());
+    }
+
+    let define_code = format!(
+        "static \u{0275}pipe = \u{0275}\u{0275}definePipe({{ {} }})",
+        props.join(", ")
+    );
+
+    Ok(IvyOutput {
+        factory_code,
+        static_fields: vec![define_code],
+        child_template_functions: Vec::new(),
+        ivy_imports,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::DecoratorCommon;
+
+    fn make_pipe(
+        pipe_name: &str,
+        class_name: &str,
+        pure: Option<bool>,
+        standalone: bool,
+    ) -> ExtractedPipe {
+        ExtractedPipe {
+            class_name: class_name.to_string(),
+            pipe_name: pipe_name.to_string(),
+            pure,
+            standalone,
+            constructor_params: Vec::new(),
+            common: DecoratorCommon {
+                decorator_span: (0, 0),
+                class_body_start: 0,
+                angular_core_import_span: None,
+                other_angular_core_imports: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_pipe_basic() {
+        let extracted = make_pipe("dateFormat", "DateFormatPipe", None, true);
+        let output = generate_pipe_ivy(&extracted).unwrap();
+        assert!(output.factory_code.contains("DateFormatPipe_Factory"));
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}definePipe"));
+        assert!(output.static_fields[0].contains("name: 'dateFormat'"));
+        assert!(output.static_fields[0].contains("type: DateFormatPipe"));
+        assert!(output.static_fields[0].contains("pure: true"));
+        assert!(output.static_fields[0].contains("standalone: true"));
+    }
+
+    #[test]
+    fn test_pipe_impure() {
+        let extracted = make_pipe("async", "AsyncPipe", Some(false), true);
+        let output = generate_pipe_ivy(&extracted).unwrap();
+        assert!(output.static_fields[0].contains("pure: false"));
+    }
+
+    #[test]
+    fn test_pipe_not_standalone() {
+        let extracted = make_pipe("myPipe", "MyPipe", None, false);
+        let output = generate_pipe_ivy(&extracted).unwrap();
+        assert!(!output.static_fields[0].contains("standalone"));
+    }
+}

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -71,12 +71,6 @@ pub fn rewrite_source_generic(
 
     let mut result = String::new();
 
-    // Prepend child template functions
-    for child_fn in &ivy_output.child_template_functions {
-        result.push_str(child_fn);
-        result.push('\n');
-    }
-
     // Segment A+B: everything before the decorator, with import rewriting
     if let Some((import_start, import_end)) = common.angular_core_import_span {
         let import_start = import_start as usize;
@@ -88,6 +82,12 @@ pub fn rewrite_source_generic(
         result.push_str(&new_import);
         result.push('\n');
         result.push_str(&source[..decorator_start]);
+    }
+
+    // Insert child template functions after imports, before the class
+    for child_fn in &ivy_output.child_template_functions {
+        result.push_str(child_fn);
+        result.push('\n');
     }
 
     // Segment C: skip the decorator and trailing newlines

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -83,9 +83,11 @@ pub fn rewrite_source(
     result.push_str("  ");
     result.push_str(&ivy_output.factory_code);
     result.push_str(";\n");
-    result.push_str("  ");
-    result.push_str(&ivy_output.define_component_code);
-    result.push_str(";\n");
+    for field in &ivy_output.static_fields {
+        result.push_str("  ");
+        result.push_str(field);
+        result.push_str(";\n");
+    }
 
     // Segment E: rest of the file (after class body `{`)
     result.push_str(&source[class_body_start + 1..]);
@@ -136,7 +138,7 @@ mod tests {
     fn make_ivy_output() -> IvyOutput {
         IvyOutput {
             factory_code: "static \u{0275}fac = function AppComponent_Factory(t: any) { return new (t || AppComponent)(); }".to_string(),
-            define_component_code: "static \u{0275}cmp = \u{0275}\u{0275}defineComponent({\n    type: AppComponent\n  })".to_string(),
+            static_fields: vec!["static \u{0275}cmp = \u{0275}\u{0275}defineComponent({\n    type: AppComponent\n  })".to_string()],
             child_template_functions: Vec::new(),
             ivy_imports: BTreeSet::from([
                 "\u{0275}\u{0275}defineComponent".to_string(),

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -1,7 +1,7 @@
 use ngc_diagnostics::{NgcError, NgcResult};
 
 use crate::codegen::IvyOutput;
-use crate::extract::ExtractedComponent;
+use crate::extract::{DecoratorCommon, ExtractedComponent};
 
 /// Rewrite a TypeScript source string to replace the `@Component` decorator
 /// with Ivy static metadata.
@@ -14,9 +14,28 @@ pub fn rewrite_source(
     component: &ExtractedComponent,
     ivy_output: &IvyOutput,
 ) -> NgcResult<String> {
-    let decorator_start = component.decorator_span.0 as usize;
-    let decorator_end = component.decorator_span.1 as usize;
-    let class_body_start = component.class_body_start as usize;
+    let common = DecoratorCommon {
+        decorator_span: component.decorator_span,
+        class_body_start: component.class_body_start,
+        angular_core_import_span: component.angular_core_import_span,
+        other_angular_core_imports: component.other_angular_core_imports.clone(),
+    };
+    rewrite_source_generic(source, &common, ivy_output)
+}
+
+/// Rewrite a TypeScript source string to replace any Angular decorator with
+/// Ivy static metadata.
+///
+/// Generic version that accepts `DecoratorCommon` fields, usable for all
+/// Angular decorator types (`@Component`, `@Injectable`, `@Directive`, etc.).
+pub fn rewrite_source_generic(
+    source: &str,
+    common: &DecoratorCommon,
+    ivy_output: &IvyOutput,
+) -> NgcResult<String> {
+    let decorator_start = common.decorator_span.0 as usize;
+    let decorator_end = common.decorator_span.1 as usize;
+    let class_body_start = common.class_body_start as usize;
 
     // Validate spans
     if decorator_end > source.len() || class_body_start >= source.len() {
@@ -39,7 +58,7 @@ pub fn rewrite_source(
 
     // Build the new @angular/core import line
     let mut ivy_symbols: Vec<&str> = ivy_output.ivy_imports.iter().map(|s| s.as_str()).collect();
-    for imp in &component.other_angular_core_imports {
+    for imp in &common.other_angular_core_imports {
         if !ivy_symbols.contains(&imp.as_str()) {
             ivy_symbols.push(imp);
         }
@@ -59,7 +78,7 @@ pub fn rewrite_source(
     }
 
     // Segment A+B: everything before the decorator, with import rewriting
-    if let Some((import_start, import_end)) = component.angular_core_import_span {
+    if let Some((import_start, import_end)) = common.angular_core_import_span {
         let import_start = import_start as usize;
         let import_end = import_end as usize;
         result.push_str(&source[..import_start]);

--- a/crates/template-compiler/src/selector.rs
+++ b/crates/template-compiler/src/selector.rs
@@ -1,0 +1,161 @@
+//! Parse CSS selector strings into Angular's internal selector array format.
+//!
+//! Angular selectors use a nested array format: `[['tag', 'attr', 'value', ...], ...]`
+//! where multiple top-level arrays represent comma-separated alternatives.
+//!
+//! ## Examples
+//! - `"my-comp"` → `[["my-comp"]]`
+//! - `"[myDir]"` → `[["", "myDir", ""]]`
+//! - `"[attr=value]"` → `[["", "attr", "value"]]`
+//! - `"my-comp, other"` → `[["my-comp"], ["other"]]`
+//! - `".my-class"` → `[["", 8, "my-class"]]`
+
+/// Parse a CSS selector string into Angular's selector array format.
+///
+/// Returns a JavaScript source string like `[['my-comp']]`.
+pub fn parse_selector(selector: &str) -> String {
+    let alternatives: Vec<&str> = selector.split(',').map(|s| s.trim()).collect();
+    let mut parts = Vec::new();
+
+    for alt in alternatives {
+        parts.push(parse_single_selector(alt));
+    }
+
+    format!("[{}]", parts.join(", "))
+}
+
+/// Parse a single selector (no commas) into its array representation.
+fn parse_single_selector(selector: &str) -> String {
+    let selector = selector.trim();
+
+    if selector.is_empty() {
+        return "['']".to_string();
+    }
+
+    let mut items: Vec<String> = Vec::new();
+    let mut tag = String::new();
+    let mut i = 0;
+    let chars: Vec<char> = selector.chars().collect();
+
+    // Parse tag name (if present at the start)
+    while i < chars.len() && chars[i] != '[' && chars[i] != '.' && chars[i] != ':' {
+        tag.push(chars[i]);
+        i += 1;
+    }
+
+    items.push(format!("'{}'", tag.trim()));
+
+    // Parse remaining parts (attributes, classes)
+    while i < chars.len() {
+        match chars[i] {
+            '[' => {
+                // Attribute selector: [name] or [name=value]
+                i += 1;
+                let mut attr_name = String::new();
+                let mut attr_value = String::new();
+                let mut has_value = false;
+
+                while i < chars.len() && chars[i] != ']' {
+                    if chars[i] == '=' {
+                        has_value = true;
+                        i += 1;
+                        // Skip optional quotes
+                        if i < chars.len() && (chars[i] == '\'' || chars[i] == '"') {
+                            let quote = chars[i];
+                            i += 1;
+                            while i < chars.len() && chars[i] != quote {
+                                attr_value.push(chars[i]);
+                                i += 1;
+                            }
+                            if i < chars.len() {
+                                i += 1; // skip closing quote
+                            }
+                        } else {
+                            while i < chars.len() && chars[i] != ']' {
+                                attr_value.push(chars[i]);
+                                i += 1;
+                            }
+                        }
+                    } else {
+                        attr_name.push(chars[i]);
+                        i += 1;
+                    }
+                }
+                if i < chars.len() {
+                    i += 1; // skip ']'
+                }
+
+                items.push(format!("'{}'", attr_name.trim()));
+                items.push(format!(
+                    "'{}'",
+                    if has_value { attr_value.trim() } else { "" }
+                ));
+            }
+            '.' => {
+                // Class selector
+                i += 1;
+                let mut class_name = String::new();
+                while i < chars.len() && chars[i] != '.' && chars[i] != '[' && chars[i] != ':' {
+                    class_name.push(chars[i]);
+                    i += 1;
+                }
+                // 8 = SelectorFlags.CLASS
+                items.push("8".to_string());
+                items.push(format!("'{}'", class_name.trim()));
+            }
+            ':' => {
+                // Pseudo-selector (skip for now)
+                i += 1;
+                while i < chars.len() && chars[i] != ' ' && chars[i] != '[' && chars[i] != '.' {
+                    i += 1;
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    format!("[{}]", items.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_element_selector() {
+        assert_eq!(parse_selector("my-comp"), "[['my-comp']]");
+    }
+
+    #[test]
+    fn test_attribute_selector() {
+        assert_eq!(parse_selector("[myDir]"), "[['', 'myDir', '']]");
+    }
+
+    #[test]
+    fn test_attribute_with_value() {
+        assert_eq!(parse_selector("[attr=value]"), "[['', 'attr', 'value']]");
+    }
+
+    #[test]
+    fn test_multiple_selectors() {
+        assert_eq!(
+            parse_selector("my-comp, other-comp"),
+            "[['my-comp'], ['other-comp']]"
+        );
+    }
+
+    #[test]
+    fn test_class_selector() {
+        assert_eq!(parse_selector(".my-class"), "[['', 8, 'my-class']]");
+    }
+
+    #[test]
+    fn test_element_with_attribute() {
+        assert_eq!(
+            parse_selector("button[type=submit]"),
+            "[['button', 'type', 'submit']]"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #15.

Extends the template compiler to AOT-compile all Angular decorators (`@Injectable`, `@Directive`, `@Pipe`, `@NgModule`) in project files, and fixes numerous template compiler codegen issues discovered during real-world testing.

## Changes

### AOT Decorator Compilation (issue #15)
- **New extraction functions** for `@Injectable`, `@Directive`, `@Pipe`, `@NgModule` with constructor DI parameter extraction (`@Inject`, `@Optional`, `@Self`, `@SkipSelf`, `@Host`)
- **New codegen modules**: `factory_codegen.rs`, `injectable_codegen.rs`, `directive_codegen.rs`, `pipe_codegen.rs`, `ng_module_codegen.rs`
- **`compile_all_decorators()` public API** — replaces `compile_templates()`, tries all decorator types per file
- **Generalized `IvyOutput`** — `static_fields: Vec<String>` supports multiple fields (NgModule needs ɵmod + ɵinj)

### Template Compiler Fixes
- **`ctx_expr` rewrite** — oxc AST-based expression compilation with proper `ctx.` prefixing, TS non-null assertion stripping, and ɵ-symbol exclusion
- **Pipe compilation in bindings** — `[attr.title]="expr | pipe:arg"` compiled to `ɵɵpipeBind*` calls at any nesting depth, with pipe argument support
- **`consts` array** — static attributes registered in `consts` table and referenced by index in `ɵɵelementStart`
- **JS string escaping** — newlines, quotes, backslashes escaped in text nodes and static attribute values
- **Child template placement** — moved after imports to comply with ESM import-first requirement
- **Event handler compilation** — multi-statement handlers with `$event` parameter and proper `return` placement
- **Standalone component scope** — `ɵɵgetComponentDepsFactory` for NgModule dependency resolution via Angular's `depsTracker`

### Linker Fixes
- **`{ token: 'name', attribute: true }` format** — Angular v21 factory dependency format for `ɵɵinjectAttribute`
- **Skip `contentQueries`/`viewQuery`** — array descriptor format incompatible with runtime function format

### Bundler Fix
- **Preserve exports in lazy chunks** — entry modules of lazy chunks keep `export` statements for dynamic `import()` resolution

## Remaining issue

Lazy-loaded routes fail because lazy chunks reference npm symbols (`ɵɵdefineComponent`, etc.) without importing them. Tracked in #17.

## Test plan

- [x] 286 workspace tests pass (82 in template-compiler alone)
- [x] Round-trip tests for all decorator types and complex component patterns
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 0 transform fallbacks on real Angular project
- [x] App renders: header, sidebar, icons, hover effects, auth redirect working