### PR TITLE
fix: lazy chunk imports, @let support, and linker improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -7,7 +7,7 @@ use oxc_sourcemap::{ConcatSourceMapBuilder, SourceMap};
 use petgraph::graph::DiGraph;
 use tracing::debug;
 
-use crate::chunk::build_chunk_graph;
+use crate::chunk::{build_chunk_graph, ChunkKind};
 use crate::minify;
 use crate::rewrite::{self, ExternalImport};
 use crate::shake;
@@ -90,8 +90,47 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     let mut output_chunks: HashMap<String, String> = HashMap::new();
     let mut chunk_source_maps: HashMap<String, SourceMap> = HashMap::new();
 
-    for chunk in &chunk_graph.chunks {
-        // Run tree shaking analysis for this chunk if enabled
+    // Process main chunk first to get specifier→namespace mapping
+    let main_chunk = &chunk_graph.chunks[0];
+    let main_unused = if input.options.tree_shake {
+        shake::analyze_unused_exports(
+            &main_chunk.modules,
+            &input.modules,
+            &main_chunk.entry,
+            &prefix_refs,
+        )?
+    } else {
+        HashMap::new()
+    };
+
+    let main_module_set: HashSet<PathBuf> = main_chunk.modules.iter().cloned().collect();
+    let main_result = bundle_chunk(&ChunkBundleParams {
+        module_paths: &main_chunk.modules,
+        all_modules: &input.modules,
+        root_dir: &input.root_dir,
+        prefix_refs: &prefix_refs,
+        specifier_rewrites: &specifier_rewrites,
+        per_module_maps: &input.per_module_maps,
+        generate_source_maps: input.options.source_maps,
+        unused_exports: &main_unused,
+        bundled_specifiers: &input.bundled_specifiers,
+        chunk_entry: &main_chunk.entry,
+        chunk_kind: &main_chunk.kind,
+        chunk_module_set: &main_module_set,
+        main_file_to_ns: &HashMap::new(),
+        main_chunk_module_set: &main_module_set,
+    })?;
+    let main_spec_to_ns = main_result.specifier_to_namespace;
+    let main_file_to_ns = main_result.file_to_namespace;
+    output_chunks.insert(main_chunk.filename.clone(), main_result.code);
+    if let Some(map) = main_result.source_map {
+        chunk_source_maps.insert(main_chunk.filename.clone(), map);
+    }
+
+    // Process lazy/shared chunks, collecting symbols they need from main
+    let mut all_needed_npm: HashMap<String, BTreeSet<String>> = HashMap::new();
+    let mut all_needed_project: BTreeSet<String> = BTreeSet::new();
+    for chunk in &chunk_graph.chunks[1..] {
         let unused_exports = if input.options.tree_shake {
             shake::analyze_unused_exports(
                 &chunk.modules,
@@ -103,7 +142,8 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
             HashMap::new()
         };
 
-        let (chunk_code, chunk_map) = bundle_chunk(&ChunkBundleParams {
+        let lazy_module_set: HashSet<PathBuf> = chunk.modules.iter().cloned().collect();
+        let result = bundle_chunk(&ChunkBundleParams {
             module_paths: &chunk.modules,
             all_modules: &input.modules,
             root_dir: &input.root_dir,
@@ -114,10 +154,43 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
             unused_exports: &unused_exports,
             bundled_specifiers: &input.bundled_specifiers,
             chunk_entry: &chunk.entry,
+            chunk_kind: &chunk.kind,
+            chunk_module_set: &lazy_module_set,
+            main_file_to_ns: &main_file_to_ns,
+            main_chunk_module_set: &main_module_set,
         })?;
-        output_chunks.insert(chunk.filename.clone(), chunk_code);
-        if let Some(map) = chunk_map {
+
+        // Collect npm symbols this chunk needs.
+        // Namespace imports ("* as X") are stored with the local name only.
+        for ext in &result.npm_externals {
+            let entry = all_needed_npm.entry(ext.source.clone()).or_default();
+            for name in &ext.named_imports {
+                if let Some(local) = name.strip_prefix("* as ") {
+                    entry.insert(format!("__ns_import__{local}"));
+                } else {
+                    entry.insert(name.clone());
+                }
+            }
+            if let Some(ref default) = ext.default_import {
+                entry.insert(default.clone());
+            }
+        }
+
+        // Collect project symbols this chunk needs from main
+        all_needed_project.extend(result.project_cross_chunk_symbols);
+
+        output_chunks.insert(chunk.filename.clone(), result.code);
+        if let Some(map) = result.source_map {
             chunk_source_maps.insert(chunk.filename.clone(), map);
+        }
+    }
+
+    // Append re-exports to main chunk for symbols that lazy chunks need.
+    if !all_needed_npm.is_empty() || !all_needed_project.is_empty() {
+        let reexport_code =
+            generate_cross_chunk_exports(&all_needed_npm, &main_spec_to_ns, &all_needed_project);
+        if let Some(main_code) = output_chunks.get_mut("main.js") {
+            main_code.push_str(&reexport_code);
         }
     }
 
@@ -251,58 +324,87 @@ struct ChunkBundleParams<'a> {
     bundled_specifiers: &'a HashSet<String>,
     /// The chunk's entry module — exports from this module are preserved.
     chunk_entry: &'a Path,
+    /// The kind of chunk being bundled (Main, Lazy, or Shared).
+    chunk_kind: &'a ChunkKind,
+    /// Set of canonical module paths in this chunk (for cross-chunk import detection).
+    chunk_module_set: &'a HashSet<PathBuf>,
+    /// Main chunk's file path → namespace mapping (for resolving npm cross-chunk imports).
+    main_file_to_ns: &'a HashMap<PathBuf, String>,
+    /// Set of canonical module paths in the main chunk.
+    main_chunk_module_set: &'a HashSet<PathBuf>,
+}
+
+/// Result of bundling a single chunk, including cross-chunk dependency info.
+struct ChunkBundleResult {
+    /// The bundled chunk code.
+    code: String,
+    /// Optional source map for the chunk.
+    source_map: Option<SourceMap>,
+    /// For lazy/shared chunks: npm external imports that need re-exporting from main.
+    npm_externals: Vec<ExternalImport>,
+    /// For lazy/shared chunks: project symbols imported from main chunk modules.
+    project_cross_chunk_symbols: BTreeSet<String>,
+    /// For main chunk: bare specifier → namespace variable name mapping.
+    specifier_to_namespace: HashMap<String, String>,
+    /// For main chunk: canonical file path → namespace variable name mapping.
+    file_to_namespace: HashMap<PathBuf, String>,
 }
 
 /// Bundle a single chunk's modules into an ESM string, optionally with a source map.
-fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMap>)> {
+fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
+    let is_lazy = *p.chunk_kind != ChunkKind::Main;
+
     let mut all_externals: Vec<ExternalImport> = Vec::new();
     let mut sections: Vec<ModuleSection> = Vec::new();
 
     // Build namespace map: npm file path → namespace variable name
-    // and specifier → namespace for project code imports
+    // and specifier → namespace for project code imports.
+    // Only needed for the main chunk — lazy chunks import npm symbols from main.
     let node_modules_dir = p.root_dir.join("node_modules");
     let mut file_to_namespace: HashMap<PathBuf, String> = HashMap::new();
     let mut specifier_to_namespace: HashMap<String, String> = HashMap::new();
 
-    // First pass: assign namespaces to all npm modules in this chunk
-    for module_path in p.module_paths {
-        let is_npm = module_path
-            .components()
-            .any(|c| c.as_os_str() == "node_modules");
-        if is_npm {
-            let ns = crate::npm_wrap::namespace_from_path(module_path, &node_modules_dir);
-            debug!(path = %module_path.display(), namespace = %ns, "assigned npm namespace");
-            file_to_namespace.insert(module_path.clone(), ns);
-        }
-    }
-    debug!(
-        npm_module_count = file_to_namespace.len(),
-        total_modules = p.module_paths.len(),
-        "npm namespace assignment complete"
-    );
-
-    // Build specifier → namespace mapping for project code and npm cross-references.
-    // Resolve each bare specifier to its actual entry file path and look up the namespace.
-    for spec in p.bundled_specifiers.iter() {
-        // Try to resolve the specifier to its entry file using the npm resolver
-        if let Ok(entry_path) = ngc_npm_resolver::resolve::resolve_bare_specifier(
-            spec,
-            node_modules_dir.parent().unwrap_or(&node_modules_dir),
-        ) {
-            let canonical = entry_path.canonicalize().unwrap_or(entry_path);
-            if let Some(ns) = file_to_namespace.get(&canonical) {
-                specifier_to_namespace.insert(spec.clone(), ns.clone());
-                continue;
+    if !is_lazy {
+        // First pass: assign namespaces to all npm modules in this chunk
+        for module_path in p.module_paths {
+            let is_npm = module_path
+                .components()
+                .any(|c| c.as_os_str() == "node_modules");
+            if is_npm {
+                let ns = crate::npm_wrap::namespace_from_path(module_path, &node_modules_dir);
+                debug!(path = %module_path.display(), namespace = %ns, "assigned npm namespace");
+                file_to_namespace.insert(module_path.clone(), ns);
             }
         }
-        // Fallback: for vendored/synthetic modules (e.g., @oxc-project/runtime/helpers/decorate)
-        // that don't have a package.json, match by path suffix in the file_to_namespace map.
-        let spec_path_suffix = spec.replace('/', std::path::MAIN_SEPARATOR_STR);
-        for (path, ns) in &file_to_namespace {
-            let path_str = path.to_string_lossy();
-            if path_str.contains(&spec_path_suffix) {
-                specifier_to_namespace.insert(spec.clone(), ns.clone());
-                break;
+        debug!(
+            npm_module_count = file_to_namespace.len(),
+            total_modules = p.module_paths.len(),
+            "npm namespace assignment complete"
+        );
+
+        // Build specifier → namespace mapping for project code and npm cross-references.
+        // Resolve each bare specifier to its actual entry file path and look up the namespace.
+        for spec in p.bundled_specifiers.iter() {
+            // Try to resolve the specifier to its entry file using the npm resolver
+            if let Ok(entry_path) = ngc_npm_resolver::resolve::resolve_bare_specifier(
+                spec,
+                node_modules_dir.parent().unwrap_or(&node_modules_dir),
+            ) {
+                let canonical = entry_path.canonicalize().unwrap_or(entry_path);
+                if let Some(ns) = file_to_namespace.get(&canonical) {
+                    specifier_to_namespace.insert(spec.clone(), ns.clone());
+                    continue;
+                }
+            }
+            // Fallback: for vendored/synthetic modules (e.g., @oxc-project/runtime/helpers/decorate)
+            // that don't have a package.json, match by path suffix in the file_to_namespace map.
+            let spec_path_suffix = spec.replace('/', std::path::MAIN_SEPARATOR_STR);
+            for (path, ns) in &file_to_namespace {
+                let path_str = path.to_string_lossy();
+                if path_str.contains(&spec_path_suffix) {
+                    specifier_to_namespace.insert(spec.clone(), ns.clone());
+                    break;
+                }
             }
         }
     }
@@ -374,21 +476,112 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMa
                 });
             }
         } else {
-            // Project module: use existing rewriter with namespace map
+            // Project module: use existing rewriter with namespace map.
+            // For lazy/shared chunks, pass empty prefixes and bundled_specifiers
+            // so ALL imports are collected as external (for cross-chunk resolution).
+            let empty_specifiers = HashSet::new();
+            let empty_ns_map = HashMap::new();
+            let empty_prefixes: Vec<&str> = Vec::new();
+            let (effective_prefixes, effective_bundled, effective_ns_map) = if is_lazy {
+                (empty_prefixes.as_slice(), &empty_specifiers, &empty_ns_map)
+            } else {
+                (p.prefix_refs, p.bundled_specifiers, &specifier_to_namespace)
+            };
+
             let module_unused = p.unused_exports.get(module_path);
             let is_chunk_entry = module_path == p.chunk_entry;
             let rewritten = rewrite::rewrite_module_with_shaking(
                 js_code,
                 &file_name,
-                p.prefix_refs,
+                effective_prefixes,
                 p.specifier_rewrites,
                 module_unused,
-                p.bundled_specifiers,
-                &specifier_to_namespace,
+                effective_bundled,
+                effective_ns_map,
                 is_chunk_entry,
             )?;
 
-            all_externals.extend(rewritten.external_imports);
+            if is_lazy {
+                // For lazy chunks, classify each external import per-module
+                // so relative paths can be resolved from the correct source.
+                let module_dir = module_path.parent();
+                let is_npm_module = module_path
+                    .components()
+                    .any(|c| c.as_os_str() == "node_modules");
+                for ext in rewritten.external_imports {
+                    if p.bundled_specifiers.contains(&ext.source) {
+                        // npm bare specifier → cross-chunk from main
+                        all_externals.push(ext);
+                    } else if ext.source.starts_with('.') {
+                        if is_npm_module {
+                            // Relative import from an npm module to another npm module.
+                            // Resolve to find the target's namespace in the main chunk.
+                            let mut resolved_ext = ext.clone();
+                            if let Some(dir) = module_dir {
+                                let target = dir.join(&ext.source);
+                                for c in &[
+                                    target.clone(),
+                                    target.with_extension("js"),
+                                    target.with_extension("mjs"),
+                                    target.join("index.js"),
+                                    target.join("index.mjs"),
+                                ] {
+                                    if let Ok(canon) = c.canonicalize() {
+                                        if let Some(ns) = p.main_file_to_ns.get(&canon) {
+                                            resolved_ext.source = format!("__resolved_ns__{ns}");
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            // If resolution failed, still mark as npm-sourced so it
+                            // doesn't get misclassified as a project symbol
+                            if !resolved_ext.source.starts_with("__resolved_ns__") {
+                                resolved_ext.source = "__npm_unresolved__".to_string();
+                            }
+                            all_externals.push(resolved_ext);
+                            continue;
+                        }
+                        // Relative import from project module — resolve from this module's directory
+                        let resolved = module_dir.and_then(|dir| {
+                            let candidate = dir.join(&ext.source);
+                            for c in &[
+                                candidate.clone(),
+                                candidate.with_extension("ts"),
+                                candidate.with_extension("js"),
+                                candidate.with_extension("mjs"),
+                            ] {
+                                if let Ok(canon) = c.canonicalize() {
+                                    return Some(canon);
+                                }
+                            }
+                            None
+                        });
+                        match resolved {
+                            Some(ref resolved_path) => {
+                                if p.chunk_module_set.contains(resolved_path) {
+                                    continue; // Same chunk — discard
+                                }
+                                if p.main_chunk_module_set.contains(resolved_path) {
+                                    all_externals.push(ext); // Verified in main
+                                }
+                                // else: in another lazy/shared chunk — discard
+                            }
+                            None => {
+                                // Unresolved relative import — discard (can't verify main)
+                            }
+                        }
+                    } else if p.prefix_refs.iter().any(|pfx| ext.source.starts_with(pfx)) {
+                        // Path alias import — cross-chunk from main
+                        all_externals.push(ext);
+                    } else {
+                        // Unknown bare specifier — treat as npm
+                        all_externals.push(ext);
+                    }
+                }
+            } else {
+                all_externals.extend(rewritten.external_imports);
+            }
 
             let trimmed = rewritten.code.trim();
             if !trimmed.is_empty() {
@@ -402,6 +595,63 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMa
                     source_path: module_path.clone(),
                 });
             }
+        }
+    }
+
+    // For lazy/shared chunks, all remaining externals are cross-chunk imports
+    // (same-chunk imports were already filtered in the per-module loop above).
+    // Merge them all into a single import from ./main.js.
+    let mut npm_externals: Vec<ExternalImport> = Vec::new();
+    let mut project_cross_chunk_symbols: BTreeSet<String> = BTreeSet::new();
+    if is_lazy {
+        let mut main_js_named = BTreeSet::new();
+        let mut main_js_default = None;
+
+        for ext in all_externals {
+            // Classify: npm externals go through namespace lookup, project externals
+            // are already top-level declarations in main.js.
+            let is_from_npm = ext.source.starts_with("__resolved_ns__")
+                || ext.source.starts_with("__npm_")
+                || p.bundled_specifiers.contains(&ext.source)
+                || (!ext.source.starts_with('.')
+                    && !p.prefix_refs.iter().any(|pfx| ext.source.starts_with(pfx)));
+
+            if is_from_npm {
+                npm_externals.push(ext.clone());
+            } else {
+                // Project symbol — already in main chunk scope
+                for name in &ext.named_imports {
+                    let local = name.strip_prefix("* as ").unwrap_or(name);
+                    project_cross_chunk_symbols.insert(local.to_string());
+                }
+                if let Some(ref default) = ext.default_import {
+                    project_cross_chunk_symbols.insert(default.clone());
+                }
+            }
+
+            // Collect all symbols for the ./main.js import
+            for name in &ext.named_imports {
+                if let Some(local) = name.strip_prefix("* as ") {
+                    main_js_named.insert(local.to_string());
+                } else {
+                    main_js_named.insert(name.clone());
+                }
+            }
+            if main_js_default.is_none() {
+                main_js_default.clone_from(&ext.default_import);
+            }
+        }
+
+        all_externals = Vec::new();
+
+        // Merge all cross-chunk imports into a single import from ./main.js
+        if !main_js_named.is_empty() || main_js_default.is_some() {
+            all_externals.push(ExternalImport {
+                source: "./main.js".to_string(),
+                default_import: main_js_default,
+                named_imports: main_js_named,
+                is_side_effect: false,
+            });
         }
     }
 
@@ -464,7 +714,66 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<(String, Option<SourceMa
         None
     };
 
-    Ok((output, combined_map))
+    Ok(ChunkBundleResult {
+        code: output,
+        source_map: combined_map,
+        npm_externals,
+        project_cross_chunk_symbols,
+        specifier_to_namespace,
+        file_to_namespace,
+    })
+}
+
+/// Generate export statements on the main chunk for symbols that lazy chunks need.
+///
+/// For npm symbols, emits `var` declarations from IIFE namespaces.
+/// For project symbols, they're already in scope as top-level declarations.
+/// Both are exported via a single `export { ... }` statement.
+fn generate_cross_chunk_exports(
+    needed_npm: &HashMap<String, BTreeSet<String>>,
+    specifier_to_ns: &HashMap<String, String>,
+    needed_project: &BTreeSet<String>,
+) -> String {
+    let mut all_symbols: BTreeSet<String> = BTreeSet::new();
+    let mut var_lines: Vec<String> = Vec::new();
+
+    for (specifier, symbols) in needed_npm {
+        // Look up namespace: first by specifier, then by resolved namespace key
+        let resolved_ns_key = specifier.strip_prefix("__resolved_ns__").map(String::from);
+        let ns = specifier_to_ns.get(specifier).or(resolved_ns_key.as_ref());
+        // Skip symbols without a namespace mapping — they come from npm modules
+        // in non-main chunks and can't be exported from main.js.
+        let Some(ns) = ns else {
+            continue;
+        };
+        for sym in symbols {
+            if let Some(local) = sym.strip_prefix("__ns_import__") {
+                if all_symbols.insert(local.to_string()) {
+                    var_lines.push(format!("var {local} = {ns};"));
+                }
+            } else if all_symbols.insert(sym.clone()) {
+                var_lines.push(format!("var {sym} = {ns}.{sym};"));
+            }
+        }
+    }
+
+    // Additional project symbols from the needed_project set.
+    for sym in needed_project {
+        all_symbols.insert(sym.clone());
+    }
+
+    if all_symbols.is_empty() {
+        return String::new();
+    }
+
+    let mut code = String::from("\n// Cross-chunk exports for lazy-loaded chunks\n");
+    for line in &var_lines {
+        code.push_str(line);
+        code.push('\n');
+    }
+    let syms: Vec<&str> = all_symbols.iter().map(|s| s.as_str()).collect();
+    code.push_str(&format!("export {{ {} }};\n", syms.join(", ")));
+    code
 }
 
 /// Compute a truncated SHA-256 content hash (8 hex characters).
@@ -515,7 +824,14 @@ fn apply_content_hashes(
     if let Some(main_code) = chunks.get("main.js") {
         let hash = content_hash(main_code);
         let hashed_main = insert_hash_in_filename("main.js", &hash);
-        rename_map.insert("main.js".to_string(), hashed_main);
+        rename_map.insert("main.js".to_string(), hashed_main.clone());
+
+        // Replace main.js references in lazy/shared chunks (they import from ./main.js)
+        for (filename, code) in chunks.iter_mut() {
+            if filename != "main.js" {
+                *code = code.replace("./main.js", &format!("./{hashed_main}"));
+            }
+        }
     }
 
     // Apply renames to the chunks and source_maps HashMaps

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -545,13 +545,12 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
                         // Relative import from project module — resolve from this module's directory
                         let resolved = module_dir.and_then(|dir| {
                             let candidate = dir.join(&ext.source);
-                            for c in &[
-                                candidate.clone(),
-                                candidate.with_extension("ts"),
-                                candidate.with_extension("js"),
-                                candidate.with_extension("mjs"),
-                            ] {
-                                if let Ok(canon) = c.canonicalize() {
+                            let candidate_str = candidate.to_string_lossy().to_string();
+                            // Append extensions (not replace) to handle paths like
+                            // ./logto-auth.service where .service is NOT an extension.
+                            for suffix in &["", ".ts", ".js", ".mjs"] {
+                                let full = PathBuf::from(format!("{candidate_str}{suffix}"));
+                                if let Ok(canon) = full.canonicalize() {
                                     return Some(canon);
                                 }
                             }

--- a/crates/bundler/src/npm_wrap.rs
+++ b/crates/bundler/src/npm_wrap.rs
@@ -120,6 +120,9 @@ where
                 ModuleDeclaration::ExportNamedDeclaration(export) => {
                     if export.source.is_some() {
                         // Re-export: export { X } from './other'
+                        // In ESM, re-exports do NOT create local bindings. We must
+                        // assign directly to __exports to avoid shadowing imports
+                        // that use the same local name.
                         let source = export
                             .source
                             .as_ref()
@@ -130,9 +133,11 @@ where
                         for spec in &export.specifiers {
                             let exported = spec.exported.name().to_string();
                             let local = spec.local.name().to_string();
-                            exported_names.push(exported.clone());
+                            // Don't add to exported_names — we handle the export inline
                             if let Some(ref ns) = target_ns {
-                                replacements.push(format!("var {exported} = {ns}.{local};"));
+                                replacements.push(format!("__exports.{exported} = {ns}.{local};"));
+                            } else {
+                                exported_names.push(exported.clone());
                             }
                         }
                         let replacement = if replacements.is_empty() {

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -46,7 +46,7 @@ class AppComponent {
 				ɵɵelement(2, 'router-outlet');
 			}
 			if (rf & 2) {
-				ɵɵadvance();
+				ɵɵadvance(2);
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -73,9 +73,17 @@ pub fn transform(
     }
 
     // Template compilation
+    let mut child_fns_code: Vec<String> = Vec::new();
+    let mut extra_ivy_imports: std::collections::BTreeSet<String> =
+        std::collections::BTreeSet::new();
     if let Some(template_str) = metadata::get_string_prop(obj, "template") {
         let template_ok = match compile_template(&template_str, &type_name, file_path) {
-            Ok((template_fn, decls, vars, _child_fns)) => {
+            Ok(tpl) => {
+                let template_fn = tpl.template_function;
+                let decls = tpl.decls;
+                let vars = tpl.vars;
+                let child_fns = tpl.child_template_functions;
+                let ivy_imports = tpl.ivy_imports;
                 // Validate that the compiled template is valid JavaScript
                 // (the template parser may "succeed" on unsupported syntax like @let
                 // but produce output with literal newlines inside string literals)
@@ -83,6 +91,8 @@ pub fn transform(
                     props.push(format!("decls: {decls}"));
                     props.push(format!("vars: {vars}"));
                     props.push(format!("template: {template_fn}"));
+                    child_fns_code = child_fns;
+                    extra_ivy_imports = ivy_imports;
                     true
                 } else {
                     tracing::warn!(
@@ -152,7 +162,26 @@ pub fn transform(
         props.push(format!("changeDetection: {cd}"));
     }
 
-    Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
+    let define_call = format!("{define_fn}({{ {} }})", props.join(", "));
+
+    // If the template produced child template functions (e.g. for @if/@for blocks),
+    // wrap everything in an IIFE so the functions are in scope when the template runs.
+    if child_fns_code.is_empty() && extra_ivy_imports.is_empty() {
+        Ok(define_call)
+    } else {
+        let fns = child_fns_code.join("\n");
+        // Add var declarations for new Ivy symbols (e.g. ɵɵdeclareLet, ɵɵstoreLet)
+        // that weren't in the original npm source. Use the ng_import prefix (e.g. i0).
+        let mut var_decls = String::new();
+        if !ng_import.is_empty() {
+            for sym in &extra_ivy_imports {
+                var_decls.push_str(&format!("var {sym} = {ng_import}.{sym};\n"));
+            }
+        }
+        Ok(format!(
+            "(function() {{ {var_decls}{fns}\nreturn {define_call}; }})()"
+        ))
+    }
 }
 
 /// Validate that a generated template function is valid JavaScript.
@@ -169,12 +198,12 @@ fn is_valid_js_function(code: &str) -> bool {
 
 /// Compile a template string into a template function using the template compiler.
 ///
-/// Returns `(template_function_code, decls, vars, child_template_functions)`.
+/// Compile a template and return the template function output.
 fn compile_template(
     template: &str,
     component_name: &str,
     file_path: &Path,
-) -> NgcResult<(String, u32, u32, Vec<String>)> {
+) -> NgcResult<ngc_template_compiler::TemplateFnOutput> {
     use ngc_template_compiler::{generate_template_fn, TemplateMetadata};
 
     let meta = TemplateMetadata {
@@ -185,14 +214,7 @@ fn compile_template(
         styles_source: None,
     };
 
-    let result = generate_template_fn(template, &meta, file_path)?;
-
-    Ok((
-        result.template_function,
-        result.decls,
-        result.vars,
-        result.child_template_functions,
-    ))
+    generate_template_fn(template, &meta, file_path)
 }
 
 /// Build the `dependencies` array from the declare format.

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -253,9 +253,9 @@ pub fn build_host_bindings(
                 let key = prop_key_text(&p.key, source);
                 if let Expression::StringLiteral(s) = &p.value {
                     let prop_fn = if ng_import.is_empty() {
-                        "\u{0275}\u{0275}hostProperty".to_string()
+                        "\u{0275}\u{0275}property".to_string()
                     } else {
-                        format!("{ng_import}.\u{0275}\u{0275}hostProperty")
+                        format!("{ng_import}.\u{0275}\u{0275}property")
                     };
                     let expr = compile_host_expression(&s.value);
                     binding_stmts.push(format!("{prop_fn}(\"{key}\", {expr})"));

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -119,10 +119,20 @@ pub fn build_define_call(
         props.push(format!("providers: {providers}"));
     }
 
-    // Queries: contentQueries and viewQuery require compilation from declare format
-    // (array of descriptors) to runtime format (functions with ɵɵcontentQuery/ɵɵviewQuery calls).
-    // Skipped for now — the raw array format crashes the Angular runtime.
-    // TODO: compile query descriptors to query functions
+    // Content queries: compile from declare format (array of descriptors) to runtime
+    // format (contentQueries function with ɵɵcontentQuery/ɵɵloadQuery/ɵɵqueryRefresh calls).
+    if let Some(queries) = metadata::get_source_text(obj, "queries", source) {
+        if let Some(content_queries_fn) = build_content_queries(queries, ng_import, source, obj) {
+            props.push(format!("contentQueries: {content_queries_fn}"));
+        }
+    }
+
+    // View queries: compile from declare format to runtime format.
+    if let Some(view_queries) = metadata::get_source_text(obj, "viewQueries", source) {
+        if let Some(view_query_fn) = build_view_queries(view_queries, ng_import, source, obj) {
+            props.push(format!("viewQuery: {view_query_fn}"));
+        }
+    }
 
     Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
 }
@@ -246,20 +256,50 @@ pub fn build_host_bindings(
         attrs.push(format!("'{style_attr}'"));
     }
 
-    // Property bindings
+    // Property bindings — dispatch to the correct Ivy instruction based on property name
     if let Some(properties_obj) = metadata::get_object_prop(host_obj, "properties") {
         for prop in &properties_obj.properties {
             if let ObjectPropertyKind::ObjectProperty(p) = prop {
                 let key = prop_key_text(&p.key, source);
                 if let Expression::StringLiteral(s) = &p.value {
-                    let prop_fn = if ng_import.is_empty() {
-                        "\u{0275}\u{0275}property".to_string()
-                    } else {
-                        format!("{ng_import}.\u{0275}\u{0275}property")
-                    };
                     let expr = compile_host_expression(&s.value);
-                    binding_stmts.push(format!("{prop_fn}(\"{key}\", {expr})"));
-                    host_vars += 1;
+                    if let Some(style_prop) = key.strip_prefix("style.") {
+                        // style.X → ɵɵstyleProp (2 vars per style binding)
+                        let fn_name = if ng_import.is_empty() {
+                            "\u{0275}\u{0275}styleProp".to_string()
+                        } else {
+                            format!("{ng_import}.\u{0275}\u{0275}styleProp")
+                        };
+                        binding_stmts.push(format!("{fn_name}(\"{style_prop}\", {expr})"));
+                        host_vars += 2;
+                    } else if let Some(class_name) = key.strip_prefix("class.") {
+                        // class.X → ɵɵclassProp (2 vars per class binding)
+                        let fn_name = if ng_import.is_empty() {
+                            "\u{0275}\u{0275}classProp".to_string()
+                        } else {
+                            format!("{ng_import}.\u{0275}\u{0275}classProp")
+                        };
+                        binding_stmts.push(format!("{fn_name}(\"{class_name}\", {expr})"));
+                        host_vars += 2;
+                    } else if key == "class" {
+                        // class → ɵɵclassMap
+                        let fn_name = if ng_import.is_empty() {
+                            "\u{0275}\u{0275}classMap".to_string()
+                        } else {
+                            format!("{ng_import}.\u{0275}\u{0275}classMap")
+                        };
+                        binding_stmts.push(format!("{fn_name}({expr})"));
+                        host_vars += 2;
+                    } else {
+                        // Regular property → ɵɵproperty (1 var)
+                        let fn_name = if ng_import.is_empty() {
+                            "\u{0275}\u{0275}property".to_string()
+                        } else {
+                            format!("{ng_import}.\u{0275}\u{0275}property")
+                        };
+                        binding_stmts.push(format!("{fn_name}(\"{key}\", {expr})"));
+                        host_vars += 1;
+                    }
                 }
             }
         }
@@ -523,6 +563,205 @@ fn collect_ctx_rewrites(
             // For other expression types, leave as-is
         }
     }
+}
+
+/// Build a `contentQueries` function from the declare-format `queries` array.
+///
+/// Transforms: `[{ propertyName: "links", predicate: RouterLink, descendants: true }]`
+/// Into: `function(rf, ctx, directiveIndex) { if (rf & 1) { ɵɵcontentQuery(directiveIndex, RouterLink, 5); } if (rf & 2) { let _t; ɵɵqueryRefresh(_t = ɵɵloadQuery()) && (ctx.links = _t); } }`
+fn build_content_queries(
+    queries_source: &str,
+    ng_import: &str,
+    source: &str,
+    obj: &oxc_ast::ast::ObjectExpression<'_>,
+) -> Option<String> {
+    let queries = parse_query_descriptors(queries_source, source, obj)?;
+    if queries.is_empty() {
+        return None;
+    }
+
+    let (cq, refresh, load) = if ng_import.is_empty() {
+        (
+            "\u{0275}\u{0275}contentQuery".to_string(),
+            "\u{0275}\u{0275}queryRefresh".to_string(),
+            "\u{0275}\u{0275}loadQuery".to_string(),
+        )
+    } else {
+        (
+            format!("{ng_import}.\u{0275}\u{0275}contentQuery"),
+            format!("{ng_import}.\u{0275}\u{0275}queryRefresh"),
+            format!("{ng_import}.\u{0275}\u{0275}loadQuery"),
+        )
+    };
+
+    let mut create_stmts = Vec::new();
+    let mut update_stmts = Vec::new();
+
+    for q in &queries {
+        let flags = compute_query_flags(q);
+        let read_arg = if let Some(ref read) = q.read {
+            format!(", {read}")
+        } else {
+            String::new()
+        };
+        create_stmts.push(format!(
+            "{cq}(directiveIndex, {}, {flags}{read_arg});",
+            q.predicate
+        ));
+        update_stmts.push(format!(
+            "let _t; {refresh}(_t = {load}()) && (ctx.{} = _t);",
+            q.property_name
+        ));
+    }
+
+    let mut body = String::from("if (rf & 1) { ");
+    for s in &create_stmts {
+        body.push_str(s);
+        body.push(' ');
+    }
+    body.push_str("} if (rf & 2) { ");
+    for s in &update_stmts {
+        body.push_str(s);
+        body.push(' ');
+    }
+    body.push('}');
+
+    Some(format!("function(rf, ctx, directiveIndex) {{ {body} }}"))
+}
+
+/// Build a `viewQuery` function from the declare-format `viewQueries` array.
+fn build_view_queries(
+    queries_source: &str,
+    ng_import: &str,
+    source: &str,
+    obj: &oxc_ast::ast::ObjectExpression<'_>,
+) -> Option<String> {
+    let queries = parse_query_descriptors(queries_source, source, obj)?;
+    if queries.is_empty() {
+        return None;
+    }
+
+    let (vq, refresh, load) = if ng_import.is_empty() {
+        (
+            "\u{0275}\u{0275}viewQuery".to_string(),
+            "\u{0275}\u{0275}queryRefresh".to_string(),
+            "\u{0275}\u{0275}loadQuery".to_string(),
+        )
+    } else {
+        (
+            format!("{ng_import}.\u{0275}\u{0275}viewQuery"),
+            format!("{ng_import}.\u{0275}\u{0275}queryRefresh"),
+            format!("{ng_import}.\u{0275}\u{0275}loadQuery"),
+        )
+    };
+
+    let mut create_stmts = Vec::new();
+    let mut update_stmts = Vec::new();
+
+    for q in &queries {
+        let flags = compute_query_flags(q);
+        let read_arg = if let Some(ref read) = q.read {
+            format!(", {read}")
+        } else {
+            String::new()
+        };
+        create_stmts.push(format!("{vq}({}, {flags}{read_arg});", q.predicate));
+        update_stmts.push(format!(
+            "let _t; {refresh}(_t = {load}()) && (ctx.{} = _t);",
+            q.property_name
+        ));
+    }
+
+    let mut body = String::from("if (rf & 1) { ");
+    for s in &create_stmts {
+        body.push_str(s);
+        body.push(' ');
+    }
+    body.push_str("} if (rf & 2) { ");
+    for s in &update_stmts {
+        body.push_str(s);
+        body.push(' ');
+    }
+    body.push('}');
+
+    Some(format!("function(rf, ctx) {{ {body} }}"))
+}
+
+/// A parsed query descriptor.
+struct QueryDescriptor {
+    property_name: String,
+    predicate: String,
+    descendants: bool,
+    is_static: bool,
+    read: Option<String>,
+    first: bool,
+}
+
+/// Compute the flags integer for a query.
+fn compute_query_flags(q: &QueryDescriptor) -> u32 {
+    let mut flags: u32 = 0;
+    if q.descendants {
+        flags |= 1; // QueryFlags.descendants
+    }
+    if q.is_static {
+        flags |= 2; // QueryFlags.isStatic
+    }
+    if !q.first {
+        flags |= 4; // QueryFlags.emitDistinctChangesOnly (for QueryList)
+    }
+    flags
+}
+
+/// Parse query descriptors from the raw source text of the `queries` array.
+///
+/// Uses oxc to parse the array literal and extract each query's fields.
+fn parse_query_descriptors(
+    _queries_source: &str,
+    source: &str,
+    obj: &oxc_ast::ast::ObjectExpression<'_>,
+) -> Option<Vec<QueryDescriptor>> {
+    use oxc_ast::ast::*;
+
+    // Find the queries/viewQueries property
+    let queries_arr = obj.properties.iter().find_map(|p| {
+        if let ObjectPropertyKind::ObjectProperty(prop) = p {
+            let key_name = match &prop.key {
+                PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+                _ => None,
+            };
+            if key_name == Some("queries") || key_name == Some("viewQueries") {
+                if let Expression::ArrayExpression(arr) = &prop.value {
+                    return Some(arr.as_ref());
+                }
+            }
+        }
+        None
+    })?;
+
+    let mut descriptors = Vec::new();
+    for elem in &queries_arr.elements {
+        if let ArrayExpressionElement::ObjectExpression(desc_obj) = elem {
+            let property_name = metadata::get_string_prop(desc_obj, "propertyName")?;
+            let predicate = metadata::get_source_text(desc_obj, "predicate", source)
+                .unwrap_or("null")
+                .to_string();
+            let descendants = metadata::get_bool_prop(desc_obj, "descendants").unwrap_or(false);
+            let is_static = metadata::get_bool_prop(desc_obj, "static").unwrap_or(false);
+            let first = metadata::get_bool_prop(desc_obj, "first").unwrap_or(false);
+            let read = metadata::get_source_text(desc_obj, "read", source).map(|s| s.to_string());
+
+            descriptors.push(QueryDescriptor {
+                property_name,
+                predicate,
+                descendants,
+                is_static,
+                read,
+                first,
+            });
+        }
+    }
+
+    Some(descriptors)
 }
 
 #[cfg(test)]

--- a/crates/linker/src/metadata.rs
+++ b/crates/linker/src/metadata.rs
@@ -34,8 +34,15 @@ pub fn get_string_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<String> 
     for prop in &obj.properties {
         if let ObjectPropertyKind::ObjectProperty(p) = prop {
             if property_key_matches(&p.key, key) {
-                if let Expression::StringLiteral(s) = &p.value {
-                    return Some(s.value.to_string());
+                match &p.value {
+                    Expression::StringLiteral(s) => return Some(s.value.to_string()),
+                    Expression::TemplateLiteral(t) if t.expressions.is_empty() => {
+                        // Simple template literal with no interpolations (e.g. `hello`)
+                        if let Some(quasi) = t.quasis.first() {
+                            return Some(quasi.value.raw.to_string());
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/crates/template-compiler/src/ast.rs
+++ b/crates/template-compiler/src/ast.rs
@@ -13,6 +13,8 @@ pub enum TemplateNode {
     ForBlock(ForBlockNode),
     /// An `@switch` / `@case` / `@default` control flow block.
     SwitchBlock(SwitchBlockNode),
+    /// An `@let` variable declaration.
+    LetDeclaration(LetDeclarationNode),
 }
 
 /// An HTML element node.
@@ -167,6 +169,15 @@ pub struct SwitchBlockNode {
     pub cases: Vec<CaseBranch>,
     /// Optional default branch.
     pub default_branch: Option<Vec<TemplateNode>>,
+}
+
+/// An `@let` variable declaration: `@let name = expression;`
+#[derive(Debug, Clone, PartialEq)]
+pub struct LetDeclarationNode {
+    /// The variable name (e.g. `_options`).
+    pub name: String,
+    /// The initializer expression (e.g. `options()`).
+    pub expression: String,
 }
 
 /// A `@case` branch.

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -30,6 +30,10 @@ struct IvyCodegen {
     child_counter: u32,
     /// Collected static attribute arrays for the `consts` field.
     consts: Vec<String>,
+    /// Active `@let` declarations: maps variable name to slot index.
+    let_declarations: Vec<(String, u32)>,
+    /// Local variable names that should NOT get `ctx.` prefix in expressions.
+    local_vars: BTreeSet<String>,
 }
 
 struct ChildTemplate {
@@ -55,6 +59,8 @@ pub fn generate_ivy(
         ivy_imports: BTreeSet::new(),
         child_counter: 0,
         consts: Vec::new(),
+        let_declarations: Vec::new(),
+        local_vars: BTreeSet::new(),
     };
 
     gen.ivy_imports
@@ -162,6 +168,7 @@ impl IvyCodegen {
             TemplateNode::IfBlock(block) => self.generate_if_block(block),
             TemplateNode::ForBlock(block) => self.generate_for_block(block),
             TemplateNode::SwitchBlock(block) => self.generate_switch_block(block),
+            TemplateNode::LetDeclaration(decl) => self.generate_let_declaration(decl),
         }
     }
 
@@ -465,6 +472,7 @@ impl IvyCodegen {
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
+        let parent_lets = self.let_declarations.clone();
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -472,9 +480,9 @@ impl IvyCodegen {
         self.generate_element(el);
 
         let decls = self.slot_index;
-        let vars = self.var_count;
+        let vars = self.var_count + parent_lets.len() as u32;
 
-        let mut code = format!("function {fn_name}(rf: number, ctx: any) {{\n");
+        let mut code = format!("function {fn_name}(rf, ctx) {{\n");
         if !self.creation.is_empty() {
             code.push_str("  if (rf & 1) {\n");
             for instr in &self.creation {
@@ -484,8 +492,15 @@ impl IvyCodegen {
             }
             code.push_str("  }\n");
         }
-        if !self.update.is_empty() {
+        if !self.update.is_empty() || !parent_lets.is_empty() {
             code.push_str("  if (rf & 2) {\n");
+            for (name, slot) in &parent_lets {
+                self.ivy_imports
+                    .insert("\u{0275}\u{0275}readContextLet".to_string());
+                code.push_str(&format!(
+                    "    const {name} = \u{0275}\u{0275}readContextLet({slot});\n"
+                ));
+            }
             for instr in &self.update {
                 code.push_str("    ");
                 code.push_str(instr);
@@ -500,6 +515,7 @@ impl IvyCodegen {
         self.creation = parent_creation;
         self.update = parent_update;
         self.consts = parent_consts;
+        self.let_declarations = parent_lets;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -602,7 +618,12 @@ impl IvyCodegen {
 
         // Update block: conditional
         self.add_advance(slot);
-        let cond_expr = build_conditional_expr(&block.condition, &else_if_fns, &else_fn_name);
+        let cond_expr = build_conditional_expr(
+            &block.condition,
+            &else_if_fns,
+            &else_fn_name,
+            &self.local_vars,
+        );
         self.update
             .push(format!("\u{0275}\u{0275}conditional({cond_expr});"));
         self.var_count += 1;
@@ -627,8 +648,27 @@ impl IvyCodegen {
 
         let child =
             self.generate_for_child_template(&child_fn_name, &block.item_name, &block.children);
+        // Build the track-by function from the track expression.
+        // Angular expects: (index, item) => item.id
+        let track_expr = ctx_expr(&block.track_expression);
+        let track_fn = if track_expr.contains("ctx.$index") || track_expr == "ctx.$index" {
+            // track $index → identity by index
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}repeaterTrackByIndex".to_string());
+            "\u{0275}\u{0275}repeaterTrackByIndex".to_string()
+        } else if track_expr == format!("ctx.{}", block.item_name) || track_expr == block.item_name
+        {
+            // track item → identity by reference
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}repeaterTrackByIdentity".to_string());
+            "\u{0275}\u{0275}repeaterTrackByIdentity".to_string()
+        } else {
+            // Custom track expression → wrap in arrow function
+            let item = &block.item_name;
+            format!("(i, {item}) => {track_expr}")
+        };
         self.creation.push(format!(
-            "\u{0275}\u{0275}repeaterCreate({slot}, {child_fn_name}, {}, {});",
+            "\u{0275}\u{0275}repeaterCreate({slot}, {child_fn_name}, {}, {}, {track_fn});",
             child.decls, child.vars
         ));
         self.child_templates.push(child);
@@ -729,16 +769,18 @@ impl IvyCodegen {
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
+        let parent_lets = self.let_declarations.clone();
 
         self.slot_index = 0;
         self.var_count = 0;
+        // Don't clear let_declarations or local_vars — children inherit parent scope
 
         self.generate_nodes(children);
 
         let decls = self.slot_index;
-        let vars = self.var_count;
+        let vars = self.var_count + parent_lets.len() as u32;
 
-        let mut code = format!("function {fn_name}(rf: number, ctx: any) {{\n");
+        let mut code = format!("function {fn_name}(rf, ctx) {{\n");
         if !self.creation.is_empty() {
             code.push_str("  if (rf & 1) {\n");
             for instr in &self.creation {
@@ -748,8 +790,16 @@ impl IvyCodegen {
             }
             code.push_str("  }\n");
         }
-        if !self.update.is_empty() {
+        if !self.update.is_empty() || !parent_lets.is_empty() {
             code.push_str("  if (rf & 2) {\n");
+            // Inject @let variable reads from parent context
+            for (name, slot) in &parent_lets {
+                self.ivy_imports
+                    .insert("\u{0275}\u{0275}readContextLet".to_string());
+                code.push_str(&format!(
+                    "    const {name} = \u{0275}\u{0275}readContextLet({slot});\n"
+                ));
+            }
             for instr in &self.update {
                 code.push_str("    ");
                 code.push_str(instr);
@@ -765,6 +815,7 @@ impl IvyCodegen {
         self.creation = parent_creation;
         self.update = parent_update;
         self.consts = parent_consts;
+        self.let_declarations = parent_lets;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -786,6 +837,7 @@ impl IvyCodegen {
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
+        let parent_lets = self.let_declarations.clone();
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -793,9 +845,9 @@ impl IvyCodegen {
         self.generate_nodes(children);
 
         let decls = self.slot_index;
-        let vars = self.var_count;
+        let vars = self.var_count + parent_lets.len() as u32;
 
-        let mut code = format!("function {fn_name}(rf: number, ctx: any) {{\n");
+        let mut code = format!("function {fn_name}(rf, ctx) {{\n");
         if !self.creation.is_empty() {
             code.push_str("  if (rf & 1) {\n");
             for instr in &self.creation {
@@ -805,9 +857,16 @@ impl IvyCodegen {
             }
             code.push_str("  }\n");
         }
-        if !self.update.is_empty() {
+        if !self.update.is_empty() || !parent_lets.is_empty() {
             code.push_str("  if (rf & 2) {\n");
             code.push_str(&format!("    const {item_name} = ctx.$implicit;\n"));
+            for (name, slot) in &parent_lets {
+                self.ivy_imports
+                    .insert("\u{0275}\u{0275}readContextLet".to_string());
+                code.push_str(&format!(
+                    "    const {name} = \u{0275}\u{0275}readContextLet({slot});\n"
+                ));
+            }
             for instr in &self.update {
                 code.push_str("    ");
                 code.push_str(instr);
@@ -823,6 +882,7 @@ impl IvyCodegen {
         self.creation = parent_creation;
         self.update = parent_update;
         self.consts = parent_consts;
+        self.let_declarations = parent_lets;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -868,11 +928,40 @@ impl IvyCodegen {
     ///
     /// Scans for `expr | pipeName` patterns (Angular pipe syntax) anywhere in the
     /// expression, compiles each to a `ɵɵpipeBind*` call, and applies `ctx.` prefixes.
+    /// Generate an `@let` variable declaration.
+    fn generate_let_declaration(&mut self, decl: &LetDeclarationNode) {
+        let slot = self.slot_index;
+        self.slot_index += 1;
+
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}declareLet".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}storeLet".to_string());
+
+        // Creation mode: allocate the let slot
+        self.creation
+            .push(format!("\u{0275}\u{0275}declareLet({slot});"));
+
+        // Update mode: evaluate expression and store the value
+        let compiled_expr = self.compile_binding_expr(&decl.expression);
+        self.update.push(format!(
+            "const {} = \u{0275}\u{0275}storeLet({compiled_expr});",
+            decl.name
+        ));
+
+        // Track for child templates and ctx. prefix exclusion
+        self.let_declarations.push((decl.name.clone(), slot));
+        self.local_vars.insert(decl.name.clone());
+
+        // storeLet counts as one binding var
+        self.var_count += 1;
+    }
+
     fn compile_binding_expr(&mut self, expression: &str) -> String {
         let segments = extract_all_pipe_segments(expression);
         if segments.is_empty() {
             // No pipes found — just compile with ctx. prefix
-            return ctx_expr(expression);
+            return ctx_expr_with_locals(expression, &self.local_vars);
         }
 
         // First segment is the base expression, rest are pipe names
@@ -1235,13 +1324,24 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
 /// Uses oxc to parse the expression AST and walk it, ensuring all standalone
 /// identifiers (not member properties, not builtins) get the `ctx.` prefix.
 fn ctx_expr(expr: &str) -> String {
+    ctx_expr_with_locals(expr, &BTreeSet::new())
+}
+
+/// Rewrite an expression by adding `ctx.` prefix to top-level identifiers,
+/// except for builtins and local variables (like `@let` declarations).
+fn ctx_expr_with_locals(expr: &str, locals: &BTreeSet<String>) -> String {
     let trimmed = expr.trim();
     if trimmed.is_empty() {
         return String::new();
     }
 
-    // Fast path for simple property paths
+    // Fast path for simple property paths (skip if it's a local var)
     if is_simple_property_path(trimmed) {
+        if locals.contains(trimmed)
+            || trimmed.contains('.') && locals.contains(trimmed.split('.').next().unwrap_or(""))
+        {
+            return trimmed.to_string();
+        }
         return format!("ctx.{trimmed}");
     }
 
@@ -1271,7 +1371,13 @@ fn ctx_expr(expr: &str) -> String {
     // Collect positions of identifiers that need `ctx.` prefix and `!` to remove
     let mut ctx_inserts: Vec<u32> = Vec::new();
     let mut remove_ranges: Vec<(u32, u32)> = Vec::new();
-    collect_ctx_rewrites(init_expr, &mut ctx_inserts, &mut remove_ranges, false);
+    collect_ctx_rewrites(
+        init_expr,
+        &mut ctx_inserts,
+        &mut remove_ranges,
+        false,
+        locals,
+    );
 
     // Map wrapper byte offsets back to expression byte offsets
     let expr_offset = "var __expr = ".len() as u32;
@@ -1349,9 +1455,12 @@ fn collect_ctx_rewrites(
     ctx_inserts: &mut Vec<u32>,
     remove_ranges: &mut Vec<(u32, u32)>,
     is_member_property: bool,
+    locals: &BTreeSet<String>,
 ) {
     use oxc_ast::ast::*;
     use oxc_span::GetSpan;
+
+    let is_local = |name: &str| -> bool { locals.contains(name) };
 
     fn is_builtin(name: &str) -> bool {
         // Angular runtime symbols (ɵɵ-prefixed) are not component properties
@@ -1390,45 +1499,63 @@ fn collect_ctx_rewrites(
 
     match expr {
         Expression::Identifier(id) => {
-            if !is_member_property && !is_builtin(&id.name) {
+            if !is_member_property && !is_builtin(&id.name) && !is_local(&id.name) {
                 ctx_inserts.push(id.span.start);
             }
         }
         Expression::CallExpression(call) => {
-            collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false, locals);
             for arg in &call.arguments {
                 if let Argument::SpreadElement(spread) = arg {
-                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
+                    collect_ctx_rewrites(
+                        &spread.argument,
+                        ctx_inserts,
+                        remove_ranges,
+                        false,
+                        locals,
+                    );
                 } else {
-                    collect_ctx_rewrites(arg.to_expression(), ctx_inserts, remove_ranges, false);
+                    collect_ctx_rewrites(
+                        arg.to_expression(),
+                        ctx_inserts,
+                        remove_ranges,
+                        false,
+                        locals,
+                    );
                 }
             }
         }
         Expression::StaticMemberExpression(member) => {
-            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::ComputedMemberExpression(member) => {
-            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&member.expression, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false, locals);
+            collect_ctx_rewrites(
+                &member.expression,
+                ctx_inserts,
+                remove_ranges,
+                false,
+                locals,
+            );
         }
         Expression::UnaryExpression(unary) => {
-            collect_ctx_rewrites(&unary.argument, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&unary.argument, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::BinaryExpression(binary) => {
-            collect_ctx_rewrites(&binary.left, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&binary.right, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&binary.left, ctx_inserts, remove_ranges, false, locals);
+            collect_ctx_rewrites(&binary.right, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::LogicalExpression(logical) => {
-            collect_ctx_rewrites(&logical.left, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&logical.right, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&logical.left, ctx_inserts, remove_ranges, false, locals);
+            collect_ctx_rewrites(&logical.right, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::ConditionalExpression(cond) => {
-            collect_ctx_rewrites(&cond.test, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&cond.consequent, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&cond.alternate, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.test, ctx_inserts, remove_ranges, false, locals);
+            collect_ctx_rewrites(&cond.consequent, ctx_inserts, remove_ranges, false, locals);
+            collect_ctx_rewrites(&cond.alternate, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::ParenthesizedExpression(paren) => {
-            collect_ctx_rewrites(&paren.expression, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&paren.expression, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::AssignmentExpression(assign) => {
             if let AssignmentTarget::AssignmentTargetIdentifier(id) = &assign.left {
@@ -1436,7 +1563,7 @@ fn collect_ctx_rewrites(
                     ctx_inserts.push(id.span.start);
                 }
             }
-            collect_ctx_rewrites(&assign.right, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&assign.right, ctx_inserts, remove_ranges, false, locals);
         }
         Expression::TSNonNullExpression(non_null) => {
             collect_ctx_rewrites(
@@ -1444,6 +1571,7 @@ fn collect_ctx_rewrites(
                 ctx_inserts,
                 remove_ranges,
                 is_member_property,
+                locals,
             );
             let inner_end = non_null.expression.span().end;
             let outer_end = non_null.span.end;
@@ -1454,22 +1582,34 @@ fn collect_ctx_rewrites(
         Expression::ObjectExpression(obj) => {
             for prop in &obj.properties {
                 if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                    collect_ctx_rewrites(&p.value, ctx_inserts, remove_ranges, false);
+                    collect_ctx_rewrites(&p.value, ctx_inserts, remove_ranges, false, locals);
                 }
             }
         }
         Expression::ArrayExpression(arr) => {
             for elem in &arr.elements {
                 if let ArrayExpressionElement::SpreadElement(spread) = elem {
-                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
+                    collect_ctx_rewrites(
+                        &spread.argument,
+                        ctx_inserts,
+                        remove_ranges,
+                        false,
+                        locals,
+                    );
                 } else if !elem.is_elision() {
-                    collect_ctx_rewrites(elem.to_expression(), ctx_inserts, remove_ranges, false);
+                    collect_ctx_rewrites(
+                        elem.to_expression(),
+                        ctx_inserts,
+                        remove_ranges,
+                        false,
+                        locals,
+                    );
                 }
             }
         }
         Expression::TemplateLiteral(tpl) => {
             for expr in &tpl.expressions {
-                collect_ctx_rewrites(expr, ctx_inserts, remove_ranges, false);
+                collect_ctx_rewrites(expr, ctx_inserts, remove_ranges, false, locals);
             }
         }
         _ => {}
@@ -1481,11 +1621,16 @@ fn build_conditional_expr(
     condition: &str,
     else_ifs: &[(String, String)],
     else_fn: &Option<String>,
+    locals: &BTreeSet<String>,
 ) -> String {
-    let mut expr = format!("{} ? 0 : ", ctx_expr(condition));
+    let mut expr = format!("{} ? 0 : ", ctx_expr_with_locals(condition, locals));
 
     for (i, (cond, _fn_name)) in else_ifs.iter().enumerate() {
-        expr.push_str(&format!("{} ? {} : ", ctx_expr(cond), i + 1));
+        expr.push_str(&format!(
+            "{} ? {} : ",
+            ctx_expr_with_locals(cond, locals),
+            i + 1
+        ));
     }
 
     if else_fn.is_some() {

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -34,6 +34,9 @@ struct IvyCodegen {
     let_declarations: Vec<(String, u32)>,
     /// Local variable names that should NOT get `ctx.` prefix in expressions.
     local_vars: BTreeSet<String>,
+    /// Last slot index emitted in the update block (for computing `ɵɵadvance` deltas).
+    /// `None` means no advance has been emitted yet (runtime starts at selectedIndex=-1).
+    last_update_slot: Option<u32>,
 }
 
 struct ChildTemplate {
@@ -61,6 +64,7 @@ pub fn generate_ivy(
         consts: Vec::new(),
         let_declarations: Vec::new(),
         local_vars: BTreeSet::new(),
+        last_update_slot: None,
     };
 
     gen.ivy_imports
@@ -222,21 +226,11 @@ impl IvyCodegen {
 
         let is_ng_container = el.tag == "ng-container";
 
-        // Collect event and update bindings
+        // Check for event bindings (used for listener creation)
         let _has_events = el
             .attributes
             .iter()
             .any(|a| matches!(a, TemplateAttribute::Event { .. }));
-        let has_bindings = el.attributes.iter().any(|a| {
-            matches!(
-                a,
-                TemplateAttribute::Property { .. }
-                    | TemplateAttribute::ClassBinding { .. }
-                    | TemplateAttribute::StyleBinding { .. }
-                    | TemplateAttribute::AttrBinding { .. }
-                    | TemplateAttribute::TwoWayBinding { .. }
-            )
-        });
 
         // Static attributes for consts
         let static_attrs: Vec<(&str, &str)> = el
@@ -266,6 +260,9 @@ impl IvyCodegen {
                 self.creation
                     .push(format!("{instr}({slot}, '{}', {const_idx});", el.tag));
             }
+
+            // Bindings for void elements
+            self.emit_element_bindings(el, slot);
         } else {
             let (start_instr, end_instr) = if is_ng_container {
                 (
@@ -310,6 +307,10 @@ impl IvyCodegen {
                 }
             }
 
+            // Property bindings in update block — emitted before children
+            // so ɵɵadvance() targets the correct element slot.
+            self.emit_element_bindings(el, slot);
+
             // Generate children
             self.generate_nodes(&el.children);
 
@@ -325,68 +326,6 @@ impl IvyCodegen {
                     self.creation
                         .push(format!("\u{0275}\u{0275}reference({ref_slot});"));
                 }
-            }
-        }
-
-        // Property bindings in update block
-        if has_bindings {
-            self.add_advance(slot);
-        }
-        for attr in &el.attributes {
-            match attr {
-                TemplateAttribute::Property { name, expression } => {
-                    self.ivy_imports
-                        .insert("\u{0275}\u{0275}property".to_string());
-                    let compiled = self.compile_binding_expr(expression);
-                    self.update
-                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
-                    self.var_count += 1;
-                }
-                TemplateAttribute::TwoWayBinding { name, expression } => {
-                    self.ivy_imports
-                        .insert("\u{0275}\u{0275}property".to_string());
-                    let compiled = self.compile_binding_expr(expression);
-                    self.update
-                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
-                    self.var_count += 1;
-                }
-                TemplateAttribute::ClassBinding {
-                    class_name,
-                    expression,
-                } => {
-                    self.ivy_imports
-                        .insert("\u{0275}\u{0275}classProp".to_string());
-                    let compiled = self.compile_binding_expr(expression);
-                    self.update.push(format!(
-                        "\u{0275}\u{0275}classProp('{}', {compiled});",
-                        class_name,
-                    ));
-                    self.var_count += 1;
-                }
-                TemplateAttribute::StyleBinding {
-                    property,
-                    expression,
-                } => {
-                    self.ivy_imports
-                        .insert("\u{0275}\u{0275}styleProp".to_string());
-                    let compiled = self.compile_binding_expr(expression);
-                    self.update.push(format!(
-                        "\u{0275}\u{0275}styleProp('{}', {compiled});",
-                        property,
-                    ));
-                    self.var_count += 1;
-                }
-                TemplateAttribute::AttrBinding { name, expression } => {
-                    self.ivy_imports
-                        .insert("\u{0275}\u{0275}attribute".to_string());
-                    let compiled = self.compile_binding_expr(expression);
-                    self.update.push(format!(
-                        "\u{0275}\u{0275}attribute('{}', {compiled});",
-                        name,
-                    ));
-                    self.var_count += 1;
-                }
-                _ => {}
             }
         }
     }
@@ -469,6 +408,7 @@ impl IvyCodegen {
     ) -> ChildTemplate {
         let parent_slot = self.slot_index;
         let parent_var = self.var_count;
+        let parent_last_update: Option<u32> = self.last_update_slot;
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
@@ -476,6 +416,7 @@ impl IvyCodegen {
 
         self.slot_index = 0;
         self.var_count = 0;
+        self.last_update_slot = None;
 
         self.generate_element(el);
 
@@ -512,6 +453,7 @@ impl IvyCodegen {
 
         self.slot_index = parent_slot;
         self.var_count = parent_var;
+        self.last_update_slot = parent_last_update;
         self.creation = parent_creation;
         self.update = parent_update;
         self.consts = parent_consts;
@@ -766,6 +708,7 @@ impl IvyCodegen {
         // Save parent state
         let parent_slot = self.slot_index;
         let parent_var = self.var_count;
+        let parent_last_update: Option<u32> = self.last_update_slot;
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
@@ -773,6 +716,7 @@ impl IvyCodegen {
 
         self.slot_index = 0;
         self.var_count = 0;
+        self.last_update_slot = None;
         // Don't clear let_declarations or local_vars — children inherit parent scope
 
         self.generate_nodes(children);
@@ -812,6 +756,7 @@ impl IvyCodegen {
         // Restore parent state
         self.slot_index = parent_slot;
         self.var_count = parent_var;
+        self.last_update_slot = parent_last_update;
         self.creation = parent_creation;
         self.update = parent_update;
         self.consts = parent_consts;
@@ -834,6 +779,7 @@ impl IvyCodegen {
         // Save parent state
         let parent_slot = self.slot_index;
         let parent_var = self.var_count;
+        let parent_last_update: Option<u32> = self.last_update_slot;
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
@@ -841,6 +787,7 @@ impl IvyCodegen {
 
         self.slot_index = 0;
         self.var_count = 0;
+        self.last_update_slot = None;
 
         self.generate_nodes(children);
 
@@ -879,6 +826,7 @@ impl IvyCodegen {
         // Restore parent state
         self.slot_index = parent_slot;
         self.var_count = parent_var;
+        self.last_update_slot = parent_last_update;
         self.creation = parent_creation;
         self.update = parent_update;
         self.consts = parent_consts;
@@ -1020,13 +968,99 @@ impl IvyCodegen {
         idx
     }
 
-    /// Add an `ɵɵadvance()` instruction to the update block if needed.
-    fn add_advance(&mut self, _target_slot: u32) {
-        self.ivy_imports
-            .insert("\u{0275}\u{0275}advance".to_string());
-        // For simplicity, always emit advance() (delta = 1)
-        // A more sophisticated implementation would compute exact deltas
-        self.update.push("\u{0275}\u{0275}advance();".to_string());
+    /// Add an `ɵɵadvance()` instruction to the update block.
+    fn add_advance(&mut self, target_slot: u32) {
+        // Angular's runtime starts with selectedIndex = -1 before the update block.
+        // The first ɵɵadvance() must advance from -1 to the target slot (delta = target + 1).
+        let delta = match self.last_update_slot {
+            None => target_slot + 1, // First advance: from -1 to target
+            Some(last) => target_slot.saturating_sub(last),
+        };
+        if delta > 0 {
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}advance".to_string());
+            if delta == 1 {
+                self.update.push("\u{0275}\u{0275}advance();".to_string());
+            } else {
+                self.update
+                    .push(format!("\u{0275}\u{0275}advance({delta});"));
+            }
+        }
+        self.last_update_slot = Some(target_slot);
+    }
+
+    /// Emit property/class/style/attr bindings for an element in the update block.
+    fn emit_element_bindings(&mut self, el: &ElementNode, slot: u32) {
+        let has_bindings = el.attributes.iter().any(|a| {
+            matches!(
+                a,
+                TemplateAttribute::Property { .. }
+                    | TemplateAttribute::ClassBinding { .. }
+                    | TemplateAttribute::StyleBinding { .. }
+                    | TemplateAttribute::AttrBinding { .. }
+                    | TemplateAttribute::TwoWayBinding { .. }
+            )
+        });
+        if has_bindings {
+            self.add_advance(slot);
+        }
+        for attr in &el.attributes {
+            match attr {
+                TemplateAttribute::Property { name, expression } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}property".to_string());
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update
+                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
+                    self.var_count += 1;
+                }
+                TemplateAttribute::TwoWayBinding { name, expression } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}property".to_string());
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update
+                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
+                    self.var_count += 1;
+                }
+                TemplateAttribute::ClassBinding {
+                    class_name,
+                    expression,
+                } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}classProp".to_string());
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}classProp('{}', {compiled});",
+                        class_name,
+                    ));
+                    self.var_count += 2; // Angular 21: style/class bindings use 2 slots
+                }
+                TemplateAttribute::StyleBinding {
+                    property,
+                    expression,
+                } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}styleProp".to_string());
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}styleProp('{}', {compiled});",
+                        property,
+                    ));
+                    self.var_count += 2; // Angular 21: style/class bindings use 2 slots
+                }
+                TemplateAttribute::AttrBinding { name, expression } => {
+                    self.ivy_imports
+                        .insert("\u{0275}\u{0275}attribute".to_string());
+                    let compiled = self.compile_binding_expr(expression);
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}attribute('{}', {compiled});",
+                        name,
+                    ));
+                    self.var_count += 1;
+                }
+                _ => {}
+            }
+        }
     }
 }
 
@@ -1251,7 +1285,7 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
 
                 let pipe_slot = gen.slot_index;
                 gen.slot_index += 1;
-                gen.var_count += 1 + args.len() as u32;
+                gen.var_count += 2 + args.len() as u32;
                 gen.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
 
                 let bind_fn = match args.len() {

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -2,13 +2,13 @@
 
 template = { SOI ~ node* ~ EOI }
 
-node = _{ control_flow | html_comment | element | interpolation | text }
+node = _{ control_flow | let_block | html_comment | element | interpolation | text }
 
 // HTML comments: <!-- ... -->
 html_comment = { "<!--" ~ (!"-->" ~ ANY)* ~ "-->" }
 
 // Text: anything not starting a tag, interpolation, or control flow keyword
-text = @{ (!("<" | "{{" | "}" | "@if" | "@for" | "@switch" | "@else" | "@case" | "@default" | "@empty") ~ ANY)+ }
+text = @{ (!("<" | "{{" | "}" | "@if" | "@for" | "@switch" | "@else" | "@case" | "@default" | "@empty" | "@let") ~ ANY)+ }
 
 // Text interpolation: {{ expression | pipe }}
 // Handles || (logical OR), balanced parens, and | only as top-level pipe separator
@@ -57,6 +57,10 @@ inner_value = @{ (!("\"") ~ ANY)* }
 inner_value_sq = @{ (!("'") ~ ANY)* }
 
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+
+// @let variable declaration
+let_block = { "@let" ~ identifier ~ "=" ~ let_expression ~ ";" }
+let_expression = @{ (!";" ~ ANY)+ }
 
 // Control flow blocks
 control_flow = _{ if_block | for_block | switch_block }

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -52,6 +52,8 @@ pub struct TemplateFnOutput {
     pub vars: u32,
     /// Child template functions (for @if, @for, @switch blocks).
     pub child_template_functions: Vec<String>,
+    /// Set of Ivy runtime symbols needed from `@angular/core`.
+    pub ivy_imports: std::collections::BTreeSet<String>,
 }
 
 /// Compile a template string into a standalone template function.
@@ -108,6 +110,7 @@ pub fn generate_template_fn(
         decls,
         vars,
         child_template_functions: child_fns,
+        ivy_imports: ivy_output.ivy_imports,
     })
 }
 

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -54,6 +54,7 @@ fn parse_node(pair: pest::iterators::Pair<Rule>) -> NgcResult<Option<TemplateNod
         Rule::if_block => Ok(Some(parse_if_block(pair)?)),
         Rule::for_block => Ok(Some(parse_for_block(pair)?)),
         Rule::switch_block => Ok(Some(parse_switch_block(pair)?)),
+        Rule::let_block => Ok(Some(parse_let_block(pair)?)),
         Rule::node => {
             let inner = pair.into_inner().next();
             match inner {
@@ -471,6 +472,25 @@ fn parse_switch_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNo
     }))
 }
 
+/// Parse an `@let name = expression;` declaration.
+fn parse_let_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let mut inner = pair.into_inner();
+
+    let name = inner
+        .next()
+        .map(|p| p.as_str().to_string())
+        .unwrap_or_default();
+
+    let expression = inner
+        .next()
+        .map(|p| p.as_str().trim().to_string())
+        .unwrap_or_default();
+
+    Ok(TemplateNode::LetDeclaration(
+        crate::ast::LetDeclarationNode { name, expression },
+    ))
+}
+
 /// Extract the text content from an expression pair, handling nested rules.
 fn extract_expression_text(pair: pest::iterators::Pair<Rule>) -> String {
     // For ctrl_expression and track_expression, the text comes from
@@ -652,5 +672,26 @@ mod tests {
             }
             _ => panic!("expected switch block"),
         }
+    }
+
+    #[test]
+    fn test_let_block() {
+        let nodes = parse("@let _options = options();");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::LetDeclaration(l) => {
+                assert_eq!(l.name, "_options");
+                assert_eq!(l.expression, "options()");
+            }
+            _ => panic!("expected let declaration"),
+        }
+    }
+
+    #[test]
+    fn test_let_with_if() {
+        let nodes = parse("@let x = value(); @if (x) { <p>yes</p> }");
+        assert_eq!(nodes.len(), 2);
+        assert!(matches!(&nodes[0], TemplateNode::LetDeclaration(_)));
+        assert!(matches!(&nodes[1], TemplateNode::IfBlock(_)));
     }
 }


### PR DESCRIPTION
## Summary
- Fix cross-chunk imports for lazy-loaded route chunks (issue #17)
- Prevent re-export var declarations from shadowing imports in npm IIFE wrapping
- Add @let directive support to template compiler
- Fix linker: host bindings (style/class dispatch), template literals, child template functions, content/view queries
- Compute correct ɵɵadvance() deltas for element bindings

## Changes
- **Bundler** (`concat.rs`): Cross-chunk import system for lazy chunks importing npm and project symbols from main chunk
- **Bundler** (`npm_wrap.rs`): Fix re-export shadowing that broke ComponentFactory
- **Linker** (`directive.rs`): Host binding dispatch (style.X → ɵɵstyleProp, class.X → ɵɵclassProp), content/view query compilation, correct hostVars counting
- **Linker** (`component.rs`): Child template IIFE wrapping, template literal support, Ivy import declarations
- **Linker** (`metadata.rs`): Template literal handling in get_string_prop
- **Template Compiler**: @let directive (grammar, AST, parser, codegen), correct ɵɵadvance() delta computation, bindings-before-children ordering, emit_element_bindings helper, ɵɵrepeaterCreate track functions

## Test plan
- [x] `cargo test --workspace && cargo clippy -- -D warnings && cargo fmt --check`
- [x] Build Treasr frontend locally and verify sidebar renders with navigation
- [x] Lazy routes (/imprint) load and render content
- [ ] Full Docker build and deploy verification
- [ ] Auth callback flow testing