### PR TITLE
fix(v0.7.6): flatten NgModule imports at build time (resolves #19)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "criterion",
  "glob",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "clap",
  "colored",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
+++ b/crates/bundler/tests/snapshots/snapshot_tests__bundle_output.snap
@@ -3,7 +3,7 @@ source: crates/bundler/tests/snapshot_tests.rs
 expression: bundle
 ---
 import { RouterOutlet, provideRouter } from '@angular/router';
-import { ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵgetComponentDepsFactory, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
+import { ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵtext, ɵɵtextInterpolate } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 // src/environments/environment.js
@@ -62,7 +62,7 @@ class AppComponent {
 				ɵɵtextInterpolate(ctx.title);
 			}
 		},
-		dependencies: ɵɵgetComponentDepsFactory(AppComponent, [RouterOutlet])
+		dependencies: [RouterOutlet]
 	});
 	title = SharedUtils.appName();
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -236,7 +236,8 @@ fn run_build(
     }
 
     // Step 6.6: Link partially compiled Angular npm packages
-    let linker_stats = ngc_linker::link_npm_modules(&mut modules, &config_dir)?;
+    let module_registry = ngc_linker::ModuleRegistry::new();
+    let linker_stats = ngc_linker::link_npm_modules(&mut modules, &config_dir, &module_registry)?;
     if linker_stats.files_linked > 0 {
         tracing::info!(
             "linked {} Angular package file(s)",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -228,7 +228,8 @@ fn run_build(
             bare_specifiers.push(spec);
         }
     }
-    let npm_resolution = ngc_npm_resolver::resolve_npm_dependencies(&bare_specifiers, &config_dir)?;
+    let mut npm_resolution =
+        ngc_npm_resolver::resolve_npm_dependencies(&bare_specifiers, &config_dir)?;
 
     // Merge npm modules into the modules map (they're already JS — no transform needed)
     for (path, source) in &npm_resolution.modules {
@@ -250,6 +251,49 @@ fn run_build(
             linker_stats.components_flattened,
             linker_stats.modules_registered
         );
+    }
+
+    // Step 6.7: Resolve any bare specifiers the flatten pass introduced. When
+    // it injects an `import { CdkPortal } from '@angular/cdk/portal'` into a
+    // project file, that specifier wasn't known to the initial npm resolution
+    // — so we re-scan and resolve the delta, folding the new modules +
+    // internal edges into `npm_resolution` so the graph-construction below
+    // picks them up.
+    let post_link_specifiers = scan_transformed_bare_specifiers(&modules, &local_prefixes);
+    let mut new_specifiers: Vec<String> = Vec::new();
+    for spec in post_link_specifiers {
+        if !bare_specifiers.contains(&spec) {
+            new_specifiers.push(spec);
+        }
+    }
+    if !new_specifiers.is_empty() {
+        tracing::info!(
+            "resolving {} additional specifier(s) introduced by flatten pass: {:?}",
+            new_specifiers.len(),
+            new_specifiers
+        );
+        bare_specifiers.extend(new_specifiers.iter().cloned());
+        let extra = ngc_npm_resolver::resolve_npm_dependencies(&new_specifiers, &config_dir)?;
+        tracing::info!(
+            "post-flatten npm resolution pulled in {} file(s)",
+            extra.modules.len()
+        );
+        for (path, source) in &extra.modules {
+            modules.entry(path.clone()).or_insert_with(|| source.clone());
+            npm_resolution
+                .modules
+                .entry(path.clone())
+                .or_insert_with(|| source.clone());
+        }
+        for spec in &new_specifiers {
+            npm_resolution.resolved_specifiers.insert(spec.clone());
+        }
+        for edge in extra.edges {
+            npm_resolution.edges.push(edge);
+        }
+        // Re-run the linker on any newly-pulled-in npm files so their
+        // ɵɵngDeclare calls are transformed too.
+        let _ = ngc_linker::link_modules(&mut modules, &config_dir)?;
     }
 
     // Inject vendored helpers for oxc runtime (not an npm dependency of the project)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -235,13 +235,20 @@ fn run_build(
         modules.insert(path.clone(), source.clone());
     }
 
-    // Step 6.6: Link partially compiled Angular npm packages
-    let module_registry = ngc_linker::ModuleRegistry::new();
-    let linker_stats = ngc_linker::link_npm_modules(&mut modules, &config_dir, &module_registry)?;
+    // Step 6.6: Link partially compiled Angular npm packages and flatten
+    // NgModule references in component dependencies arrays.
+    let linker_stats = ngc_linker::link_modules(&mut modules, &config_dir)?;
     if linker_stats.files_linked > 0 {
         tracing::info!(
             "linked {} Angular package file(s)",
             linker_stats.files_linked
+        );
+    }
+    if linker_stats.components_flattened > 0 {
+        tracing::info!(
+            "flattened NgModule imports in {} component file(s) across {} registered module(s)",
+            linker_stats.components_flattened,
+            linker_stats.modules_registered
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -259,7 +259,18 @@ fn run_build(
     // — so we re-scan and resolve the delta, folding the new modules +
     // internal edges into `npm_resolution` so the graph-construction below
     // picks them up.
-    let post_link_specifiers = scan_transformed_bare_specifiers(&modules, &local_prefixes);
+    //
+    // Scope the scan to PROJECT files only. Scanning npm files pulls in
+    // spurious specifiers from packages' embedded test/dev code (e.g.
+    // `@vitest/*`, `pathe`, `tinyrainbow`) that the app never reaches but
+    // which, once linked, can corrupt the evaluation order of unrelated
+    // modules — observed in treasr-frontend as a silent dialog failure.
+    let project_modules: HashMap<PathBuf, String> = modules
+        .iter()
+        .filter(|(path, _)| !ngc_linker::is_npm_path(path))
+        .map(|(p, s)| (p.clone(), s.clone()))
+        .collect();
+    let post_link_specifiers = scan_transformed_bare_specifiers(&project_modules, &local_prefixes);
     let mut new_specifiers: Vec<String> = Vec::new();
     for spec in post_link_specifiers {
         if !bare_specifiers.contains(&spec) {
@@ -279,7 +290,9 @@ fn run_build(
             extra.modules.len()
         );
         for (path, source) in &extra.modules {
-            modules.entry(path.clone()).or_insert_with(|| source.clone());
+            modules
+                .entry(path.clone())
+                .or_insert_with(|| source.clone());
             npm_resolution
                 .modules
                 .entry(path.clone())

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -59,6 +59,9 @@ pub fn transform(
 
     // Features — only emit features that exist in the Angular runtime.
     // ɵɵStandaloneFeature was removed in Angular 19+; standalone is handled via property.
+    //
+    // `ɵɵProvidersFeature(providers[, viewProviders])` wires component-level
+    // providers into the node injector at instantiation time.
     let mut features = Vec::new();
     if metadata::get_bool_prop(obj, "usesInheritance") == Some(true) {
         let feat = if ng_import.is_empty() {
@@ -67,6 +70,21 @@ pub fn transform(
             format!("{ng_import}.\u{0275}\u{0275}InheritDefinitionFeature")
         };
         features.push(feat);
+    }
+    let providers_src = metadata::get_source_text(obj, "providers", source);
+    let view_providers_src = metadata::get_source_text(obj, "viewProviders", source);
+    if let Some(providers) = providers_src {
+        let providers_feature = if ng_import.is_empty() {
+            "\u{0275}\u{0275}ProvidersFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}ProvidersFeature")
+        };
+        let call = if let Some(vp) = view_providers_src {
+            format!("{providers_feature}({providers}, {vp})")
+        } else {
+            format!("{providers_feature}({providers})")
+        };
+        features.push(call);
     }
     if !features.is_empty() {
         props.push(format!("features: [{}]", features.join(", ")));

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -93,6 +93,13 @@ pub fn build_define_call(
     // Features — only emit features that exist in the Angular runtime.
     // Note: ɵɵStandaloneFeature was removed in Angular 19+; standalone is now
     // handled via the `standalone: true` property on the definition (emitted above).
+    //
+    // `ɵɵProvidersFeature(providers[, viewProviders])` is what actually wires
+    // directive `providers` into the node injector at instantiation time.
+    // Without it, `providers` on the directive def is dead weight — directly
+    // visible as `NG0201 No provider for NgControl` when e.g. `FormControlName`
+    // declares `{provide: NgControl, useExisting: FormControlName}` but
+    // `NgControlStatus` can't resolve it.
     let mut features = Vec::new();
     if metadata::get_bool_prop(obj, "usesInheritance") == Some(true) {
         let feat = if ng_import.is_empty() {
@@ -110,13 +117,29 @@ pub fn build_define_call(
         };
         features.push(feat);
     }
-    if !features.is_empty() {
-        props.push(format!("features: [{}]", features.join(", ")));
+
+    // Providers — emit BOTH the `providers` property on the def (for Angular's
+    // own introspection) AND a `ɵɵProvidersFeature(providers[, viewProviders])`
+    // call in `features` (which is what actually registers them at runtime).
+    let providers_src = metadata::get_source_text(obj, "providers", source);
+    let view_providers_src = metadata::get_source_text(obj, "viewProviders", source);
+    if let Some(providers) = providers_src {
+        props.push(format!("providers: {providers}"));
+        let providers_feature = if ng_import.is_empty() {
+            "\u{0275}\u{0275}ProvidersFeature".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}ProvidersFeature")
+        };
+        let call = if let Some(vp) = view_providers_src {
+            format!("{providers_feature}({providers}, {vp})")
+        } else {
+            format!("{providers_feature}({providers})")
+        };
+        features.push(call);
     }
 
-    // Providers
-    if let Some(providers) = metadata::get_source_text(obj, "providers", source) {
-        props.push(format!("providers: {providers}"));
+    if !features.is_empty() {
+        props.push(format!("features: [{}]", features.join(", ")));
     }
 
     // Content queries: compile from declare format (array of descriptors) to runtime

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -198,6 +198,33 @@ fn build_inputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
                         entries.push(format!("{key}: '{key}'"));
                     }
                 }
+                Expression::ArrayExpression(arr) => {
+                    // Declare format uses a 2-element array `[publicName, declaredName]`.
+                    // The Angular 21 runtime format is `[flags, publicName, declaredName, transform?]`
+                    // — a leading numeric `flags` value is required or the array
+                    // positions shift (publicName ends up where flags should be),
+                    // breaking input binding silently (e.g. `[formGroup]` never
+                    // propagates to `FormGroupDirective.form`).
+                    let elements: Vec<&str> = arr
+                        .elements
+                        .iter()
+                        .map(|el| {
+                            let sp = el.span();
+                            &source[sp.start as usize..sp.end as usize]
+                        })
+                        .collect();
+                    // If the first element is already a number, assume it's runtime-format.
+                    let first_is_number = elements.first().is_some_and(|s| {
+                        s.trim().chars().next().is_some_and(|c| c.is_ascii_digit())
+                    });
+                    let runtime = if first_is_number {
+                        format!("[{}]", elements.join(", "))
+                    } else {
+                        // Prepend `0` flags.
+                        format!("[0, {}]", elements.join(", "))
+                    };
+                    entries.push(format!("{key}: {runtime}"));
+                }
                 _ => {
                     // Pass through as source text
                     let val = &source[p.value.span().start as usize..p.value.span().end as usize];

--- a/crates/linker/src/factory.rs
+++ b/crates/linker/src/factory.rs
@@ -19,16 +19,51 @@ use oxc_ast::ast::{
 use crate::metadata;
 
 /// Transform a `ɵɵngDeclareFactory` call into a factory function.
+///
+/// `deps: null` in the declare format signals that the factory is inherited
+/// from a parent class (no deps of its own). In that case we emit an IIFE
+/// that calls `ɵɵgetInheritedFactory(Type)` to look up the parent's factory
+/// at runtime — matching what Angular's own AOT compiler emits. A plain
+/// empty-args factory would call the constructor with no arguments, which
+/// breaks e.g. `SelectControlValueAccessor extends BaseControlValueAccessor`
+/// because `_renderer` and `_elementRef` would never be injected.
 pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
     let type_name = metadata::get_identifier_prop(obj, "type")
         .or_else(|| metadata::get_source_text(obj, "type", source).map(|s| s.to_string()))
         .unwrap_or_else(|| "Unknown".to_string());
+
+    if is_deps_null(obj) {
+        let get_inherited = if ng_import.is_empty() {
+            "\u{0275}\u{0275}getInheritedFactory".to_string()
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}getInheritedFactory")
+        };
+        return Ok(format!(
+            "function {type_name}_Factory(\u{0275}t) {{ \
+                let \u{0275}{type_name}_BaseFactory; \
+                return (\u{0275}{type_name}_BaseFactory || (\u{0275}{type_name}_BaseFactory = {get_inherited}({type_name})))(\u{0275}t || {type_name}); \
+            }}"
+        ));
+    }
 
     let deps = build_deps_args(obj, source, ng_import);
 
     Ok(format!(
         "function {type_name}_Factory(\u{0275}t) {{ return new (\u{0275}t || {type_name})({deps}); }}"
     ))
+}
+
+/// Return `true` if the `deps` property is the literal `null` — the declare
+/// format's way of saying "inherit factory from parent".
+fn is_deps_null(obj: &ObjectExpression<'_>) -> bool {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if matches!(&p.key, PropertyKey::StaticIdentifier(id) if id.name.as_str() == "deps") {
+                return matches!(&p.value, Expression::NullLiteral(_));
+            }
+        }
+    }
+    false
 }
 
 /// Build the constructor arguments from the `deps` array.
@@ -166,5 +201,17 @@ mod tests {
             "{ type: MyService, deps: [{ token: SomeDep, optional: true }], target: 2 }",
         );
         assert!(result.contains("i0.\u{0275}\u{0275}inject(SomeDep, 8)"));
+    }
+
+    #[test]
+    fn test_factory_with_null_deps_inherits() {
+        let result = parse_and_transform("{ type: SubClass, deps: null, target: 2 }");
+        // No bare `new (ɵt || SubClass)()` call — must chain through inherited factory.
+        assert!(
+            result.contains("\u{0275}\u{0275}getInheritedFactory(SubClass)"),
+            "expected inherited-factory chain: {result}"
+        );
+        // The base-factory cache var prefixed with ɵ to avoid identifier clashes.
+        assert!(result.contains("\u{0275}SubClass_BaseFactory"));
     }
 }

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -35,6 +35,7 @@ use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType, Span};
 
 use crate::module_registry::ModuleRegistry;
+use crate::public_exports::PublicExports;
 
 /// One textual replacement to apply to the source.
 #[derive(Debug)]
@@ -57,12 +58,15 @@ struct NamedImport {
     existing: BTreeSet<String>,
     /// New names to add, accumulated during the deps walk.
     additions: BTreeSet<String>,
-    /// Source path string, e.g. `@angular/forms`. Currently unused in the code
-    /// path — we attribute new names via the owning-import index — but kept
-    /// for future use (e.g. adding a new import statement when no owning import
-    /// exists) and for debugging.
-    #[allow(dead_code)]
+    /// Source specifier string, e.g. `@angular/forms`.
     source: String,
+}
+
+/// A brand-new named-import statement we need to add to the file because no
+/// existing import has the right source.
+#[derive(Debug, Default)]
+struct NewImport {
+    names: BTreeSet<String>,
 }
 
 /// Walk every module and expand NgModule references in component
@@ -72,6 +76,7 @@ struct NamedImport {
 pub fn flatten_component_dependencies(
     modules: &mut HashMap<PathBuf, String>,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
 ) -> NgcResult<usize> {
     if registry.is_empty() {
         return Ok(0);
@@ -88,7 +93,7 @@ pub fn flatten_component_dependencies(
             Some(s) => s.clone(),
             None => continue,
         };
-        if let Some(updated) = flatten_one(&source, &path, registry)? {
+        if let Some(updated) = flatten_one(&source, &path, registry, public_exports)? {
             modules.insert(path.clone(), updated);
             rewritten += 1;
             tracing::debug!(path = %path.display(), "flattened component dependencies");
@@ -97,7 +102,12 @@ pub fn flatten_component_dependencies(
     Ok(rewritten)
 }
 
-fn flatten_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResult<Option<String>> {
+fn flatten_one(
+    source: &str,
+    path: &Path,
+    registry: &ModuleRegistry,
+    public_exports: &PublicExports,
+) -> NgcResult<Option<String>> {
     let alloc = Allocator::default();
     let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
     if !parsed.errors.is_empty() {
@@ -108,13 +118,16 @@ fn flatten_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResul
     }
 
     let mut imports = collect_named_imports(&parsed.program);
+    let mut new_imports: HashMap<String, NewImport> = HashMap::new();
 
     let mut deps_replacements = Vec::new();
     visit_program_deps(
         &parsed.program,
         source,
         registry,
+        public_exports,
         &mut imports,
+        &mut new_imports,
         &mut deps_replacements,
     );
 
@@ -122,7 +135,7 @@ fn flatten_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResul
         return Ok(None);
     }
 
-    // Build replacements for each import that gained additions.
+    // Extend existing imports with added names.
     let mut all_replacements: Vec<Replacement> = deps_replacements;
     for imp in &imports {
         let truly_new: Vec<&String> = imp
@@ -150,6 +163,31 @@ fn flatten_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResul
     for r in &all_replacements {
         result.replace_range(r.start as usize..r.end as usize, &r.text);
     }
+
+    // Prepend any brand-new import statements at the top of the file. Grouped
+    // by source path. Placed before any existing content so ES module imports
+    // stay at the top of the file.
+    if !new_imports.is_empty() {
+        let mut prefix = String::new();
+        let mut sources: Vec<&String> = new_imports.keys().collect();
+        sources.sort();
+        for src_spec in sources {
+            let ni = &new_imports[src_spec];
+            if ni.names.is_empty() {
+                continue;
+            }
+            let names: Vec<String> = ni.names.iter().cloned().collect();
+            prefix.push_str(&format!(
+                "import {{ {} }} from '{}';\n",
+                names.join(", "),
+                src_spec
+            ));
+        }
+        if !prefix.is_empty() {
+            result.insert_str(0, &prefix);
+        }
+    }
+
     Ok(Some(result))
 }
 
@@ -204,11 +242,21 @@ fn visit_program_deps(
     program: &Program<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
     imports: &mut [NamedImport],
+    new_imports: &mut HashMap<String, NewImport>,
     out: &mut Vec<Replacement>,
 ) {
     for stmt in &program.body {
-        visit_stmt(stmt, source, registry, imports, out);
+        visit_stmt(
+            stmt,
+            source,
+            registry,
+            public_exports,
+            imports,
+            new_imports,
+            out,
+        );
     }
 }
 
@@ -216,17 +264,33 @@ fn visit_stmt(
     stmt: &Statement<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
     imports: &mut [NamedImport],
+    new_imports: &mut HashMap<String, NewImport>,
     out: &mut Vec<Replacement>,
 ) {
     match stmt {
-        Statement::ExpressionStatement(s) => {
-            visit_expr(&s.expression, source, registry, imports, out)
-        }
+        Statement::ExpressionStatement(s) => visit_expr(
+            &s.expression,
+            source,
+            registry,
+            public_exports,
+            imports,
+            new_imports,
+            out,
+        ),
         Statement::VariableDeclaration(decl) => {
             for declarator in &decl.declarations {
                 if let Some(init) = &declarator.init {
-                    visit_expr(init, source, registry, imports, out);
+                    visit_expr(
+                        init,
+                        source,
+                        registry,
+                        public_exports,
+                        imports,
+                        new_imports,
+                        out,
+                    );
                 }
             }
         }
@@ -236,12 +300,28 @@ fn visit_stmt(
                     Declaration::VariableDeclaration(var_decl) => {
                         for declarator in &var_decl.declarations {
                             if let Some(init) = &declarator.init {
-                                visit_expr(init, source, registry, imports, out);
+                                visit_expr(
+                                    init,
+                                    source,
+                                    registry,
+                                    public_exports,
+                                    imports,
+                                    new_imports,
+                                    out,
+                                );
                             }
                         }
                     }
                     Declaration::ClassDeclaration(class) => {
-                        visit_class(class, source, registry, imports, out);
+                        visit_class(
+                            class,
+                            source,
+                            registry,
+                            public_exports,
+                            imports,
+                            new_imports,
+                            out,
+                        );
                     }
                     _ => {}
                 }
@@ -249,10 +329,26 @@ fn visit_stmt(
         }
         Statement::ExportDefaultDeclaration(export) => {
             if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &export.declaration {
-                visit_class(class, source, registry, imports, out);
+                visit_class(
+                    class,
+                    source,
+                    registry,
+                    public_exports,
+                    imports,
+                    new_imports,
+                    out,
+                );
             }
         }
-        Statement::ClassDeclaration(class) => visit_class(class, source, registry, imports, out),
+        Statement::ClassDeclaration(class) => visit_class(
+            class,
+            source,
+            registry,
+            public_exports,
+            imports,
+            new_imports,
+            out,
+        ),
         _ => {}
     }
 }
@@ -261,19 +357,37 @@ fn visit_class(
     class: &oxc_ast::ast::Class<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
     imports: &mut [NamedImport],
+    new_imports: &mut HashMap<String, NewImport>,
     out: &mut Vec<Replacement>,
 ) {
     for element in &class.body.body {
         match element {
             oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
                 if let Some(ref init) = prop.value {
-                    visit_expr(init, source, registry, imports, out);
+                    visit_expr(
+                        init,
+                        source,
+                        registry,
+                        public_exports,
+                        imports,
+                        new_imports,
+                        out,
+                    );
                 }
             }
             oxc_ast::ast::ClassElement::StaticBlock(block) => {
                 for stmt in &block.body {
-                    visit_stmt(stmt, source, registry, imports, out);
+                    visit_stmt(
+                        stmt,
+                        source,
+                        registry,
+                        public_exports,
+                        imports,
+                        new_imports,
+                        out,
+                    );
                 }
             }
             _ => {}
@@ -285,31 +399,72 @@ fn visit_expr(
     expr: &Expression<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
     imports: &mut [NamedImport],
+    new_imports: &mut HashMap<String, NewImport>,
     out: &mut Vec<Replacement>,
 ) {
     match expr {
         Expression::CallExpression(call) => {
             if is_define_component(call) {
                 if let Some(obj) = first_object_arg(call) {
-                    if let Some(repl) = rewrite_dependencies(obj, source, registry, imports) {
+                    if let Some(repl) = rewrite_dependencies(
+                        obj,
+                        source,
+                        registry,
+                        public_exports,
+                        imports,
+                        new_imports,
+                    ) {
                         out.push(repl);
                     }
                 }
             }
             for arg in &call.arguments {
                 if let Some(inner) = arg.as_expression() {
-                    visit_expr(inner, source, registry, imports, out);
+                    visit_expr(
+                        inner,
+                        source,
+                        registry,
+                        public_exports,
+                        imports,
+                        new_imports,
+                        out,
+                    );
                 }
             }
         }
-        Expression::AssignmentExpression(a) => visit_expr(&a.right, source, registry, imports, out),
+        Expression::AssignmentExpression(a) => visit_expr(
+            &a.right,
+            source,
+            registry,
+            public_exports,
+            imports,
+            new_imports,
+            out,
+        ),
         Expression::SequenceExpression(seq) => {
             for e in &seq.expressions {
-                visit_expr(e, source, registry, imports, out);
+                visit_expr(
+                    e,
+                    source,
+                    registry,
+                    public_exports,
+                    imports,
+                    new_imports,
+                    out,
+                );
             }
         }
-        Expression::ClassExpression(class) => visit_class(class, source, registry, imports, out),
+        Expression::ClassExpression(class) => visit_class(
+            class,
+            source,
+            registry,
+            public_exports,
+            imports,
+            new_imports,
+            out,
+        ),
         _ => {}
     }
 }
@@ -334,10 +489,19 @@ fn rewrite_dependencies(
     obj: &ObjectExpression<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
     imports: &mut [NamedImport],
+    new_imports: &mut HashMap<String, NewImport>,
 ) -> Option<Replacement> {
     let array = find_dependencies_array(obj)?;
-    let (new_items, any_expanded) = flatten_array_items(array, source, registry, imports);
+    let (new_items, any_expanded) = flatten_array_items(
+        array,
+        source,
+        registry,
+        public_exports,
+        imports,
+        new_imports,
+    );
     if !any_expanded {
         return None;
     }
@@ -381,7 +545,9 @@ fn flatten_array_items(
     array: &ArrayExpression<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    public_exports: &PublicExports,
     imports: &mut [NamedImport],
+    new_imports: &mut HashMap<String, NewImport>,
 ) -> (Vec<String>, bool) {
     let mut items: Vec<String> = Vec::new();
     let mut seen: BTreeSet<String> = BTreeSet::new();
@@ -400,27 +566,45 @@ fn flatten_array_items(
                 if registry.is_module(name) {
                     any_expanded = true;
                     let flat = registry.flatten(name);
-                    let owner_idx = find_import_owning(imports, name);
                     for new_name in &flat {
-                        // Skip identifiers that start with an underscore — by JS
-                        // convention they are package-private. Some Angular
-                        // modules (notably `RouterModule`) list such classes in
-                        // `ɵmod.exports` for their own internal resolution, but
-                        // the classes are *not* publicly exported from the npm
-                        // package. Adding them to a project file's import would
-                        // bind to `undefined` at runtime → `NG0919 — Cannot
-                        // read @Component metadata`. The ɵ-prefix convention
-                        // (e.g. `ɵNgNoValidate`) *is* publicly exported and
-                        // passes through normally.
+                        // Skip underscore-prefixed names — these are JS-private
+                        // by convention and typically not publicly exported from
+                        // any npm package (e.g. `_EmptyOutletComponent` from
+                        // `@angular/router`).
                         if new_name.starts_with('_') {
                             continue;
                         }
-                        push_unique(&mut items, &mut seen, new_name.clone());
-                        if let Some(idx) = owner_idx {
-                            if !any_import_has(imports, new_name) {
-                                imports[idx].additions.insert(new_name.clone());
-                            }
+                        // If the name is already in scope via any existing
+                        // import (original or already-scheduled addition), just
+                        // emit it — no import rewrite needed.
+                        if any_import_has(imports, new_name) {
+                            push_unique(&mut items, &mut seen, new_name.clone());
+                            continue;
                         }
+                        // Find the npm specifier that publicly exports this
+                        // name. If none is known, we cannot safely add it —
+                        // including it in deps would bind to `undefined` and
+                        // trigger NG0919. Drop it silently (matches what ng
+                        // build effectively does when a directive is not
+                        // reachable).
+                        let Some(spec) = public_exports.specifier_for(new_name) else {
+                            tracing::debug!(
+                                name = %new_name,
+                                "flatten: dropping directive — no public npm export found"
+                            );
+                            continue;
+                        };
+                        // Prefer extending an existing same-source import.
+                        if let Some(idx) = find_import_by_source(imports, &spec) {
+                            imports[idx].additions.insert(new_name.clone());
+                        } else {
+                            new_imports
+                                .entry(spec)
+                                .or_default()
+                                .names
+                                .insert(new_name.clone());
+                        }
+                        push_unique(&mut items, &mut seen, new_name.clone());
                     }
                 } else {
                     push_unique(&mut items, &mut seen, name.to_string());
@@ -430,8 +614,6 @@ fn flatten_array_items(
             other => {
                 let span = other.span();
                 let text = &source[span.start as usize..span.end as usize];
-                // Non-identifier elements (spreads, calls, etc.) keep verbatim
-                // text and don't participate in dedup.
                 items.push(text.to_string());
             }
         }
@@ -439,8 +621,8 @@ fn flatten_array_items(
     (items, any_expanded)
 }
 
-fn find_import_owning(imports: &[NamedImport], name: &str) -> Option<usize> {
-    imports.iter().position(|i| i.existing.contains(name))
+fn find_import_by_source(imports: &[NamedImport], source: &str) -> Option<usize> {
+    imports.iter().position(|i| i.source == source)
 }
 
 fn any_import_has(imports: &[NamedImport], name: &str) -> bool {
@@ -452,6 +634,30 @@ fn any_import_has(imports: &[NamedImport], name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_public_exports() -> PublicExports {
+        // Populate with all the names the tests expand to, from plausible
+        // specifier origins. Tests that specifically want to exercise the
+        // "name not publicly exported" case use a separate, empty registry.
+        let pe = PublicExports::new();
+        let forms = "/project/node_modules/@angular/forms/fesm2022/forms.mjs";
+        let exports = "export { DefaultValueAccessor, NgControlStatus, FormGroupDirective, FormControlName, NgModel, \u{0275}NgNoValidate };";
+        pe.scan_file(exports, Path::new(forms));
+        let router = "/project/node_modules/@angular/router/fesm2022/router.mjs";
+        pe.scan_file(
+            "export { RouterOutlet, RouterLink, RouterLinkActive };",
+            Path::new(router),
+        );
+        let dialog = "/project/node_modules/@angular/cdk/fesm2022/dialog.mjs";
+        pe.scan_file("export { CdkDialogContainer };", Path::new(dialog));
+        let portal = "/project/node_modules/@angular/cdk/fesm2022/portal.mjs";
+        pe.scan_file("export { CdkPortal, CdkPortalOutlet };", Path::new(portal));
+        let cdk_dialog_for_cdkdialog = "/project/node_modules/@angular/cdk/fesm2022/dialog.mjs";
+        pe.scan_file("export { CdkDialog };", Path::new(cdk_dialog_for_cdkdialog));
+        let x_mod = "/project/node_modules/x/fesm2022/x.mjs";
+        pe.scan_file("export { SomeDir, OtherPipe };", Path::new(x_mod));
+        pe
+    }
 
     fn make_registry() -> ModuleRegistry {
         let reg = ModuleRegistry::new();
@@ -481,7 +687,9 @@ class C {}\n\
 C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule, MyStandaloneDir] });";
         modules.insert(PathBuf::from("/app/c.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/c.js")).unwrap();
         assert!(
@@ -532,7 +740,9 @@ C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [Reacti
 X.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: X, dependencies: [SomeDir, OtherPipe] });";
         modules.insert(PathBuf::from("/app/x.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 0);
     }
 
@@ -544,7 +754,9 @@ X.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: X, dependencies: [SomeDi
 Y.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Y, dependencies: [ReactiveFormsModule, ...extraDeps, someFn()] });";
         modules.insert(PathBuf::from("/app/y.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/y.js")).unwrap();
         assert!(out.contains("...extraDeps"));
@@ -561,7 +773,9 @@ Y.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Y, dependencies: [Reacti
 Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [ReactiveFormsModule] });";
         modules.insert(PathBuf::from("/app/z.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/z.js")).unwrap();
         let forms_line = out
@@ -581,7 +795,9 @@ Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [Reacti
 Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [X] });";
         modules.insert(PathBuf::from("/app/z.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 0);
     }
 
@@ -593,7 +809,9 @@ Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [X] });
             PathBuf::from("/app/plain.js"),
             "export function f() { return 42; }".to_string(),
         );
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 0);
     }
 
@@ -605,7 +823,9 @@ Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [X] });
 C.\u{0275}cmp = i0.\u{0275}\u{0275}defineComponent({ type: C, dependencies: [DialogModule] });";
         modules.insert(PathBuf::from("/app/c.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/c.js")).unwrap();
         assert!(out.contains("dependencies: [CdkDialog]"));
@@ -641,7 +861,8 @@ C.\u{0275}cmp = i0.\u{0275}\u{0275}defineComponent({ type: C, dependencies: [Dia
 C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [FormsModule, ReactiveFormsModule] });";
         modules.insert(PathBuf::from("/app/c.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &reg).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &reg, &make_public_exports()).unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/c.js")).unwrap();
 
@@ -684,7 +905,8 @@ C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [FormsM
 S.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: S, dependencies: [RouterModule] });";
         modules.insert(PathBuf::from("/app/s.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &reg).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &reg, &make_public_exports()).unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/s.js")).unwrap();
         assert!(out.contains("dependencies: [RouterOutlet, RouterLink, RouterLinkActive]"));
@@ -720,30 +942,119 @@ S.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: S, dependencies: [Router
 C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule] });";
         modules.insert(PathBuf::from("/app/c.js"), source.to_string());
 
-        let _ = flatten_component_dependencies(&mut modules, &reg).unwrap();
+        let _ = flatten_component_dependencies(&mut modules, &reg, &make_public_exports()).unwrap();
         let out = modules.get(Path::new("/app/c.js")).unwrap();
         assert!(out.contains("\u{0275}NgNoValidate"));
         assert!(out.contains("FormGroupDirective"));
     }
 
     #[test]
-    fn skips_import_extension_when_module_not_imported_in_file() {
+    fn adds_new_import_when_module_not_imported_in_file() {
         // Edge case: the dependencies array names a module that the file doesn't
-        // import directly. We still flatten the array but we cannot guess where
-        // to import the directives from. Currently we only extend imports we can
-        // attribute; the bundler may leave the names unresolved — caller's
-        // responsibility to ensure the source brings the module in.
+        // import directly. Now that we know each directive's public npm
+        // specifier (via PublicExports), we can emit a brand-new import
+        // statement so the flattened names are actually in scope.
         let registry = make_registry();
         let mut modules = HashMap::new();
         let source = "Q.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Q, dependencies: [ReactiveFormsModule] });";
         modules.insert(PathBuf::from("/app/q.js"), source.to_string());
 
-        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &registry, &make_public_exports())
+                .unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/q.js")).unwrap();
         // deps array got flattened
         assert!(out.contains("FormControlName"));
-        // no import lines were touched (none existed)
-        assert!(!out.contains("from '@angular/forms'"));
+        // A new import statement is prepended for the flattened names, from
+        // the correct source package inferred via PublicExports.
+        assert!(
+            out.contains("from '@angular/forms'"),
+            "expected injected import, got: {out}"
+        );
+    }
+
+    #[test]
+    fn drops_name_without_known_public_export() {
+        // Edge case: a flattened name has no entry in PublicExports — we must
+        // not include it in deps (would be undefined at runtime) and must not
+        // fabricate an import (we don't know where from).
+        let reg = ModuleRegistry::new();
+        reg.register(
+            "MysteryModule",
+            vec!["KnownDir".into(), "UnknownDir".into()],
+        );
+
+        // PublicExports that knows about KnownDir but not UnknownDir.
+        let pe = PublicExports::new();
+        pe.scan_file(
+            "export { KnownDir };",
+            Path::new("/proj/node_modules/pkg/fesm2022/pkg.mjs"),
+        );
+
+        let mut modules = HashMap::new();
+        let source = "C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [MysteryModule] });";
+        modules.insert(PathBuf::from("/app/c.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &reg, &pe).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/c.js")).unwrap();
+        assert!(out.contains("KnownDir"));
+        assert!(!out.contains("UnknownDir"), "UnknownDir leaked: {out}");
+    }
+
+    #[test]
+    fn adds_to_different_import_when_directive_lives_in_different_subpath() {
+        // Real-world case: DialogModule re-exports PortalModule (whose exports
+        // live in @angular/cdk/portal), but the project only imports DialogModule
+        // from @angular/cdk/dialog. Flatten must add CdkPortal/CdkPortalOutlet
+        // via a NEW import from @angular/cdk/portal, not the existing
+        // @angular/cdk/dialog one (which doesn't export those names).
+        let reg = ModuleRegistry::new();
+        reg.register(
+            "PortalModule",
+            vec!["CdkPortal".into(), "CdkPortalOutlet".into()],
+        );
+        reg.register(
+            "DialogModule",
+            vec!["PortalModule".into(), "CdkDialogContainer".into()],
+        );
+
+        let pe = PublicExports::new();
+        pe.scan_file(
+            "export { CdkPortal, CdkPortalOutlet };",
+            Path::new("/proj/node_modules/@angular/cdk/fesm2022/portal.mjs"),
+        );
+        pe.scan_file(
+            "export { CdkDialogContainer, DialogModule };",
+            Path::new("/proj/node_modules/@angular/cdk/fesm2022/dialog.mjs"),
+        );
+
+        let mut modules = HashMap::new();
+        let source = "import { DialogModule } from '@angular/cdk/dialog';\n\
+D.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: D, dependencies: [DialogModule] });";
+        modules.insert(PathBuf::from("/app/d.js"), source.to_string());
+
+        flatten_component_dependencies(&mut modules, &reg, &pe).unwrap();
+        let out = modules.get(Path::new("/app/d.js")).unwrap();
+        assert!(out.contains("dependencies: [CdkPortal, CdkPortalOutlet, CdkDialogContainer]"));
+        // CdkDialogContainer was added to the existing @angular/cdk/dialog import.
+        let dialog_line = out
+            .lines()
+            .find(|l| l.contains("from '@angular/cdk/dialog'"))
+            .expect("dialog import");
+        assert!(dialog_line.contains("CdkDialogContainer"), "{dialog_line}");
+        assert!(
+            !dialog_line.contains("CdkPortal"),
+            "CdkPortal must NOT be added to dialog import: {dialog_line}"
+        );
+        // CdkPortal + CdkPortalOutlet were added via a NEW import from
+        // @angular/cdk/portal.
+        let portal_line = out
+            .lines()
+            .find(|l| l.contains("from '@angular/cdk/portal'"))
+            .expect("portal import injected");
+        assert!(portal_line.contains("CdkPortal"));
+        assert!(portal_line.contains("CdkPortalOutlet"));
     }
 }

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -4,31 +4,39 @@
 //! every known `ɵɵdefineNgModule`, this pass walks all `ɵɵdefineComponent(`
 //! calls in the module graph and, for each `dependencies: [...]` array,
 //! expands any element that names an NgModule into the module's transitively
-//! flattened directive/pipe/component list. Non-NgModule elements
-//! (directives, pipes, call expressions, spreads, anything else) are preserved
-//! verbatim from the original source text.
+//! flattened directive/pipe/component list.
 //!
-//! This is what `ng build` does at AOT time — and removing
-//! `ɵɵgetComponentDepsFactory` from runtime behavior is the whole reason we
-//! need this pass.
+//! Because the expanded directive identifiers (e.g. `NgControlStatus`,
+//! `FormGroupDirective`) are not normally imported into the project file —
+//! the source typically only imports the wrapping module like
+//! `import { ReactiveFormsModule } from '@angular/forms'` — this pass also
+//! **extends the file's existing named imports** so the new identifiers are
+//! actually defined at runtime. Without that step, the flattened deps array
+//! would reference dangling names and Angular would `ReferenceError` during
+//! component definition (white-screen-of-death).
+//!
+//! The per-module source of truth is the project file's *own* import
+//! statement: if the file imports `{ ReactiveFormsModule } from '@angular/forms'`,
+//! we add `NgControlStatus, FormGroupDirective, …` to that same brace list.
+//! This sidesteps the npm-package-vs-subpath problem because we mirror what
+//! the source file already chose.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::{NgcError, NgcResult};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     ArrayExpression, ArrayExpressionElement, CallExpression, Declaration,
-    ExportDefaultDeclarationKind, Expression, ObjectExpression, ObjectPropertyKind, Program,
-    PropertyKey, Statement,
+    ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier, ObjectExpression,
+    ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 use oxc_parser::Parser;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::{GetSpan, SourceType, Span};
 
 use crate::module_registry::ModuleRegistry;
 
-/// One `dependencies: [...]` array found in an emitted component def whose
-/// module references need expansion.
+/// One textual replacement to apply to the source.
 #[derive(Debug)]
 struct Replacement {
     start: u32,
@@ -36,12 +44,31 @@ struct Replacement {
     text: String,
 }
 
+/// Information about a single named-import statement in the file.
+///
+/// We track only `import { a, b } from 'x'` style — the form the template
+/// compiler emits for project files. Namespace and default imports are
+/// recorded for name lookup but cannot be extended in place.
+#[derive(Debug)]
+struct NamedImport {
+    /// Span of the brace list including braces, e.g. `{ A, B }`.
+    list_span: Span,
+    /// Existing imported local names.
+    existing: BTreeSet<String>,
+    /// New names to add, accumulated during the deps walk.
+    additions: BTreeSet<String>,
+    /// Source path string, e.g. `@angular/forms`. Currently unused in the code
+    /// path — we attribute new names via the owning-import index — but kept
+    /// for future use (e.g. adding a new import statement when no owning import
+    /// exists) and for debugging.
+    #[allow(dead_code)]
+    source: String,
+}
+
 /// Walk every module and expand NgModule references in component
 /// `dependencies` arrays using `registry`.
 ///
-/// Returns the number of `dependencies` arrays that were actually rewritten.
-/// Arrays that contain no NgModule references (or are already fully flat) are
-/// left untouched.
+/// Returns the number of files that were actually rewritten.
 pub fn flatten_component_dependencies(
     modules: &mut HashMap<PathBuf, String>,
     registry: &ModuleRegistry,
@@ -80,29 +107,108 @@ fn flatten_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResul
         });
     }
 
-    let mut replacements = Vec::new();
-    visit_program(&parsed.program, source, registry, &mut replacements);
+    let mut imports = collect_named_imports(&parsed.program);
 
-    if replacements.is_empty() {
+    let mut deps_replacements = Vec::new();
+    visit_program_deps(
+        &parsed.program,
+        source,
+        registry,
+        &mut imports,
+        &mut deps_replacements,
+    );
+
+    if deps_replacements.is_empty() {
         return Ok(None);
     }
 
-    replacements.sort_by_key(|r| std::cmp::Reverse(r.start));
+    // Build replacements for each import that gained additions.
+    let mut all_replacements: Vec<Replacement> = deps_replacements;
+    for imp in &imports {
+        let truly_new: Vec<&String> = imp
+            .additions
+            .iter()
+            .filter(|n| !imp.existing.contains(n.as_str()))
+            .collect();
+        if truly_new.is_empty() {
+            continue;
+        }
+        let mut all_names: Vec<String> = imp.existing.iter().cloned().collect();
+        for n in truly_new {
+            all_names.push(n.clone());
+        }
+        let text = format!("{{ {} }}", all_names.join(", "));
+        all_replacements.push(Replacement {
+            start: imp.list_span.start,
+            end: imp.list_span.end,
+            text,
+        });
+    }
+
+    all_replacements.sort_by_key(|r| std::cmp::Reverse(r.start));
     let mut result = source.to_string();
-    for r in &replacements {
+    for r in &all_replacements {
         result.replace_range(r.start as usize..r.end as usize, &r.text);
     }
     Ok(Some(result))
 }
 
-fn visit_program(
+/// Collect all top-level `import { a, b } from 'x'` statements.
+fn collect_named_imports(program: &Program<'_>) -> Vec<NamedImport> {
+    let mut out = Vec::new();
+    for stmt in &program.body {
+        if let Statement::ImportDeclaration(decl) = stmt {
+            let Some(specifiers) = &decl.specifiers else {
+                continue;
+            };
+            // Determine if there's at least one named import (vs. only namespace/default)
+            let mut has_named = false;
+            let mut existing = BTreeSet::new();
+            let mut min_start = u32::MAX;
+            let mut max_end = 0u32;
+            for spec in specifiers {
+                if let ImportDeclarationSpecifier::ImportSpecifier(s) = spec {
+                    has_named = true;
+                    existing.insert(s.local.name.to_string());
+                    let sp = s.span();
+                    if sp.start < min_start {
+                        min_start = sp.start;
+                    }
+                    if sp.end > max_end {
+                        max_end = sp.end;
+                    }
+                }
+            }
+            if !has_named {
+                continue;
+            }
+            // Find the brace span: scan source to widen min_start..max_end to include braces.
+            // We use the parser-provided endpoints; the surrounding braces sit just outside
+            // the first/last specifier. Caller widens by ±1 byte to swallow `{` and `}`.
+            // To be safe, use the declaration's source range minus the from-clause.
+            // Simpler and reliable: construct the new brace block as `{ ... }` but
+            // replace exactly the existing brace block, located by scanning.
+            let list_span = Span::new(min_start.saturating_sub(2), max_end + 2);
+            out.push(NamedImport {
+                list_span,
+                existing,
+                additions: BTreeSet::new(),
+                source: decl.source.value.to_string(),
+            });
+        }
+    }
+    out
+}
+
+fn visit_program_deps(
     program: &Program<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    imports: &mut [NamedImport],
     out: &mut Vec<Replacement>,
 ) {
     for stmt in &program.body {
-        visit_stmt(stmt, source, registry, out);
+        visit_stmt(stmt, source, registry, imports, out);
     }
 }
 
@@ -110,14 +216,17 @@ fn visit_stmt(
     stmt: &Statement<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    imports: &mut [NamedImport],
     out: &mut Vec<Replacement>,
 ) {
     match stmt {
-        Statement::ExpressionStatement(s) => visit_expr(&s.expression, source, registry, out),
+        Statement::ExpressionStatement(s) => {
+            visit_expr(&s.expression, source, registry, imports, out)
+        }
         Statement::VariableDeclaration(decl) => {
             for declarator in &decl.declarations {
                 if let Some(init) = &declarator.init {
-                    visit_expr(init, source, registry, out);
+                    visit_expr(init, source, registry, imports, out);
                 }
             }
         }
@@ -127,12 +236,12 @@ fn visit_stmt(
                     Declaration::VariableDeclaration(var_decl) => {
                         for declarator in &var_decl.declarations {
                             if let Some(init) = &declarator.init {
-                                visit_expr(init, source, registry, out);
+                                visit_expr(init, source, registry, imports, out);
                             }
                         }
                     }
                     Declaration::ClassDeclaration(class) => {
-                        visit_class(class, source, registry, out);
+                        visit_class(class, source, registry, imports, out);
                     }
                     _ => {}
                 }
@@ -140,10 +249,10 @@ fn visit_stmt(
         }
         Statement::ExportDefaultDeclaration(export) => {
             if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &export.declaration {
-                visit_class(class, source, registry, out);
+                visit_class(class, source, registry, imports, out);
             }
         }
-        Statement::ClassDeclaration(class) => visit_class(class, source, registry, out),
+        Statement::ClassDeclaration(class) => visit_class(class, source, registry, imports, out),
         _ => {}
     }
 }
@@ -152,18 +261,19 @@ fn visit_class(
     class: &oxc_ast::ast::Class<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    imports: &mut [NamedImport],
     out: &mut Vec<Replacement>,
 ) {
     for element in &class.body.body {
         match element {
             oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
                 if let Some(ref init) = prop.value {
-                    visit_expr(init, source, registry, out);
+                    visit_expr(init, source, registry, imports, out);
                 }
             }
             oxc_ast::ast::ClassElement::StaticBlock(block) => {
                 for stmt in &block.body {
-                    visit_stmt(stmt, source, registry, out);
+                    visit_stmt(stmt, source, registry, imports, out);
                 }
             }
             _ => {}
@@ -175,32 +285,31 @@ fn visit_expr(
     expr: &Expression<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    imports: &mut [NamedImport],
     out: &mut Vec<Replacement>,
 ) {
     match expr {
         Expression::CallExpression(call) => {
             if is_define_component(call) {
                 if let Some(obj) = first_object_arg(call) {
-                    if let Some(repl) = rewrite_dependencies(obj, source, registry) {
+                    if let Some(repl) = rewrite_dependencies(obj, source, registry, imports) {
                         out.push(repl);
                     }
                 }
             }
-            // Walk arguments too — rare, but defineComponent can appear inside
-            // helper call wrappers.
             for arg in &call.arguments {
                 if let Some(inner) = arg.as_expression() {
-                    visit_expr(inner, source, registry, out);
+                    visit_expr(inner, source, registry, imports, out);
                 }
             }
         }
-        Expression::AssignmentExpression(a) => visit_expr(&a.right, source, registry, out),
+        Expression::AssignmentExpression(a) => visit_expr(&a.right, source, registry, imports, out),
         Expression::SequenceExpression(seq) => {
             for e in &seq.expressions {
-                visit_expr(e, source, registry, out);
+                visit_expr(e, source, registry, imports, out);
             }
         }
-        Expression::ClassExpression(class) => visit_class(class, source, registry, out),
+        Expression::ClassExpression(class) => visit_class(class, source, registry, imports, out),
         _ => {}
     }
 }
@@ -225,9 +334,10 @@ fn rewrite_dependencies(
     obj: &ObjectExpression<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    imports: &mut [NamedImport],
 ) -> Option<Replacement> {
     let array = find_dependencies_array(obj)?;
-    let (new_items, any_expanded) = flatten_array_items(array, source, registry);
+    let (new_items, any_expanded) = flatten_array_items(array, source, registry, imports);
     if !any_expanded {
         return None;
     }
@@ -257,14 +367,14 @@ fn find_dependencies_array<'a>(obj: &'a ObjectExpression<'_>) -> Option<&'a Arra
     None
 }
 
-/// Expand each element of the array. Returns `(items, any_expanded)` where
-/// `any_expanded` is true if at least one NgModule identifier was replaced
-/// with its flattened exports (including the case of a zero-element flatten,
-/// which still counts as a replacement to preserve exact `ng build` semantics).
+/// Expand each element of the array. Returns `(items, any_expanded)`.
+/// As a side effect, schedules import additions on `imports` for any directive
+/// names that the file does not yet have in scope.
 fn flatten_array_items(
     array: &ArrayExpression<'_>,
     source: &str,
     registry: &ModuleRegistry,
+    imports: &mut [NamedImport],
 ) -> (Vec<String>, bool) {
     let mut items = Vec::new();
     let mut any_expanded = false;
@@ -274,16 +384,23 @@ fn flatten_array_items(
                 let name = id.name.as_str();
                 if registry.is_module(name) {
                     any_expanded = true;
-                    for flat in registry.flatten(name) {
-                        items.push(flat);
+                    let flat = registry.flatten(name);
+                    let owner_idx = find_import_owning(imports, name);
+                    for new_name in &flat {
+                        items.push(new_name.clone());
+                        if let Some(idx) = owner_idx {
+                            // Skip if any existing named import (anywhere in the file)
+                            // already brings this in.
+                            if !any_import_has(imports, new_name) {
+                                imports[idx].additions.insert(new_name.clone());
+                            }
+                        }
                     }
                 } else {
                     items.push(name.to_string());
                 }
             }
-            ArrayExpressionElement::Elision(_) => {
-                // sparse array slot — drop it; Angular treats missing deps as absent
-            }
+            ArrayExpressionElement::Elision(_) => {}
             other => {
                 let span = other.span();
                 let text = &source[span.start as usize..span.end as usize];
@@ -292,6 +409,16 @@ fn flatten_array_items(
         }
     }
     (items, any_expanded)
+}
+
+fn find_import_owning(imports: &[NamedImport], name: &str) -> Option<usize> {
+    imports.iter().position(|i| i.existing.contains(name))
+}
+
+fn any_import_has(imports: &[NamedImport], name: &str) -> bool {
+    imports
+        .iter()
+        .any(|i| i.existing.contains(name) || i.additions.contains(name))
 }
 
 #[cfg(test)]
@@ -317,71 +444,113 @@ mod tests {
     }
 
     #[test]
-    fn flattens_module_and_keeps_standalone_directive() {
+    fn flattens_module_and_extends_existing_import() {
         let registry = make_registry();
         let mut modules = HashMap::new();
-        let source = "class C {} C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule, MyStandaloneDir] });";
+        let source = "import { ReactiveFormsModule, FormBuilder } from '@angular/forms';\n\
+import { MyStandaloneDir } from './my-dir';\n\
+class C {}\n\
+C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule, MyStandaloneDir] });";
         modules.insert(PathBuf::from("/app/c.js"), source.to_string());
 
         let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/c.js")).unwrap();
-        assert!(out.contains(
-            "dependencies: [DefaultValueAccessor, NgControlStatus, FormGroupDirective, FormControlName, MyStandaloneDir]"
-        ), "unexpected output: {out}");
+        assert!(
+            out.contains(
+                "dependencies: [DefaultValueAccessor, NgControlStatus, FormGroupDirective, FormControlName, MyStandaloneDir]"
+            ),
+            "deps array unexpected: {out}"
+        );
+        // The import statement should now also bring in the directive names.
+        for needed in [
+            "DefaultValueAccessor",
+            "NgControlStatus",
+            "FormGroupDirective",
+            "FormControlName",
+        ] {
+            assert!(out.contains(needed), "directive {needed} missing: {out}");
+        }
+        // Specifically, the @angular/forms import line should now include them.
+        assert!(
+            out.contains("from '@angular/forms'"),
+            "forms import missing: {out}"
+        );
+        // The @angular/forms import should contain the directive names in its brace list.
+        let forms_line = out
+            .lines()
+            .find(|l| l.contains("from '@angular/forms'"))
+            .expect("forms import line");
+        for needed in [
+            "ReactiveFormsModule",
+            "FormBuilder",
+            "DefaultValueAccessor",
+            "NgControlStatus",
+            "FormGroupDirective",
+            "FormControlName",
+        ] {
+            assert!(
+                forms_line.contains(needed),
+                "{needed} not in forms import: {forms_line}"
+            );
+        }
     }
 
     #[test]
     fn no_rewrite_when_array_has_no_modules() {
         let registry = make_registry();
         let mut modules = HashMap::new();
-        let source = "X.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: X, dependencies: [SomeDir, OtherPipe] });";
+        let source = "import { SomeDir, OtherPipe } from 'x';\n\
+X.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: X, dependencies: [SomeDir, OtherPipe] });";
         modules.insert(PathBuf::from("/app/x.js"), source.to_string());
 
         let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
         assert_eq!(rewritten, 0);
-        let out = modules.get(Path::new("/app/x.js")).unwrap();
-        assert!(out.contains("dependencies: [SomeDir, OtherPipe]"));
     }
 
     #[test]
     fn preserves_non_identifier_elements_verbatim() {
         let registry = make_registry();
         let mut modules = HashMap::new();
-        let source = "Y.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Y, dependencies: [ReactiveFormsModule, ...extraDeps, someFn()] });";
+        let source = "import { ReactiveFormsModule } from '@angular/forms';\n\
+Y.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Y, dependencies: [ReactiveFormsModule, ...extraDeps, someFn()] });";
         modules.insert(PathBuf::from("/app/y.js"), source.to_string());
 
         let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/y.js")).unwrap();
-        assert!(out.contains("...extraDeps"), "spread lost: {out}");
-        assert!(out.contains("someFn()"), "call lost: {out}");
-        assert!(out.contains("FormControlName"), "flatten lost: {out}");
+        assert!(out.contains("...extraDeps"));
+        assert!(out.contains("someFn()"));
+        assert!(out.contains("FormControlName"));
     }
 
     #[test]
-    fn two_components_in_one_file() {
+    fn does_not_duplicate_already_imported_directive() {
         let registry = make_registry();
         let mut modules = HashMap::new();
-        let source = "A.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: A, dependencies: [ReactiveFormsModule] });\n\
-B.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: B, dependencies: [DialogModule, MyDir] });";
-        modules.insert(PathBuf::from("/app/multi.js"), source.to_string());
+        // FormControlName is already imported directly for some other use.
+        let source = "import { ReactiveFormsModule, FormControlName } from '@angular/forms';\n\
+Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [ReactiveFormsModule] });";
+        modules.insert(PathBuf::from("/app/z.js"), source.to_string());
 
         let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
-        assert_eq!(rewritten, 1); // one file rewritten; both arrays were handled within it
-        let out = modules.get(Path::new("/app/multi.js")).unwrap();
-        assert!(out.contains(
-            "dependencies: [DefaultValueAccessor, NgControlStatus, FormGroupDirective, FormControlName]"
-        ));
-        assert!(out.contains("dependencies: [CdkDialog, MyDir]"));
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/z.js")).unwrap();
+        let forms_line = out
+            .lines()
+            .find(|l| l.contains("from '@angular/forms'"))
+            .expect("forms import line");
+        // FormControlName must appear exactly once in the brace list.
+        let count = forms_line.matches("FormControlName").count();
+        assert_eq!(count, 1, "duplicate import: {forms_line}");
     }
 
     #[test]
     fn empty_registry_skips_work() {
         let registry = ModuleRegistry::new();
         let mut modules = HashMap::new();
-        let source =
-            "Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [X] });";
+        let source = "import { X } from 'x';\n\
+Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [X] });";
         modules.insert(PathBuf::from("/app/z.js"), source.to_string());
 
         let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
@@ -404,13 +573,39 @@ B.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: B, dependencies: [Dialog
     fn handles_namespaced_define_component_call() {
         let registry = make_registry();
         let mut modules = HashMap::new();
-        // Some linked output uses i0.ɵɵdefineComponent(...)
-        let source = "C.\u{0275}cmp = i0.\u{0275}\u{0275}defineComponent({ type: C, dependencies: [DialogModule] });";
+        let source = "import { DialogModule } from '@angular/cdk/dialog';\n\
+C.\u{0275}cmp = i0.\u{0275}\u{0275}defineComponent({ type: C, dependencies: [DialogModule] });";
         modules.insert(PathBuf::from("/app/c.js"), source.to_string());
 
         let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
         assert_eq!(rewritten, 1);
         let out = modules.get(Path::new("/app/c.js")).unwrap();
         assert!(out.contains("dependencies: [CdkDialog]"));
+        let cdk_line = out
+            .lines()
+            .find(|l| l.contains("from '@angular/cdk/dialog'"))
+            .expect("cdk import line");
+        assert!(cdk_line.contains("CdkDialog"), "{cdk_line}");
+    }
+
+    #[test]
+    fn skips_import_extension_when_module_not_imported_in_file() {
+        // Edge case: the dependencies array names a module that the file doesn't
+        // import directly. We still flatten the array but we cannot guess where
+        // to import the directives from. Currently we only extend imports we can
+        // attribute; the bundler may leave the names unresolved — caller's
+        // responsibility to ensure the source brings the module in.
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        let source = "Q.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Q, dependencies: [ReactiveFormsModule] });";
+        modules.insert(PathBuf::from("/app/q.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/q.js")).unwrap();
+        // deps array got flattened
+        assert!(out.contains("FormControlName"));
+        // no import lines were touched (none existed)
+        assert!(!out.contains("from '@angular/forms'"));
     }
 }

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -1,0 +1,416 @@
+//! Pass B: flatten NgModule references in component `dependencies` arrays.
+//!
+//! After the npm linker and Pass A have populated the [`ModuleRegistry`] with
+//! every known `ɵɵdefineNgModule`, this pass walks all `ɵɵdefineComponent(`
+//! calls in the module graph and, for each `dependencies: [...]` array,
+//! expands any element that names an NgModule into the module's transitively
+//! flattened directive/pipe/component list. Non-NgModule elements
+//! (directives, pipes, call expressions, spreads, anything else) are preserved
+//! verbatim from the original source text.
+//!
+//! This is what `ng build` does at AOT time — and removing
+//! `ɵɵgetComponentDepsFactory` from runtime behavior is the whole reason we
+//! need this pass.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    ArrayExpression, ArrayExpressionElement, CallExpression, Declaration,
+    ExportDefaultDeclarationKind, Expression, ObjectExpression, ObjectPropertyKind, Program,
+    PropertyKey, Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+use crate::module_registry::ModuleRegistry;
+
+/// One `dependencies: [...]` array found in an emitted component def whose
+/// module references need expansion.
+#[derive(Debug)]
+struct Replacement {
+    start: u32,
+    end: u32,
+    text: String,
+}
+
+/// Walk every module and expand NgModule references in component
+/// `dependencies` arrays using `registry`.
+///
+/// Returns the number of `dependencies` arrays that were actually rewritten.
+/// Arrays that contain no NgModule references (or are already fully flat) are
+/// left untouched.
+pub fn flatten_component_dependencies(
+    modules: &mut HashMap<PathBuf, String>,
+    registry: &ModuleRegistry,
+) -> NgcResult<usize> {
+    if registry.is_empty() {
+        return Ok(0);
+    }
+    let paths: Vec<PathBuf> = modules
+        .iter()
+        .filter(|(_, source)| source.contains("\u{0275}\u{0275}defineComponent"))
+        .map(|(path, _)| path.clone())
+        .collect();
+
+    let mut rewritten = 0;
+    for path in paths {
+        let source = match modules.get(&path) {
+            Some(s) => s.clone(),
+            None => continue,
+        };
+        if let Some(updated) = flatten_one(&source, &path, registry)? {
+            modules.insert(path.clone(), updated);
+            rewritten += 1;
+            tracing::debug!(path = %path.display(), "flattened component dependencies");
+        }
+    }
+    Ok(rewritten)
+}
+
+fn flatten_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResult<Option<String>> {
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
+    if !parsed.errors.is_empty() {
+        return Err(NgcError::LinkerError {
+            path: path.to_path_buf(),
+            message: format!("parse error: {}", parsed.errors[0]),
+        });
+    }
+
+    let mut replacements = Vec::new();
+    visit_program(&parsed.program, source, registry, &mut replacements);
+
+    if replacements.is_empty() {
+        return Ok(None);
+    }
+
+    replacements.sort_by_key(|r| std::cmp::Reverse(r.start));
+    let mut result = source.to_string();
+    for r in &replacements {
+        result.replace_range(r.start as usize..r.end as usize, &r.text);
+    }
+    Ok(Some(result))
+}
+
+fn visit_program(
+    program: &Program<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+    out: &mut Vec<Replacement>,
+) {
+    for stmt in &program.body {
+        visit_stmt(stmt, source, registry, out);
+    }
+}
+
+fn visit_stmt(
+    stmt: &Statement<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+    out: &mut Vec<Replacement>,
+) {
+    match stmt {
+        Statement::ExpressionStatement(s) => visit_expr(&s.expression, source, registry, out),
+        Statement::VariableDeclaration(decl) => {
+            for declarator in &decl.declarations {
+                if let Some(init) = &declarator.init {
+                    visit_expr(init, source, registry, out);
+                }
+            }
+        }
+        Statement::ExportNamedDeclaration(export) => {
+            if let Some(ref d) = export.declaration {
+                match d {
+                    Declaration::VariableDeclaration(var_decl) => {
+                        for declarator in &var_decl.declarations {
+                            if let Some(init) = &declarator.init {
+                                visit_expr(init, source, registry, out);
+                            }
+                        }
+                    }
+                    Declaration::ClassDeclaration(class) => {
+                        visit_class(class, source, registry, out);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Statement::ExportDefaultDeclaration(export) => {
+            if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &export.declaration {
+                visit_class(class, source, registry, out);
+            }
+        }
+        Statement::ClassDeclaration(class) => visit_class(class, source, registry, out),
+        _ => {}
+    }
+}
+
+fn visit_class(
+    class: &oxc_ast::ast::Class<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+    out: &mut Vec<Replacement>,
+) {
+    for element in &class.body.body {
+        match element {
+            oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
+                if let Some(ref init) = prop.value {
+                    visit_expr(init, source, registry, out);
+                }
+            }
+            oxc_ast::ast::ClassElement::StaticBlock(block) => {
+                for stmt in &block.body {
+                    visit_stmt(stmt, source, registry, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn visit_expr(
+    expr: &Expression<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+    out: &mut Vec<Replacement>,
+) {
+    match expr {
+        Expression::CallExpression(call) => {
+            if is_define_component(call) {
+                if let Some(obj) = first_object_arg(call) {
+                    if let Some(repl) = rewrite_dependencies(obj, source, registry) {
+                        out.push(repl);
+                    }
+                }
+            }
+            // Walk arguments too — rare, but defineComponent can appear inside
+            // helper call wrappers.
+            for arg in &call.arguments {
+                if let Some(inner) = arg.as_expression() {
+                    visit_expr(inner, source, registry, out);
+                }
+            }
+        }
+        Expression::AssignmentExpression(a) => visit_expr(&a.right, source, registry, out),
+        Expression::SequenceExpression(seq) => {
+            for e in &seq.expressions {
+                visit_expr(e, source, registry, out);
+            }
+        }
+        Expression::ClassExpression(class) => visit_class(class, source, registry, out),
+        _ => {}
+    }
+}
+
+fn is_define_component(call: &CallExpression<'_>) -> bool {
+    let name = match &call.callee {
+        Expression::Identifier(id) => id.name.as_str(),
+        Expression::StaticMemberExpression(m) => m.property.name.as_str(),
+        _ => return false,
+    };
+    name.ends_with("defineComponent")
+}
+
+fn first_object_arg<'a>(call: &'a CallExpression<'_>) -> Option<&'a ObjectExpression<'a>> {
+    match call.arguments.first()? {
+        oxc_ast::ast::Argument::ObjectExpression(obj) => Some(obj.as_ref()),
+        _ => None,
+    }
+}
+
+fn rewrite_dependencies(
+    obj: &ObjectExpression<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+) -> Option<Replacement> {
+    let array = find_dependencies_array(obj)?;
+    let (new_items, any_expanded) = flatten_array_items(array, source, registry);
+    if !any_expanded {
+        return None;
+    }
+    let span = array.span;
+    Some(Replacement {
+        start: span.start,
+        end: span.end,
+        text: format!("[{}]", new_items.join(", ")),
+    })
+}
+
+fn find_dependencies_array<'a>(obj: &'a ObjectExpression<'_>) -> Option<&'a ArrayExpression<'a>> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            let key_matches = match &p.key {
+                PropertyKey::StaticIdentifier(id) => id.name.as_str() == "dependencies",
+                PropertyKey::StringLiteral(s) => s.value.as_str() == "dependencies",
+                _ => false,
+            };
+            if key_matches {
+                if let Expression::ArrayExpression(arr) = &p.value {
+                    return Some(arr);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Expand each element of the array. Returns `(items, any_expanded)` where
+/// `any_expanded` is true if at least one NgModule identifier was replaced
+/// with its flattened exports (including the case of a zero-element flatten,
+/// which still counts as a replacement to preserve exact `ng build` semantics).
+fn flatten_array_items(
+    array: &ArrayExpression<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+) -> (Vec<String>, bool) {
+    let mut items = Vec::new();
+    let mut any_expanded = false;
+    for element in &array.elements {
+        match element {
+            ArrayExpressionElement::Identifier(id) => {
+                let name = id.name.as_str();
+                if registry.is_module(name) {
+                    any_expanded = true;
+                    for flat in registry.flatten(name) {
+                        items.push(flat);
+                    }
+                } else {
+                    items.push(name.to_string());
+                }
+            }
+            ArrayExpressionElement::Elision(_) => {
+                // sparse array slot — drop it; Angular treats missing deps as absent
+            }
+            other => {
+                let span = other.span();
+                let text = &source[span.start as usize..span.end as usize];
+                items.push(text.to_string());
+            }
+        }
+    }
+    (items, any_expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_registry() -> ModuleRegistry {
+        let reg = ModuleRegistry::new();
+        reg.register(
+            "InternalShared",
+            vec!["DefaultValueAccessor".into(), "NgControlStatus".into()],
+        );
+        reg.register(
+            "ReactiveFormsModule",
+            vec![
+                "InternalShared".into(),
+                "FormGroupDirective".into(),
+                "FormControlName".into(),
+            ],
+        );
+        reg.register("DialogModule", vec!["CdkDialog".into()]);
+        reg
+    }
+
+    #[test]
+    fn flattens_module_and_keeps_standalone_directive() {
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        let source = "class C {} C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule, MyStandaloneDir] });";
+        modules.insert(PathBuf::from("/app/c.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/c.js")).unwrap();
+        assert!(out.contains(
+            "dependencies: [DefaultValueAccessor, NgControlStatus, FormGroupDirective, FormControlName, MyStandaloneDir]"
+        ), "unexpected output: {out}");
+    }
+
+    #[test]
+    fn no_rewrite_when_array_has_no_modules() {
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        let source = "X.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: X, dependencies: [SomeDir, OtherPipe] });";
+        modules.insert(PathBuf::from("/app/x.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 0);
+        let out = modules.get(Path::new("/app/x.js")).unwrap();
+        assert!(out.contains("dependencies: [SomeDir, OtherPipe]"));
+    }
+
+    #[test]
+    fn preserves_non_identifier_elements_verbatim() {
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        let source = "Y.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Y, dependencies: [ReactiveFormsModule, ...extraDeps, someFn()] });";
+        modules.insert(PathBuf::from("/app/y.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/y.js")).unwrap();
+        assert!(out.contains("...extraDeps"), "spread lost: {out}");
+        assert!(out.contains("someFn()"), "call lost: {out}");
+        assert!(out.contains("FormControlName"), "flatten lost: {out}");
+    }
+
+    #[test]
+    fn two_components_in_one_file() {
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        let source = "A.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: A, dependencies: [ReactiveFormsModule] });\n\
+B.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: B, dependencies: [DialogModule, MyDir] });";
+        modules.insert(PathBuf::from("/app/multi.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 1); // one file rewritten; both arrays were handled within it
+        let out = modules.get(Path::new("/app/multi.js")).unwrap();
+        assert!(out.contains(
+            "dependencies: [DefaultValueAccessor, NgControlStatus, FormGroupDirective, FormControlName]"
+        ));
+        assert!(out.contains("dependencies: [CdkDialog, MyDir]"));
+    }
+
+    #[test]
+    fn empty_registry_skips_work() {
+        let registry = ModuleRegistry::new();
+        let mut modules = HashMap::new();
+        let source =
+            "Z.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: Z, dependencies: [X] });";
+        modules.insert(PathBuf::from("/app/z.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 0);
+    }
+
+    #[test]
+    fn file_without_define_component_untouched() {
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        modules.insert(
+            PathBuf::from("/app/plain.js"),
+            "export function f() { return 42; }".to_string(),
+        );
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 0);
+    }
+
+    #[test]
+    fn handles_namespaced_define_component_call() {
+        let registry = make_registry();
+        let mut modules = HashMap::new();
+        // Some linked output uses i0.ɵɵdefineComponent(...)
+        let source = "C.\u{0275}cmp = i0.\u{0275}\u{0275}defineComponent({ type: C, dependencies: [DialogModule] });";
+        modules.insert(PathBuf::from("/app/c.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &registry).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/c.js")).unwrap();
+        assert!(out.contains("dependencies: [CdkDialog]"));
+    }
+}

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -368,6 +368,13 @@ fn find_dependencies_array<'a>(obj: &'a ObjectExpression<'_>) -> Option<&'a Arra
 }
 
 /// Expand each element of the array. Returns `(items, any_expanded)`.
+///
+/// Deduplication happens at the *array* level, not per-module: two
+/// flattened modules that re-export the same internal module (e.g.
+/// `FormsModule` and `ReactiveFormsModule` both re-exporting the internal
+/// forms-shared module) must not emit the shared directives twice, or Angular
+/// will throw `NG0919 — Cannot read @Component metadata` at runtime.
+///
 /// As a side effect, schedules import additions on `imports` for any directive
 /// names that the file does not yet have in scope.
 fn flatten_array_items(
@@ -376,8 +383,16 @@ fn flatten_array_items(
     registry: &ModuleRegistry,
     imports: &mut [NamedImport],
 ) -> (Vec<String>, bool) {
-    let mut items = Vec::new();
+    let mut items: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
     let mut any_expanded = false;
+
+    let push_unique = |items: &mut Vec<String>, seen: &mut BTreeSet<String>, value: String| {
+        if seen.insert(value.clone()) {
+            items.push(value);
+        }
+    };
+
     for element in &array.elements {
         match element {
             ArrayExpressionElement::Identifier(id) => {
@@ -387,23 +402,23 @@ fn flatten_array_items(
                     let flat = registry.flatten(name);
                     let owner_idx = find_import_owning(imports, name);
                     for new_name in &flat {
-                        items.push(new_name.clone());
+                        push_unique(&mut items, &mut seen, new_name.clone());
                         if let Some(idx) = owner_idx {
-                            // Skip if any existing named import (anywhere in the file)
-                            // already brings this in.
                             if !any_import_has(imports, new_name) {
                                 imports[idx].additions.insert(new_name.clone());
                             }
                         }
                     }
                 } else {
-                    items.push(name.to_string());
+                    push_unique(&mut items, &mut seen, name.to_string());
                 }
             }
             ArrayExpressionElement::Elision(_) => {}
             other => {
                 let span = other.span();
                 let text = &source[span.start as usize..span.end as usize];
+                // Non-identifier elements (spreads, calls, etc.) keep verbatim
+                // text and don't participate in dedup.
                 items.push(text.to_string());
             }
         }
@@ -586,6 +601,52 @@ C.\u{0275}cmp = i0.\u{0275}\u{0275}defineComponent({ type: C, dependencies: [Dia
             .find(|l| l.contains("from '@angular/cdk/dialog'"))
             .expect("cdk import line");
         assert!(cdk_line.contains("CdkDialog"), "{cdk_line}");
+    }
+
+    #[test]
+    fn dedups_across_sibling_modules_sharing_internal_exports() {
+        // Mirrors the real-world case: FormsModule and ReactiveFormsModule
+        // both re-export the same shared internal module. Without
+        // cross-module dedup we'd emit every shared directive twice, which
+        // Angular rejects with NG0919.
+        let reg = ModuleRegistry::new();
+        reg.register(
+            "InternalShared",
+            vec!["DefaultValueAccessor".into(), "NgControlStatus".into()],
+        );
+        reg.register(
+            "FormsModule",
+            vec!["InternalShared".into(), "NgModel".into()],
+        );
+        reg.register(
+            "ReactiveFormsModule",
+            vec!["InternalShared".into(), "FormGroupDirective".into()],
+        );
+
+        let mut modules = HashMap::new();
+        let source = "import { FormsModule, ReactiveFormsModule } from '@angular/forms';\n\
+C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [FormsModule, ReactiveFormsModule] });";
+        modules.insert(PathBuf::from("/app/c.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &reg).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/c.js")).unwrap();
+
+        // Extract deps array content.
+        let start = out.find("dependencies: [").unwrap() + "dependencies: [".len();
+        let end = out[start..].find(']').unwrap() + start;
+        let arr = &out[start..end];
+        let items: Vec<&str> = arr.split(',').map(|s| s.trim()).collect();
+        // Each name appears exactly once.
+        for needed in [
+            "DefaultValueAccessor",
+            "NgControlStatus",
+            "NgModel",
+            "FormGroupDirective",
+        ] {
+            let count = items.iter().filter(|x| **x == needed).count();
+            assert_eq!(count, 1, "{needed} appeared {count} times in {arr}");
+        }
     }
 
     #[test]

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -402,6 +402,19 @@ fn flatten_array_items(
                     let flat = registry.flatten(name);
                     let owner_idx = find_import_owning(imports, name);
                     for new_name in &flat {
+                        // Skip identifiers that start with an underscore — by JS
+                        // convention they are package-private. Some Angular
+                        // modules (notably `RouterModule`) list such classes in
+                        // `ɵmod.exports` for their own internal resolution, but
+                        // the classes are *not* publicly exported from the npm
+                        // package. Adding them to a project file's import would
+                        // bind to `undefined` at runtime → `NG0919 — Cannot
+                        // read @Component metadata`. The ɵ-prefix convention
+                        // (e.g. `ɵNgNoValidate`) *is* publicly exported and
+                        // passes through normally.
+                        if new_name.starts_with('_') {
+                            continue;
+                        }
                         push_unique(&mut items, &mut seen, new_name.clone());
                         if let Some(idx) = owner_idx {
                             if !any_import_has(imports, new_name) {
@@ -647,6 +660,70 @@ C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [FormsM
             let count = items.iter().filter(|x| **x == needed).count();
             assert_eq!(count, 1, "{needed} appeared {count} times in {arr}");
         }
+    }
+
+    #[test]
+    fn skips_underscore_prefixed_private_exports() {
+        // Mirrors the RouterModule case: its ɵmod.exports list contains
+        // `_EmptyOutletComponent`, an internal class not publicly exported
+        // from @angular/router. We must not emit such names in project
+        // dependency arrays — they bind to `undefined` and throw NG0919.
+        let reg = ModuleRegistry::new();
+        reg.register(
+            "RouterModule",
+            vec![
+                "RouterOutlet".into(),
+                "RouterLink".into(),
+                "RouterLinkActive".into(),
+                "_EmptyOutletComponent".into(),
+            ],
+        );
+
+        let mut modules = HashMap::new();
+        let source = "import { RouterModule } from '@angular/router';\n\
+S.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: S, dependencies: [RouterModule] });";
+        modules.insert(PathBuf::from("/app/s.js"), source.to_string());
+
+        let rewritten = flatten_component_dependencies(&mut modules, &reg).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/s.js")).unwrap();
+        assert!(out.contains("dependencies: [RouterOutlet, RouterLink, RouterLinkActive]"));
+        assert!(!out.contains("_EmptyOutletComponent"));
+        // The import line should include the three public directives but not the
+        // private one.
+        let router_line = out
+            .lines()
+            .find(|l| l.contains("from '@angular/router'"))
+            .expect("router import line");
+        for needed in ["RouterOutlet", "RouterLink", "RouterLinkActive"] {
+            assert!(router_line.contains(needed), "{router_line}");
+        }
+        assert!(
+            !router_line.contains("_EmptyOutletComponent"),
+            "{router_line}"
+        );
+    }
+
+    #[test]
+    fn keeps_theta_prefixed_public_exports() {
+        // ɵ-prefix is the Angular convention for "internal but still publicly
+        // exported" (e.g. `ɵNgNoValidate` from @angular/forms). We must not
+        // filter these — they ARE importable.
+        let reg = ModuleRegistry::new();
+        reg.register(
+            "ReactiveFormsModule",
+            vec!["\u{0275}NgNoValidate".into(), "FormGroupDirective".into()],
+        );
+
+        let mut modules = HashMap::new();
+        let source = "import { ReactiveFormsModule } from '@angular/forms';\n\
+C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule] });";
+        modules.insert(PathBuf::from("/app/c.js"), source.to_string());
+
+        let _ = flatten_component_dependencies(&mut modules, &reg).unwrap();
+        let out = modules.get(Path::new("/app/c.js")).unwrap();
+        assert!(out.contains("\u{0275}NgNoValidate"));
+        assert!(out.contains("FormGroupDirective"));
     }
 
     #[test]

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -192,6 +192,12 @@ fn flatten_one(
 }
 
 /// Collect all top-level `import { a, b } from 'x'` statements.
+///
+/// For each named-import block, record the exact byte span of the `{ ... }`
+/// list (inclusive of both braces) by scanning the source around the first
+/// specifier rather than guessing based on fixed offsets — whitespace and
+/// multi-line formatting would otherwise misplace the replacement range and
+/// corrupt the file.
 fn collect_named_imports(program: &Program<'_>) -> Vec<NamedImport> {
     let mut out = Vec::new();
     for stmt in &program.body {
@@ -199,7 +205,6 @@ fn collect_named_imports(program: &Program<'_>) -> Vec<NamedImport> {
             let Some(specifiers) = &decl.specifiers else {
                 continue;
             };
-            // Determine if there's at least one named import (vs. only namespace/default)
             let mut has_named = false;
             let mut existing = BTreeSet::new();
             let mut min_start = u32::MAX;
@@ -220,13 +225,15 @@ fn collect_named_imports(program: &Program<'_>) -> Vec<NamedImport> {
             if !has_named {
                 continue;
             }
-            // Find the brace span: scan source to widen min_start..max_end to include braces.
-            // We use the parser-provided endpoints; the surrounding braces sit just outside
-            // the first/last specifier. Caller widens by ±1 byte to swallow `{` and `}`.
-            // To be safe, use the declaration's source range minus the from-clause.
-            // Simpler and reliable: construct the new brace block as `{ ... }` but
-            // replace exactly the existing brace block, located by scanning.
-            let list_span = Span::new(min_start.saturating_sub(2), max_end + 2);
+            // Brace positions: scan backward from first specifier for the `{`,
+            // and forward from last specifier for the matching `}`. Bounded by
+            // the import declaration's own span.
+            let decl_span = decl.span();
+            let Some(list_span) =
+                find_brace_list_span(min_start, max_end, decl_span.start, decl_span.end, program)
+            else {
+                continue;
+            };
             out.push(NamedImport {
                 list_span,
                 existing,
@@ -236,6 +243,47 @@ fn collect_named_imports(program: &Program<'_>) -> Vec<NamedImport> {
         }
     }
     out
+}
+
+/// Find the brace span `{ … }` containing the named-import specifiers.
+///
+/// Takes the byte offsets of the first specifier's start (`first_spec_start`)
+/// and the last specifier's end (`last_spec_end`), and the import declaration's
+/// own start/end as bounds. Walks backward for `{` and forward for `}`.
+/// Returns `None` if braces aren't found — caller skips this import (we only
+/// touch well-formed `import { … } from '…'` statements).
+fn find_brace_list_span(
+    first_spec_start: u32,
+    last_spec_end: u32,
+    decl_start: u32,
+    decl_end: u32,
+    program: &Program<'_>,
+) -> Option<Span> {
+    let src = program.source_text.as_bytes();
+    let mut i = first_spec_start as usize;
+    let lower = decl_start as usize;
+    while i > lower {
+        i -= 1;
+        match src[i] {
+            b'{' => {
+                let open = i as u32;
+                let mut j = last_spec_end as usize;
+                let upper = decl_end as usize;
+                while j < upper && j < src.len() {
+                    if src[j] == b'}' {
+                        return Some(Span::new(open, (j + 1) as u32));
+                    }
+                    j += 1;
+                }
+                return None;
+            }
+            // Stop if we hit something that can't be a brace prefix — should
+            // only be whitespace between `{` and first specifier normally.
+            b'\n' | b'\r' | b'\t' | b' ' | b',' => continue,
+            _ => {}
+        }
+    }
+    None
 }
 
 fn visit_program_deps(
@@ -972,6 +1020,50 @@ C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [Reacti
             out.contains("from '@angular/forms'"),
             "expected injected import, got: {out}"
         );
+    }
+
+    #[test]
+    fn extends_multiline_import_block_correctly() {
+        // Regression: early implementations assumed `{ A, B }` fixed-offset
+        // braces and corrupted multi-line imports (which Prettier produces
+        // for long lists). The file would end up with a truncated import
+        // and stale code bleeding into the rewritten span — visible in the
+        // treasr-frontend dialog as "backdrop renders, container doesn't".
+        let reg = make_registry();
+        let mut modules = HashMap::new();
+        let source = "import {\n  ReactiveFormsModule,\n  FormBuilder,\n  FormGroup,\n  Validators,\n} from '@angular/forms';\n\
+class C {}\n\
+C.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: C, dependencies: [ReactiveFormsModule] });";
+        modules.insert(PathBuf::from("/app/m.js"), source.to_string());
+
+        let rewritten =
+            flatten_component_dependencies(&mut modules, &reg, &make_public_exports()).unwrap();
+        assert_eq!(rewritten, 1);
+        let out = modules.get(Path::new("/app/m.js")).unwrap();
+        // The defineComponent call must still be intact (no truncation).
+        assert!(
+            out.contains("C.\u{0275}cmp = \u{0275}\u{0275}defineComponent"),
+            "defineComponent corrupted: {out}"
+        );
+        assert!(out.contains("class C {}"), "class C corrupted: {out}");
+        // All original import names must still be present exactly once,
+        // checked as whole tokens (avoid `FormGroup` matching `FormGroupDirective`).
+        let import_section = out.split("} from '@angular/forms'").next().unwrap();
+        let names: Vec<&str> = import_section
+            .trim_start_matches("import {")
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        for needed in [
+            "ReactiveFormsModule",
+            "FormBuilder",
+            "FormGroup",
+            "Validators",
+        ] {
+            let count = names.iter().filter(|n| **n == needed).count();
+            assert_eq!(count, 1, "{needed} miscounted in: {import_section}");
+        }
     }
 
     #[test]

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -44,12 +44,17 @@ use ngc_diagnostics::NgcResult;
 pub use module_registry::ModuleRegistry;
 
 /// Statistics from the linking process.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LinkerStats {
     /// Number of npm files scanned for declarations.
     pub files_scanned: usize,
     /// Number of files that contained `ɵɵngDeclare*` calls and were linked.
     pub files_linked: usize,
+    /// Number of `ɵɵdefineNgModule` calls scanned in Pass A.
+    pub modules_registered: usize,
+    /// Number of files whose component `dependencies` arrays were rewritten
+    /// to expand NgModule references into flat directive/pipe lists.
+    pub components_flattened: usize,
 }
 
 /// Link all partially compiled Angular npm modules in the modules map.
@@ -102,7 +107,32 @@ pub fn link_npm_modules(
     Ok(LinkerStats {
         files_scanned,
         files_linked,
+        ..LinkerStats::default()
     })
+}
+
+/// Full Angular module-linking orchestrator.
+///
+/// Runs three passes in order:
+/// 1. [`link_npm_modules`] — rewrites npm `ɵɵngDeclare*` partial declarations
+///    into fully-compiled `ɵɵdefine*` calls, and registers each NgModule in
+///    `registry` as a side effect.
+/// 2. [`module_registry::scan_define_ng_modules`] — registers any remaining
+///    `ɵɵdefineNgModule` calls (project AOT output, pre-compiled npm bundles).
+/// 3. [`flatten::flatten_component_dependencies`] — walks every
+///    `ɵɵdefineComponent` and expands NgModule references in its
+///    `dependencies` array to transitively-exported directives/pipes. This is
+///    what removes the need for the runtime `ɵɵgetComponentDepsFactory`
+///    helper and fixes reactive-forms `NG01050` errors inside dialogs.
+pub fn link_modules(
+    modules: &mut HashMap<PathBuf, String>,
+    project_root: &Path,
+) -> NgcResult<LinkerStats> {
+    let registry = ModuleRegistry::new();
+    let mut stats = link_npm_modules(modules, project_root, &registry)?;
+    stats.modules_registered = module_registry::scan_define_ng_modules(modules, &registry)?;
+    stats.components_flattened = flatten::flatten_component_dependencies(modules, &registry)?;
+    Ok(stats)
 }
 
 /// Check whether a path is inside node_modules.

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -32,6 +32,8 @@ mod metadata;
 pub mod module_registry;
 mod ng_module;
 mod pipe;
+/// Map of publicly-exported npm identifier → best import specifier.
+pub mod public_exports;
 mod selector;
 /// Low-level linking API for transforming a single source file.
 pub mod transform;
@@ -42,6 +44,7 @@ use std::path::{Path, PathBuf};
 use ngc_diagnostics::NgcResult;
 
 pub use module_registry::ModuleRegistry;
+pub use public_exports::PublicExports;
 
 /// Statistics from the linking process.
 #[derive(Debug, Clone, Default)]
@@ -129,9 +132,22 @@ pub fn link_modules(
     project_root: &Path,
 ) -> NgcResult<LinkerStats> {
     let registry = ModuleRegistry::new();
+    let public_exports = PublicExports::new();
     let mut stats = link_npm_modules(modules, project_root, &registry)?;
+
+    // Build the public-exports index by scanning every npm file's top-level
+    // `export { … }` statements. Needed so the flatten pass can target the
+    // correct import specifier for each directive it adds.
+    for (path, source) in modules.iter() {
+        if !is_npm_module(path) {
+            continue;
+        }
+        public_exports.scan_file(source, path);
+    }
+
     stats.modules_registered = module_registry::scan_define_ng_modules(modules, &registry)?;
-    stats.components_flattened = flatten::flatten_component_dependencies(modules, &registry)?;
+    stats.components_flattened =
+        flatten::flatten_component_dependencies(modules, &registry, &public_exports)?;
     Ok(stats)
 }
 

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -23,6 +23,8 @@ mod factory;
 mod injectable;
 mod injector;
 mod metadata;
+/// Build-time NgModule registry and import-flattening primitives.
+pub mod module_registry;
 mod ng_module;
 mod pipe;
 mod selector;

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -9,10 +9,12 @@
 //! ```ignore
 //! use std::collections::HashMap;
 //! use std::path::PathBuf;
+//! use ngc_linker::ModuleRegistry;
 //!
 //! let mut modules: HashMap<PathBuf, String> = HashMap::new();
 //! // ... populate with npm module sources ...
-//! let stats = ngc_linker::link_npm_modules(&mut modules, &project_root)?;
+//! let registry = ModuleRegistry::new();
+//! let stats = ngc_linker::link_npm_modules(&mut modules, &project_root, &registry)?;
 //! println!("Linked {} files", stats.files_linked);
 //! ```
 
@@ -36,6 +38,8 @@ use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::NgcResult;
 
+pub use module_registry::ModuleRegistry;
+
 /// Statistics from the linking process.
 #[derive(Debug, Clone)]
 pub struct LinkerStats {
@@ -49,12 +53,15 @@ pub struct LinkerStats {
 ///
 /// Scans all modules whose paths contain `node_modules` for `ɵɵngDeclare*`
 /// calls. Files that contain declarations are parsed, transformed, and their
-/// source is replaced in the map.
+/// source is replaced in the map. Any `ɵɵngDeclareNgModule` calls encountered
+/// are also registered in `registry` so a later flatten pass can resolve
+/// standalone-component `imports` arrays.
 ///
 /// Files without `ɵɵngDeclare` are skipped with zero overhead (fast string check).
 pub fn link_npm_modules(
     modules: &mut HashMap<PathBuf, String>,
     _project_root: &Path,
+    registry: &ModuleRegistry,
 ) -> NgcResult<LinkerStats> {
     let mut files_scanned = 0;
     let mut files_linked = 0;
@@ -75,7 +82,7 @@ pub fn link_npm_modules(
     for path in paths_to_link {
         if let Some(source) = modules.get(&path) {
             let source = source.clone();
-            match transform::link_source(&source, &path)? {
+            match transform::link_source(&source, &path, registry)? {
                 Some(linked) => {
                     modules.insert(path.clone(), linked);
                     files_linked += 1;
@@ -136,7 +143,8 @@ mod tests {
             PathBuf::from("/project/src/app.ts"),
             "export class App {}".to_string(),
         );
-        let stats = link_npm_modules(&mut modules, Path::new("/project")).unwrap();
+        let registry = ModuleRegistry::new();
+        let stats = link_npm_modules(&mut modules, Path::new("/project"), &registry).unwrap();
         assert_eq!(stats.files_scanned, 0);
         assert_eq!(stats.files_linked, 0);
     }
@@ -148,7 +156,8 @@ mod tests {
             PathBuf::from("/project/node_modules/lodash/lodash.mjs"),
             "export function chunk() {}".to_string(),
         );
-        let stats = link_npm_modules(&mut modules, Path::new("/project")).unwrap();
+        let registry = ModuleRegistry::new();
+        let stats = link_npm_modules(&mut modules, Path::new("/project"), &registry).unwrap();
         assert_eq!(stats.files_scanned, 1);
         assert_eq!(stats.files_linked, 0);
     }
@@ -172,7 +181,8 @@ export { MyService };"#;
             source,
         );
 
-        let stats = link_npm_modules(&mut modules, Path::new("/project")).unwrap();
+        let registry = ModuleRegistry::new();
+        let stats = link_npm_modules(&mut modules, Path::new("/project"), &registry).unwrap();
         assert_eq!(stats.files_linked, 1);
 
         let linked = modules
@@ -181,5 +191,27 @@ export { MyService };"#;
         assert!(!linked.contains("\u{0275}\u{0275}ngDeclare"));
         assert!(linked.contains("_Factory"));
         assert!(linked.contains("\u{0275}\u{0275}defineInjectable"));
+    }
+
+    #[test]
+    fn test_link_npm_modules_registers_ng_module_exports() {
+        let mut modules = HashMap::new();
+        let source = "import * as i0 from '@angular/core';\n\
+class ReactiveFormsModule {}\n\
+ReactiveFormsModule.\u{0275}mod = i0.\u{0275}\u{0275}ngDeclareNgModule({ minVersion: \"14.0.0\", version: \"17.0.0\", ngImport: i0, type: ReactiveFormsModule, exports: [FormGroupDirective, FormControlName] });\n\
+export { ReactiveFormsModule };";
+        modules.insert(
+            PathBuf::from("/project/node_modules/@angular/forms/index.mjs"),
+            source.to_string(),
+        );
+
+        let registry = ModuleRegistry::new();
+        let stats = link_npm_modules(&mut modules, Path::new("/project"), &registry).unwrap();
+        assert_eq!(stats.files_linked, 1);
+        assert!(registry.is_module("ReactiveFormsModule"));
+        assert_eq!(
+            registry.flatten("ReactiveFormsModule"),
+            vec!["FormGroupDirective", "FormControlName"]
+        );
     }
 }

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -22,6 +22,9 @@ mod class_metadata;
 mod component;
 mod directive;
 mod factory;
+/// Post-link pass that expands NgModule references in component `dependencies`
+/// arrays using the [`module_registry::ModuleRegistry`].
+pub mod flatten;
 mod injectable;
 mod injector;
 mod metadata;

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -156,6 +156,12 @@ fn is_npm_module(path: &Path) -> bool {
     path.components().any(|c| c.as_os_str() == "node_modules")
 }
 
+/// Public version of [`is_npm_module`] for consumers (the CLI's post-link
+/// scan needs to filter project files vs. npm files).
+pub fn is_npm_path(path: &Path) -> bool {
+    is_npm_module(path)
+}
+
 /// Fast check whether a source file might contain Angular partial declarations.
 ///
 /// Uses a simple substring check — much faster than parsing.

--- a/crates/linker/src/module_registry.rs
+++ b/crates/linker/src/module_registry.rs
@@ -1,0 +1,320 @@
+//! Registry of NgModule classes and their exported directive/pipe/component lists.
+//!
+//! Populated from both npm `ɵɵngDeclareNgModule` calls (during npm linking) and
+//! `ɵɵdefineNgModule` calls (project AOT output). Used by the post-link pass that
+//! flattens standalone-component `imports` arrays at build time, mirroring what
+//! `ng build` does.
+//!
+//! ## Why
+//!
+//! Modern Angular apps are standalone-first, but npm packages still ship their
+//! directives bundled into NgModules (e.g. `ReactiveFormsModule` from
+//! `@angular/forms`). When a standalone component does
+//! `imports: [ReactiveFormsModule]`, Angular's official compiler walks the
+//! module's `ɵmod.exports` transitively and emits a flat directive class list
+//! on the component def. Doing this at compile time avoids the runtime
+//! `ɵɵgetComponentDepsFactory` helper, which has known instantiation-order bugs
+//! that surface as `NG01050` for reactive forms inside dialogs.
+//!
+//! ## Lifecycle
+//!
+//! - **Population is split** between npm linking (`ng_module::transform`) and a
+//!   post-pass that scans every module for `ɵɵdefineNgModule(`. This is why
+//!   transitive flattening is *lazy* — both populations must complete before
+//!   any flatten lookup is correct.
+//! - **Per-invocation** today; watch mode (v0.8) will need invalidation hooks.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
+/// Maps NgModule class names to their (transitively flattened) exported
+/// directive/pipe/component class names.
+///
+/// All keys/values are local source identifiers as they appear in the file
+/// where the NgModule was declared. Cross-file linking happens via the bundler
+/// after this stage.
+#[derive(Debug, Default)]
+pub struct ModuleRegistry {
+    /// Class name -> direct exports (in source order, possibly containing other
+    /// module names that need transitive expansion).
+    raw_exports: RwLock<HashMap<String, Vec<String>>>,
+    /// Set of class names known to be NgModules (i.e., have been registered).
+    is_module: RwLock<HashSet<String>>,
+    /// Memoized result of [`flatten`]. Cleared implicitly between builds since
+    /// each build constructs a fresh registry.
+    flat_cache: RwLock<HashMap<String, Vec<String>>>,
+}
+
+impl ModuleRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an NgModule with its direct (un-flattened) exports list.
+    ///
+    /// Subsequent registrations for the same module name overwrite the previous
+    /// entry and emit a `tracing::warn!`. This handles the rare case where a
+    /// project file declares an NgModule with the same name as one in an npm
+    /// package.
+    pub fn register(&self, name: &str, exports: Vec<String>) {
+        {
+            let mut raw = match self.raw_exports.write() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            if raw.contains_key(name) {
+                tracing::warn!(
+                    module = name,
+                    "NgModule registered more than once; later registration wins"
+                );
+            }
+            raw.insert(name.to_string(), exports);
+        }
+        {
+            let mut set = match self.is_module.write() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            set.insert(name.to_string());
+        }
+        if let Ok(mut cache) = self.flat_cache.write() {
+            cache.clear();
+        }
+    }
+
+    /// Whether the given class name is a known NgModule.
+    pub fn is_module(&self, name: &str) -> bool {
+        match self.is_module.read() {
+            Ok(g) => g.contains(name),
+            Err(p) => p.into_inner().contains(name),
+        }
+    }
+
+    /// Number of registered NgModules.
+    pub fn len(&self) -> usize {
+        match self.is_module.read() {
+            Ok(g) => g.len(),
+            Err(p) => p.into_inner().len(),
+        }
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return the transitively flattened directive/pipe class list for `name`.
+    ///
+    /// If `name` is not a known NgModule, returns `vec![name]` (pass-through —
+    /// the caller is treating the identifier as a possible module reference but
+    /// it might be a plain directive).
+    ///
+    /// Cycle-safe: a `visited` set prevents infinite recursion when
+    /// pathological NgModules transitively re-export each other.
+    /// Order-preserving: depth-first source order with O(n) dedup. The lists
+    /// are small (typically <30) so the linear contains-check is fine.
+    pub fn flatten(&self, name: &str) -> Vec<String> {
+        if let Ok(cache) = self.flat_cache.read() {
+            if let Some(hit) = cache.get(name) {
+                return hit.clone();
+            }
+        }
+        let mut visited = HashSet::new();
+        let mut out = Vec::new();
+        self.walk(name, &mut visited, &mut out);
+        if let Ok(mut cache) = self.flat_cache.write() {
+            cache.insert(name.to_string(), out.clone());
+        }
+        out
+    }
+
+    fn walk(&self, name: &str, visited: &mut HashSet<String>, out: &mut Vec<String>) {
+        if !visited.insert(name.to_string()) {
+            return;
+        }
+        let direct = match self.raw_exports.read() {
+            Ok(g) => g.get(name).cloned(),
+            Err(p) => p.into_inner().get(name).cloned(),
+        };
+        match direct {
+            Some(exports) => {
+                for e in exports {
+                    if self.is_module(&e) {
+                        self.walk(&e, visited, out);
+                    } else if !out.iter().any(|x| x == &e) {
+                        out.push(e);
+                    }
+                }
+            }
+            None => {
+                if !out.iter().any(|x| x == name) {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+}
+
+/// Parse an array-literal source text like `"[A, B, C]"` into a list of bare
+/// identifier names. Returns `None` if the text is not a simple identifier list
+/// (e.g. contains spreads, calls, or non-identifier elements).
+///
+/// Used by callers that have already extracted the raw source text of an
+/// `exports`/`imports`/`declarations` array property via
+/// [`crate::metadata::get_source_text`].
+pub fn parse_identifier_array(src: &str) -> Option<Vec<String>> {
+    let trimmed = src.trim();
+    let inner = trimmed.strip_prefix('[')?.strip_suffix(']')?;
+    let mut out = Vec::new();
+    for raw in inner.split(',') {
+        let item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+        if !is_identifier(item) {
+            return None;
+        }
+        out.push(item.to_string());
+    }
+    Some(out)
+}
+
+fn is_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    let first = match chars.next() {
+        Some(c) => c,
+        None => return false,
+    };
+    if !(first.is_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flatten_passthrough_for_unknown_class() {
+        let reg = ModuleRegistry::new();
+        assert_eq!(reg.flatten("FormControlName"), vec!["FormControlName"]);
+    }
+
+    #[test]
+    fn flatten_returns_direct_exports() {
+        let reg = ModuleRegistry::new();
+        reg.register("MyModule", vec!["DirA".into(), "DirB".into()]);
+        assert_eq!(reg.flatten("MyModule"), vec!["DirA", "DirB"]);
+    }
+
+    #[test]
+    fn flatten_walks_transitive_modules_in_source_order() {
+        let reg = ModuleRegistry::new();
+        // ReactiveFormsModule shape: re-exports an internal shared module,
+        // followed by its own directives.
+        reg.register(
+            "InternalShared",
+            vec!["DefaultValueAccessor".into(), "NgControlStatus".into()],
+        );
+        reg.register(
+            "ReactiveFormsModule",
+            vec![
+                "InternalShared".into(),
+                "FormGroupDirective".into(),
+                "FormControlName".into(),
+            ],
+        );
+        let flat = reg.flatten("ReactiveFormsModule");
+        assert_eq!(
+            flat,
+            vec![
+                "DefaultValueAccessor",
+                "NgControlStatus",
+                "FormGroupDirective",
+                "FormControlName"
+            ]
+        );
+    }
+
+    #[test]
+    fn flatten_dedups_duplicate_directives_across_modules() {
+        let reg = ModuleRegistry::new();
+        reg.register("ModA", vec!["SharedDir".into(), "DirA".into()]);
+        reg.register("ModB", vec!["SharedDir".into(), "DirB".into()]);
+        reg.register("Combined", vec!["ModA".into(), "ModB".into()]);
+        let flat = reg.flatten("Combined");
+        assert_eq!(flat, vec!["SharedDir", "DirA", "DirB"]);
+    }
+
+    #[test]
+    fn flatten_handles_cycles() {
+        let reg = ModuleRegistry::new();
+        reg.register("A", vec!["B".into(), "DirA".into()]);
+        reg.register("B", vec!["A".into(), "DirB".into()]);
+        let flat = reg.flatten("A");
+        // Walks A -> B (skips A re-entry) -> DirB, then DirA.
+        assert_eq!(flat, vec!["DirB", "DirA"]);
+    }
+
+    #[test]
+    fn flatten_caches_result() {
+        let reg = ModuleRegistry::new();
+        reg.register("M", vec!["D".into()]);
+        let first = reg.flatten("M");
+        let second = reg.flatten("M");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn register_invalidates_flat_cache() {
+        let reg = ModuleRegistry::new();
+        reg.register("M", vec!["DirOld".into()]);
+        let _ = reg.flatten("M");
+        reg.register("M", vec!["DirNew".into()]);
+        assert_eq!(reg.flatten("M"), vec!["DirNew"]);
+    }
+
+    #[test]
+    fn is_module_reflects_registration() {
+        let reg = ModuleRegistry::new();
+        assert!(!reg.is_module("M"));
+        reg.register("M", vec![]);
+        assert!(reg.is_module("M"));
+    }
+
+    #[test]
+    fn parse_identifier_array_basic() {
+        assert_eq!(
+            parse_identifier_array("[A, B, C]"),
+            Some(vec!["A".into(), "B".into(), "C".into()])
+        );
+    }
+
+    #[test]
+    fn parse_identifier_array_handles_whitespace() {
+        assert_eq!(
+            parse_identifier_array("[\n  A,\n  B,\n]"),
+            Some(vec!["A".into(), "B".into()])
+        );
+    }
+
+    #[test]
+    fn parse_identifier_array_rejects_non_identifier_elements() {
+        assert!(parse_identifier_array("[a.b, c]").is_none());
+        assert!(parse_identifier_array("[fn(), c]").is_none());
+        assert!(parse_identifier_array("[...spread, c]").is_none());
+    }
+
+    #[test]
+    fn parse_identifier_array_accepts_empty() {
+        assert_eq!(parse_identifier_array("[]"), Some(vec![]));
+    }
+
+    #[test]
+    fn parse_identifier_array_rejects_non_array() {
+        assert!(parse_identifier_array("foo").is_none());
+        assert!(parse_identifier_array("(a, b)").is_none());
+    }
+}

--- a/crates/linker/src/module_registry.rs
+++ b/crates/linker/src/module_registry.rs
@@ -326,12 +326,10 @@ fn visit_class(
 
 fn visit_expr(expr: &Expression<'_>, source: &str, registry: &ModuleRegistry, count: &mut usize) {
     match expr {
-        Expression::CallExpression(call) => {
-            if is_define_ng_module(call) {
-                if let Some(obj) = first_object_arg(call) {
-                    register_from_define(obj, source, registry);
-                    *count += 1;
-                }
+        Expression::CallExpression(call) if is_define_ng_module(call) => {
+            if let Some(obj) = first_object_arg(call) {
+                register_from_define(obj, source, registry);
+                *count += 1;
             }
         }
         Expression::AssignmentExpression(assign) => {

--- a/crates/linker/src/module_registry.rs
+++ b/crates/linker/src/module_registry.rs
@@ -25,7 +25,19 @@
 //! - **Per-invocation** today; watch mode (v0.8) will need invalidation hooks.
 
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    CallExpression, Declaration, ExportDefaultDeclarationKind, Expression, ObjectExpression,
+    Program, Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use crate::metadata;
 
 /// Maps NgModule class names to their (transitively flattened) exported
 /// directive/pipe/component class names.
@@ -53,23 +65,33 @@ impl ModuleRegistry {
 
     /// Register an NgModule with its direct (un-flattened) exports list.
     ///
-    /// Subsequent registrations for the same module name overwrite the previous
-    /// entry and emit a `tracing::warn!`. This handles the rare case where a
-    /// project file declares an NgModule with the same name as one in an npm
-    /// package.
+    /// Idempotent for identical re-registration (Pass A may re-visit a module
+    /// already registered by the npm link pass). If the module name is already
+    /// present with a *different* exports list, the later registration wins
+    /// and a `tracing::warn!` is emitted — this handles the rare case where a
+    /// project file shadows an npm package's NgModule.
     pub fn register(&self, name: &str, exports: Vec<String>) {
+        let mut changed = true;
         {
             let mut raw = match self.raw_exports.write() {
                 Ok(g) => g,
                 Err(p) => p.into_inner(),
             };
-            if raw.contains_key(name) {
-                tracing::warn!(
-                    module = name,
-                    "NgModule registered more than once; later registration wins"
-                );
+            match raw.get(name) {
+                Some(existing) if existing == &exports => {
+                    changed = false;
+                }
+                Some(_) => {
+                    tracing::warn!(
+                        module = name,
+                        "NgModule registered with conflicting exports; later registration wins"
+                    );
+                    raw.insert(name.to_string(), exports);
+                }
+                None => {
+                    raw.insert(name.to_string(), exports);
+                }
             }
-            raw.insert(name.to_string(), exports);
         }
         {
             let mut set = match self.is_module.write() {
@@ -78,8 +100,10 @@ impl ModuleRegistry {
             };
             set.insert(name.to_string());
         }
-        if let Ok(mut cache) = self.flat_cache.write() {
-            cache.clear();
+        if changed {
+            if let Ok(mut cache) = self.flat_cache.write() {
+                cache.clear();
+            }
         }
     }
 
@@ -178,6 +202,178 @@ pub fn parse_identifier_array(src: &str) -> Option<Vec<String>> {
         out.push(item.to_string());
     }
     Some(out)
+}
+
+/// Scan every module in `modules` for `ɵɵdefineNgModule(` calls and register
+/// the discovered NgModules in `registry`.
+///
+/// This is Pass A of the standalone-import flattening pipeline. It runs after
+/// npm linking (so any `ɵɵngDeclareNgModule` calls have already been rewritten
+/// to `ɵɵdefineNgModule` and also registered via the linker's transform hook)
+/// and covers two otherwise-missed cases:
+///
+/// 1. **Project NgModules** — rare in modern Angular apps but legal; emitted
+///    by [`ngc_template_compiler::ng_module_codegen`] with `ɵɵdefineNgModule`.
+/// 2. **npm packages shipping fully-compiled bundles** that bypass the
+///    `ɵɵngDeclare*` partial format.
+///
+/// Registration is idempotent for identical re-registration, so re-scanning
+/// already-registered npm modules is harmless.
+///
+/// Returns the number of `ɵɵdefineNgModule` calls found.
+pub fn scan_define_ng_modules(
+    modules: &HashMap<PathBuf, String>,
+    registry: &ModuleRegistry,
+) -> NgcResult<usize> {
+    let mut count = 0;
+    for (path, source) in modules {
+        if !source.contains("\u{0275}\u{0275}defineNgModule") {
+            continue;
+        }
+        count += scan_one(source, path, registry)?;
+    }
+    Ok(count)
+}
+
+fn scan_one(source: &str, path: &Path, registry: &ModuleRegistry) -> NgcResult<usize> {
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
+    if !parsed.errors.is_empty() {
+        return Err(NgcError::LinkerError {
+            path: path.to_path_buf(),
+            message: format!("parse error: {}", parsed.errors[0]),
+        });
+    }
+    let mut count = 0;
+    visit_program(&parsed.program, source, registry, &mut count);
+    Ok(count)
+}
+
+fn visit_program(
+    program: &Program<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+    count: &mut usize,
+) {
+    for stmt in &program.body {
+        visit_stmt(stmt, source, registry, count);
+    }
+}
+
+fn visit_stmt(stmt: &Statement<'_>, source: &str, registry: &ModuleRegistry, count: &mut usize) {
+    match stmt {
+        Statement::ExpressionStatement(expr_stmt) => {
+            visit_expr(&expr_stmt.expression, source, registry, count);
+        }
+        Statement::VariableDeclaration(decl) => {
+            for declarator in &decl.declarations {
+                if let Some(init) = &declarator.init {
+                    visit_expr(init, source, registry, count);
+                }
+            }
+        }
+        Statement::ExportNamedDeclaration(export) => {
+            if let Some(ref d) = export.declaration {
+                match d {
+                    Declaration::VariableDeclaration(var_decl) => {
+                        for declarator in &var_decl.declarations {
+                            if let Some(init) = &declarator.init {
+                                visit_expr(init, source, registry, count);
+                            }
+                        }
+                    }
+                    Declaration::ClassDeclaration(class) => {
+                        visit_class(class, source, registry, count);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Statement::ExportDefaultDeclaration(export) => {
+            if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &export.declaration {
+                visit_class(class, source, registry, count);
+            }
+        }
+        Statement::ClassDeclaration(class) => {
+            visit_class(class, source, registry, count);
+        }
+        _ => {}
+    }
+}
+
+fn visit_class(
+    class: &oxc_ast::ast::Class<'_>,
+    source: &str,
+    registry: &ModuleRegistry,
+    count: &mut usize,
+) {
+    for element in &class.body.body {
+        match element {
+            oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
+                if let Some(ref init) = prop.value {
+                    visit_expr(init, source, registry, count);
+                }
+            }
+            oxc_ast::ast::ClassElement::StaticBlock(block) => {
+                for stmt in &block.body {
+                    visit_stmt(stmt, source, registry, count);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn visit_expr(expr: &Expression<'_>, source: &str, registry: &ModuleRegistry, count: &mut usize) {
+    match expr {
+        Expression::CallExpression(call) => {
+            if is_define_ng_module(call) {
+                if let Some(obj) = first_object_arg(call) {
+                    register_from_define(obj, source, registry);
+                    *count += 1;
+                }
+            }
+        }
+        Expression::AssignmentExpression(assign) => {
+            visit_expr(&assign.right, source, registry, count);
+        }
+        Expression::SequenceExpression(seq) => {
+            for e in &seq.expressions {
+                visit_expr(e, source, registry, count);
+            }
+        }
+        Expression::ClassExpression(class) => {
+            visit_class(class, source, registry, count);
+        }
+        _ => {}
+    }
+}
+
+fn is_define_ng_module(call: &CallExpression<'_>) -> bool {
+    let name = match &call.callee {
+        Expression::Identifier(id) => id.name.as_str(),
+        Expression::StaticMemberExpression(m) => m.property.name.as_str(),
+        _ => return false,
+    };
+    name.ends_with("defineNgModule")
+}
+
+fn first_object_arg<'a>(call: &'a CallExpression<'_>) -> Option<&'a ObjectExpression<'a>> {
+    match call.arguments.first()? {
+        oxc_ast::ast::Argument::ObjectExpression(obj) => Some(obj.as_ref()),
+        _ => None,
+    }
+}
+
+fn register_from_define(obj: &ObjectExpression<'_>, source: &str, registry: &ModuleRegistry) {
+    let name = match metadata::get_identifier_prop(obj, "type") {
+        Some(n) => n,
+        None => return,
+    };
+    let exports = metadata::get_source_text(obj, "exports", source)
+        .and_then(parse_identifier_array)
+        .unwrap_or_default();
+    registry.register(&name, exports);
 }
 
 fn is_identifier(s: &str) -> bool {
@@ -316,5 +512,90 @@ mod tests {
     fn parse_identifier_array_rejects_non_array() {
         assert!(parse_identifier_array("foo").is_none());
         assert!(parse_identifier_array("(a, b)").is_none());
+    }
+
+    #[test]
+    fn register_is_idempotent_for_identical_exports() {
+        let reg = ModuleRegistry::new();
+        reg.register("M", vec!["A".into(), "B".into()]);
+        reg.register("M", vec!["A".into(), "B".into()]);
+        assert_eq!(reg.flatten("M"), vec!["A", "B"]);
+    }
+
+    #[test]
+    fn scan_registers_project_define_ng_module() {
+        let mut modules = HashMap::new();
+        let source = "class AppModule {}\n\
+AppModule.\u{0275}fac = function AppModule_Factory(t) { return new (t || AppModule)(); };\n\
+AppModule.\u{0275}mod = \u{0275}\u{0275}defineNgModule({ type: AppModule, declarations: [MyComp], imports: [SubModule], exports: [MyComp] });\n\
+AppModule.\u{0275}inj = \u{0275}\u{0275}defineInjector({});\n\
+export { AppModule };";
+        modules.insert(
+            PathBuf::from("/project/src/app.module.js"),
+            source.to_string(),
+        );
+
+        let registry = ModuleRegistry::new();
+        let count = scan_define_ng_modules(&modules, &registry).unwrap();
+        assert_eq!(count, 1);
+        assert!(registry.is_module("AppModule"));
+        assert_eq!(registry.flatten("AppModule"), vec!["MyComp"]);
+    }
+
+    #[test]
+    fn scan_is_idempotent_over_already_registered_npm_module() {
+        // Mimics the case where the npm link pass has already rewritten
+        // ɵɵngDeclareNgModule to ɵɵdefineNgModule and registered the module.
+        // Pass A then re-visits the same file and registration should be a no-op.
+        let registry = ModuleRegistry::new();
+        registry.register(
+            "ReactiveFormsModule",
+            vec!["FormGroupDirective".into(), "FormControlName".into()],
+        );
+
+        let mut modules = HashMap::new();
+        let source = "i0.\u{0275}\u{0275}defineNgModule({ type: ReactiveFormsModule, exports: [FormGroupDirective, FormControlName] });";
+        modules.insert(
+            PathBuf::from("/node_modules/@angular/forms/index.mjs"),
+            source.to_string(),
+        );
+
+        let count = scan_define_ng_modules(&modules, &registry).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            registry.flatten("ReactiveFormsModule"),
+            vec!["FormGroupDirective", "FormControlName"]
+        );
+    }
+
+    #[test]
+    fn scan_skips_files_without_define_ng_module() {
+        let mut modules = HashMap::new();
+        modules.insert(
+            PathBuf::from("/project/src/utils.js"),
+            "export function add(a, b) { return a + b; }".to_string(),
+        );
+        let registry = ModuleRegistry::new();
+        let count = scan_define_ng_modules(&modules, &registry).unwrap();
+        assert_eq!(count, 0);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn scan_handles_define_ng_module_without_exports() {
+        let mut modules = HashMap::new();
+        let source = "class EmptyModule {}\n\
+EmptyModule.\u{0275}mod = \u{0275}\u{0275}defineNgModule({ type: EmptyModule });\n\
+export { EmptyModule };";
+        modules.insert(
+            PathBuf::from("/project/src/empty.module.js"),
+            source.to_string(),
+        );
+
+        let registry = ModuleRegistry::new();
+        let count = scan_define_ng_modules(&modules, &registry).unwrap();
+        assert_eq!(count, 1);
+        assert!(registry.is_module("EmptyModule"));
+        assert!(registry.flatten("EmptyModule").is_empty());
     }
 }

--- a/crates/linker/src/ng_module.rs
+++ b/crates/linker/src/ng_module.rs
@@ -12,9 +12,18 @@ use ngc_diagnostics::NgcResult;
 use oxc_ast::ast::ObjectExpression;
 
 use crate::metadata;
+use crate::module_registry::{parse_identifier_array, ModuleRegistry};
 
 /// Transform a `ɵɵngDeclareNgModule` call into a `ɵɵdefineNgModule` call.
-pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> NgcResult<String> {
+///
+/// As a side effect, records the module's `type` name and its direct `exports`
+/// list in `registry`. Transitive flattening happens later at lookup time.
+pub fn transform(
+    obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+    registry: &ModuleRegistry,
+) -> NgcResult<String> {
     let define_fn = if ng_import.is_empty() {
         "\u{0275}\u{0275}defineNgModule".to_string()
     } else {
@@ -26,10 +35,21 @@ pub fn transform(obj: &ObjectExpression<'_>, source: &str, ng_import: &str) -> N
     let mut props = Vec::new();
     props.push(format!("type: {type_text}"));
 
+    let mut exports_src: Option<&str> = None;
     for key in &["declarations", "imports", "exports", "bootstrap", "schemas"] {
         if let Some(value) = metadata::get_source_text(obj, key, source) {
             props.push(format!("{key}: {value}"));
+            if *key == "exports" {
+                exports_src = Some(value);
+            }
         }
+    }
+
+    if let Some(type_name) = metadata::get_identifier_prop(obj, "type") {
+        let exports = exports_src
+            .and_then(parse_identifier_array)
+            .unwrap_or_default();
+        registry.register(&type_name, exports);
     }
 
     Ok(format!("{define_fn}({{ {} }})", props.join(", ")))
@@ -43,15 +63,17 @@ mod tests {
     use oxc_parser::Parser;
     use oxc_span::SourceType;
 
-    fn parse_and_transform(input: &str) -> String {
+    fn parse_and_transform(input: &str) -> (String, ModuleRegistry) {
         let alloc = Allocator::default();
         let code = format!("var x = {input};");
         let parsed = Parser::new(&alloc, &code, SourceType::mjs()).parse();
         let program = parsed.program;
+        let registry = ModuleRegistry::new();
 
         if let oxc_ast::ast::Statement::VariableDeclaration(decl) = &program.body[0] {
             if let Some(Expression::ObjectExpression(obj)) = &decl.declarations[0].init {
-                return transform(obj, &code, "i0").unwrap();
+                let out = transform(obj, &code, "i0", &registry).unwrap();
+                return (out, registry);
             }
         }
         panic!("failed to parse");
@@ -59,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_ng_module_basic() {
-        let result = parse_and_transform(
+        let (result, _) = parse_and_transform(
             "{ type: AppModule, declarations: [CompA], imports: [ModB], exports: [CompA] }",
         );
         assert!(result.contains("i0.\u{0275}\u{0275}defineNgModule"));
@@ -67,5 +89,24 @@ mod tests {
         assert!(result.contains("declarations: [CompA]"));
         assert!(result.contains("imports: [ModB]"));
         assert!(result.contains("exports: [CompA]"));
+    }
+
+    #[test]
+    fn test_ng_module_registers_exports() {
+        let (_, registry) = parse_and_transform(
+            "{ type: ReactiveFormsModule, exports: [InternalShared, FormGroupDirective, FormControlName] }",
+        );
+        assert!(registry.is_module("ReactiveFormsModule"));
+        assert_eq!(
+            registry.flatten("ReactiveFormsModule"),
+            vec!["InternalShared", "FormGroupDirective", "FormControlName"]
+        );
+    }
+
+    #[test]
+    fn test_ng_module_registers_even_without_exports() {
+        let (_, registry) = parse_and_transform("{ type: EmptyModule }");
+        assert!(registry.is_module("EmptyModule"));
+        assert!(registry.flatten("EmptyModule").is_empty());
     }
 }

--- a/crates/linker/src/public_exports.rs
+++ b/crates/linker/src/public_exports.rs
@@ -1,0 +1,350 @@
+//! Map of publicly-exported npm identifier → best import specifier.
+//!
+//! ## Why this exists
+//!
+//! The flatten pass (see `flatten.rs`) expands `imports: [SomeModule]` in a
+//! project component to its transitive list of exported directives/pipes, and
+//! needs to ensure those identifiers are actually importable in the project
+//! file. The naive approach — "append to the existing import from the same
+//! npm package" — breaks for two well-known cases:
+//!
+//! 1. An NgModule's `ɵmod.exports` list may reference a sibling NgModule whose
+//!    members live in a *different* npm subpath. Example:
+//!    `DialogModule` from `@angular/cdk/dialog` re-exports `PortalModule`,
+//!    whose members `CdkPortal` / `CdkPortalOutlet` are published under
+//!    `@angular/cdk/portal`, *not* `@angular/cdk/dialog`.
+//!    In `dialog.mjs` they are exported only under aliases (`ɵɵCdkPortal`),
+//!    so `import { CdkPortal } from '@angular/cdk/dialog'` binds to
+//!    `undefined` — triggering `NG0919` at runtime.
+//! 2. An NgModule's `ɵmod.exports` may reference an internal class that isn't
+//!    publicly exported from any npm package (e.g. `_EmptyOutletComponent`
+//!    from `@angular/router`). Those must not be added to any project file
+//!    import at all.
+//!
+//! Both cases are handled by consulting this map: for each identifier we want
+//! to add, find the *actual* npm package that publicly exports it, and add
+//! the import against that package. Identifiers with no public export are
+//! dropped from the flattened dependency list.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::RwLock;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{ExportSpecifier, ModuleExportName, Statement};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+/// Public-exports registry. Populated during npm linking from every
+/// `node_modules/…` file's top-level `export { … }` statements.
+#[derive(Debug, Default)]
+pub struct PublicExports {
+    /// Exported local name → preferred npm specifier.
+    ///
+    /// Preferred = first seen with a *canonical* specifier (see
+    /// [`derive_specifier`]). Internal chunk files like
+    /// `_router_module-chunk.mjs` are ignored.
+    name_to_specifier: RwLock<HashMap<String, String>>,
+}
+
+impl PublicExports {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Is this identifier publicly exported from any tracked npm file?
+    pub fn has(&self, name: &str) -> bool {
+        match self.name_to_specifier.read() {
+            Ok(g) => g.contains_key(name),
+            Err(p) => p.into_inner().contains_key(name),
+        }
+    }
+
+    /// Npm specifier that publicly exports `name`, or `None` if unknown.
+    pub fn specifier_for(&self, name: &str) -> Option<String> {
+        match self.name_to_specifier.read() {
+            Ok(g) => g.get(name).cloned(),
+            Err(p) => p.into_inner().get(name).cloned(),
+        }
+    }
+
+    /// Scan a single npm file's source for its top-level `export { … }` and
+    /// `export … from '…'` statements, and record each exported local name
+    /// with a specifier derived from `path`.
+    ///
+    /// Returns the number of names newly recorded (ignoring duplicates).
+    pub fn scan_file(&self, source: &str, path: &Path) -> usize {
+        let Some(specifier) = derive_specifier(path) else {
+            return 0;
+        };
+        // Cheap substring check before parsing.
+        if !source.contains("export") {
+            return 0;
+        }
+        let alloc = Allocator::default();
+        let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
+        if !parsed.errors.is_empty() {
+            return 0;
+        }
+        let mut exported = Vec::new();
+        for stmt in &parsed.program.body {
+            if let Statement::ExportNamedDeclaration(export) = stmt {
+                for spec in &export.specifiers {
+                    if let Some(name) = exported_name(spec) {
+                        exported.push(name);
+                    }
+                }
+            }
+        }
+        let mut added = 0;
+        if !exported.is_empty() {
+            let mut map = match self.name_to_specifier.write() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            for name in exported {
+                map.entry(name).or_insert_with(|| {
+                    added += 1;
+                    specifier.clone()
+                });
+            }
+        }
+        added
+    }
+
+    /// Number of registered identifiers.
+    pub fn len(&self) -> usize {
+        match self.name_to_specifier.read() {
+            Ok(g) => g.len(),
+            Err(p) => p.into_inner().len(),
+        }
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Return the exported *local* name of an export specifier.
+///
+/// For `export { Inner as Outer } from './x'` we want `Outer` (what downstream
+/// consumers import). For `export { Foo }` we want `Foo`. Returns `None` for
+/// non-identifier exports (string exports).
+fn exported_name(spec: &ExportSpecifier<'_>) -> Option<String> {
+    match &spec.exported {
+        ModuleExportName::IdentifierName(id) => Some(id.name.to_string()),
+        ModuleExportName::IdentifierReference(id) => Some(id.name.to_string()),
+        ModuleExportName::StringLiteral(_) => None,
+    }
+}
+
+/// Derive the best-guess npm import specifier from an npm file path.
+///
+/// Conventions handled:
+/// - `node_modules/@scope/pkg/fesm2022/pkg.mjs` → `@scope/pkg`
+/// - `node_modules/@scope/pkg/fesm2022/subpath.mjs` → `@scope/pkg/subpath`
+///   (e.g. `@angular/cdk/portal`)
+/// - `node_modules/pkg/fesm2022/pkg.mjs` → `pkg`
+/// - `node_modules/@scope/pkg/fesm2022/pkg-scope-pkg.mjs` (e.g.
+///   `@ngx-translate/core/fesm2022/ngx-translate-core.mjs`) → `@scope/pkg`
+///   when the filename stem equals the dashed form of the full package name.
+///
+/// Skipped (returns `None`):
+/// - Files whose stem starts with `_` (internal chunks, not publicly
+///   consumable via any import path).
+/// - Anything outside `node_modules/`.
+pub fn derive_specifier(path: &Path) -> Option<String> {
+    let s = path.to_string_lossy();
+    let idx = s.find("/node_modules/")?;
+    let rest = &s[idx + "/node_modules/".len()..];
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.is_empty() {
+        return None;
+    }
+    let (pkg, after) = if parts[0].starts_with('@') {
+        if parts.len() < 2 {
+            return None;
+        }
+        (format!("{}/{}", parts[0], parts[1]), &parts[2..])
+    } else {
+        (parts[0].to_string(), &parts[1..])
+    };
+
+    // Drop fesm2022 / fesm2020 / esm2022 wrapper directories — they're layout
+    // folders inside the package, not part of the public specifier.
+    let after: Vec<&str> = after
+        .iter()
+        .copied()
+        .filter(|p| !matches!(*p, "fesm2022" | "fesm2020" | "esm2022" | "esm2020"))
+        .collect();
+
+    if after.is_empty() {
+        return Some(pkg);
+    }
+    let file = *after.last()?;
+    let stem = file.strip_suffix(".mjs").unwrap_or(file);
+    if stem.starts_with('_') || stem.contains("-chunk") {
+        return None;
+    }
+
+    // Does the stem correspond to the package as a whole?
+    let pkg_simple = pkg.split('/').next_back().unwrap_or(&pkg);
+    // Dashed form: `@scope/pkg` → `scope-pkg`, `pkg` → `pkg`.
+    let pkg_dashed = pkg.trim_start_matches('@').replace('/', "-");
+    if stem == pkg_simple || stem == pkg_dashed {
+        return Some(pkg);
+    }
+    // Otherwise treat as subpath: `@angular/cdk/portal` etc.
+    Some(format!("{}/{}", pkg, stem))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn derive_specifier_package_main() {
+        assert_eq!(
+            derive_specifier(&PathBuf::from(
+                "/project/node_modules/@angular/forms/fesm2022/forms.mjs"
+            )),
+            Some("@angular/forms".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_specifier_subpath() {
+        assert_eq!(
+            derive_specifier(&PathBuf::from(
+                "/project/node_modules/@angular/cdk/fesm2022/portal.mjs"
+            )),
+            Some("@angular/cdk/portal".to_string())
+        );
+        assert_eq!(
+            derive_specifier(&PathBuf::from(
+                "/project/node_modules/@angular/cdk/fesm2022/dialog.mjs"
+            )),
+            Some("@angular/cdk/dialog".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_specifier_dashed_main_form() {
+        assert_eq!(
+            derive_specifier(&PathBuf::from(
+                "/project/node_modules/@ngx-translate/core/fesm2022/ngx-translate-core.mjs"
+            )),
+            Some("@ngx-translate/core".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_specifier_skips_internal_chunks() {
+        assert!(derive_specifier(&PathBuf::from(
+            "/project/node_modules/@angular/cdk/fesm2022/_overlay-module-chunk.mjs"
+        ))
+        .is_none());
+        assert!(derive_specifier(&PathBuf::from(
+            "/project/node_modules/@angular/router/fesm2022/_router_module-chunk.mjs"
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn derive_specifier_ignores_outside_node_modules() {
+        assert!(derive_specifier(&PathBuf::from("/project/src/app/foo.ts")).is_none());
+    }
+
+    #[test]
+    fn derive_specifier_handles_unscoped_pkg() {
+        assert_eq!(
+            derive_specifier(&PathBuf::from(
+                "/project/node_modules/lodash/fesm2022/lodash.mjs"
+            )),
+            Some("lodash".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_file_records_plain_export() {
+        let reg = PublicExports::new();
+        let src = "class A {}\nclass B {}\nexport { A, B };";
+        let added = reg.scan_file(
+            src,
+            Path::new("/proj/node_modules/@angular/forms/fesm2022/forms.mjs"),
+        );
+        assert_eq!(added, 2);
+        assert_eq!(reg.specifier_for("A"), Some("@angular/forms".into()));
+        assert_eq!(reg.specifier_for("B"), Some("@angular/forms".into()));
+    }
+
+    #[test]
+    fn scan_file_uses_exported_alias_not_local() {
+        let reg = PublicExports::new();
+        // Mirrors @angular/cdk/dialog: exports CdkPortal under the name ɵɵCdkPortal.
+        // The public name is what downstream code imports, so we record
+        // `ɵɵCdkPortal`, NOT `CdkPortal`.
+        let src = "class CdkPortal {}\nexport { CdkPortal as \u{0275}\u{0275}CdkPortal };";
+        reg.scan_file(
+            src,
+            Path::new("/proj/node_modules/@angular/cdk/fesm2022/dialog.mjs"),
+        );
+        assert_eq!(
+            reg.specifier_for("\u{0275}\u{0275}CdkPortal"),
+            Some("@angular/cdk/dialog".into())
+        );
+        // Plain `CdkPortal` is not publicly exported from dialog.
+        assert!(reg.specifier_for("CdkPortal").is_none());
+    }
+
+    #[test]
+    fn scan_file_records_reexport_from_subpath() {
+        let reg = PublicExports::new();
+        // Real portal.mjs declares CdkPortal and exports it by name.
+        let src = "class CdkPortal {}\nexport { CdkPortal };";
+        reg.scan_file(
+            src,
+            Path::new("/proj/node_modules/@angular/cdk/fesm2022/portal.mjs"),
+        );
+        assert_eq!(
+            reg.specifier_for("CdkPortal"),
+            Some("@angular/cdk/portal".into())
+        );
+    }
+
+    #[test]
+    fn scan_file_first_seen_wins() {
+        let reg = PublicExports::new();
+        reg.scan_file(
+            "class X {}\nexport { X };",
+            Path::new("/proj/node_modules/@a/first/fesm2022/first.mjs"),
+        );
+        reg.scan_file(
+            "class X {}\nexport { X };",
+            Path::new("/proj/node_modules/@a/second/fesm2022/second.mjs"),
+        );
+        assert_eq!(reg.specifier_for("X"), Some("@a/first".into()));
+    }
+
+    #[test]
+    fn scan_file_skips_internal_chunk_file() {
+        let reg = PublicExports::new();
+        reg.scan_file(
+            "class Internal {}\nexport { Internal };",
+            Path::new("/proj/node_modules/@angular/router/fesm2022/_router_module-chunk.mjs"),
+        );
+        assert!(reg.specifier_for("Internal").is_none());
+    }
+
+    #[test]
+    fn scan_file_ignores_string_exports() {
+        // Weird but legal: `export { "default" } from './x'` — we skip.
+        let reg = PublicExports::new();
+        let src = "export { foo } from './other';";
+        reg.scan_file(src, Path::new("/proj/node_modules/pkg/fesm2022/pkg.mjs"));
+        assert_eq!(reg.specifier_for("foo"), Some("pkg".into()));
+    }
+}

--- a/crates/linker/src/transform.rs
+++ b/crates/linker/src/transform.rs
@@ -12,6 +12,7 @@ use oxc_ast::ast::{CallExpression, Expression, Program, Statement};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 
+use crate::module_registry::ModuleRegistry;
 use crate::{class_metadata, component, directive, factory, injectable, injector, ng_module, pipe};
 
 /// A single text replacement to apply to the source.
@@ -90,7 +91,13 @@ fn get_ng_import_alias(call: &CallExpression<'_>) -> Option<String> {
 /// Transform a single npm module source by linking all `ɵɵngDeclare*` calls.
 ///
 /// Returns the transformed source, or `None` if no declarations were found.
-pub fn link_source(source: &str, file_path: &Path) -> NgcResult<Option<String>> {
+/// Any `ɵɵngDeclareNgModule` calls encountered are also registered in
+/// `registry` so the post-link flatten pass can expand them.
+pub fn link_source(
+    source: &str,
+    file_path: &Path,
+    registry: &ModuleRegistry,
+) -> NgcResult<Option<String>> {
     let alloc = Allocator::default();
     let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
 
@@ -102,7 +109,13 @@ pub fn link_source(source: &str, file_path: &Path) -> NgcResult<Option<String>> 
     }
 
     let mut replacements = Vec::new();
-    collect_replacements(&parsed.program, source, file_path, &mut replacements)?;
+    collect_replacements(
+        &parsed.program,
+        source,
+        file_path,
+        registry,
+        &mut replacements,
+    )?;
 
     if replacements.is_empty() {
         return Ok(None);
@@ -124,10 +137,11 @@ fn collect_replacements(
     program: &Program<'_>,
     source: &str,
     file_path: &Path,
+    registry: &ModuleRegistry,
     replacements: &mut Vec<Replacement>,
 ) -> NgcResult<()> {
     for stmt in &program.body {
-        visit_statement(stmt, source, file_path, replacements)?;
+        visit_statement(stmt, source, file_path, registry, replacements)?;
     }
     Ok(())
 }
@@ -137,16 +151,23 @@ fn visit_statement(
     stmt: &Statement<'_>,
     source: &str,
     file_path: &Path,
+    registry: &ModuleRegistry,
     replacements: &mut Vec<Replacement>,
 ) -> NgcResult<()> {
     match stmt {
         Statement::ExpressionStatement(expr_stmt) => {
-            visit_expression(&expr_stmt.expression, source, file_path, replacements)?;
+            visit_expression(
+                &expr_stmt.expression,
+                source,
+                file_path,
+                registry,
+                replacements,
+            )?;
         }
         Statement::VariableDeclaration(decl) => {
             for declarator in &decl.declarations {
                 if let Some(init) = &declarator.init {
-                    visit_expression(init, source, file_path, replacements)?;
+                    visit_expression(init, source, file_path, registry, replacements)?;
                 }
             }
         }
@@ -156,12 +177,12 @@ fn visit_statement(
                     oxc_ast::ast::Declaration::VariableDeclaration(var_decl) => {
                         for declarator in &var_decl.declarations {
                             if let Some(init) = &declarator.init {
-                                visit_expression(init, source, file_path, replacements)?;
+                                visit_expression(init, source, file_path, registry, replacements)?;
                             }
                         }
                     }
                     oxc_ast::ast::Declaration::ClassDeclaration(class) => {
-                        visit_class_body(class, source, file_path, replacements)?;
+                        visit_class_body(class, source, file_path, registry, replacements)?;
                     }
                     _ => {}
                 }
@@ -171,11 +192,11 @@ fn visit_statement(
             if let oxc_ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(class) =
                 &export.declaration
             {
-                visit_class_body(class, source, file_path, replacements)?;
+                visit_class_body(class, source, file_path, registry, replacements)?;
             }
         }
         Statement::ClassDeclaration(class) => {
-            visit_class_body(class, source, file_path, replacements)?;
+            visit_class_body(class, source, file_path, registry, replacements)?;
         }
         _ => {}
     }
@@ -188,19 +209,20 @@ fn visit_class_body(
     class: &oxc_ast::ast::Class<'_>,
     source: &str,
     file_path: &Path,
+    registry: &ModuleRegistry,
     replacements: &mut Vec<Replacement>,
 ) -> NgcResult<()> {
     for element in &class.body.body {
         match element {
             oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
                 if let Some(ref init) = prop.value {
-                    visit_expression(init, source, file_path, replacements)?;
+                    visit_expression(init, source, file_path, registry, replacements)?;
                 }
             }
             oxc_ast::ast::ClassElement::StaticBlock(block) => {
                 // static { this.ɵfac = i0.ɵɵngDeclareFactory({...}); }
                 for stmt in &block.body {
-                    visit_statement(stmt, source, file_path, replacements)?;
+                    visit_statement(stmt, source, file_path, registry, replacements)?;
                 }
             }
             _ => {}
@@ -214,24 +236,27 @@ fn visit_expression(
     expr: &Expression<'_>,
     source: &str,
     file_path: &Path,
+    registry: &ModuleRegistry,
     replacements: &mut Vec<Replacement>,
 ) -> NgcResult<()> {
     match expr {
         Expression::CallExpression(call) => {
-            if let Some(replacement) = try_transform_declare_call(call, source, file_path)? {
+            if let Some(replacement) =
+                try_transform_declare_call(call, source, file_path, registry)?
+            {
                 replacements.push(replacement);
             }
         }
         Expression::AssignmentExpression(assign) => {
-            visit_expression(&assign.right, source, file_path, replacements)?;
+            visit_expression(&assign.right, source, file_path, registry, replacements)?;
         }
         Expression::SequenceExpression(seq) => {
             for expr in &seq.expressions {
-                visit_expression(expr, source, file_path, replacements)?;
+                visit_expression(expr, source, file_path, registry, replacements)?;
             }
         }
         Expression::ClassExpression(class) => {
-            visit_class_body(class, source, file_path, replacements)?;
+            visit_class_body(class, source, file_path, registry, replacements)?;
         }
         _ => {}
     }
@@ -245,6 +270,7 @@ fn try_transform_declare_call(
     call: &CallExpression<'_>,
     source: &str,
     file_path: &Path,
+    registry: &ModuleRegistry,
 ) -> NgcResult<Option<Replacement>> {
     let callee_name = match get_callee_name(call) {
         Some(name) => name,
@@ -281,7 +307,7 @@ fn try_transform_declare_call(
         DeclareKind::Factory => factory::transform(obj, source, &ng_import)?,
         DeclareKind::Injectable => injectable::transform(obj, source, &ng_import)?,
         DeclareKind::Injector => injector::transform(obj, source, &ng_import)?,
-        DeclareKind::NgModule => ng_module::transform(obj, source, &ng_import)?,
+        DeclareKind::NgModule => ng_module::transform(obj, source, &ng_import, registry)?,
         DeclareKind::Pipe => pipe::transform(obj, source, &ng_import)?,
         DeclareKind::Directive => directive::transform(obj, source, &ng_import, file_path)?,
         DeclareKind::Component => component::transform(obj, source, &ng_import, file_path)?,
@@ -321,7 +347,8 @@ mod tests {
     #[test]
     fn test_no_declarations_returns_none() {
         let source = "export class Foo { bar() {} }";
-        let result = link_source(source, &PathBuf::from("test.mjs")).unwrap();
+        let registry = ModuleRegistry::new();
+        let result = link_source(source, &PathBuf::from("test.mjs"), &registry).unwrap();
         assert!(result.is_none());
     }
 }

--- a/crates/linker/tests/flatten_integration.rs
+++ b/crates/linker/tests/flatten_integration.rs
@@ -1,0 +1,95 @@
+//! End-to-end integration for `link_modules`.
+//!
+//! Exercises the full three-pass pipeline (npm link → register → flatten) on
+//! a synthetic module graph that mimics the shape ngc-rs produces when
+//! building a standalone Angular app that imports `ReactiveFormsModule`.
+//! Verifies that the component's `dependencies` array ends up as a flat list
+//! of directive class names — no factory wrappers, no module identifiers.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use ngc_linker::link_modules;
+
+const FORMS_MJS: &str = "import * as i0 from '@angular/core';\n\
+\n\
+class FormGroupDirective {}\n\
+class FormControlName {}\n\
+class NgControlStatus {}\n\
+class InternalFormsSharedModule {}\n\
+class ReactiveFormsModule {}\n\
+\n\
+InternalFormsSharedModule.\u{0275}mod = i0.\u{0275}\u{0275}ngDeclareNgModule({ minVersion: \"14.0.0\", version: \"17.0.0\", ngImport: i0, type: InternalFormsSharedModule, exports: [NgControlStatus] });\n\
+ReactiveFormsModule.\u{0275}mod = i0.\u{0275}\u{0275}ngDeclareNgModule({ minVersion: \"14.0.0\", version: \"17.0.0\", ngImport: i0, type: ReactiveFormsModule, exports: [InternalFormsSharedModule, FormGroupDirective, FormControlName] });\n\
+\n\
+export { ReactiveFormsModule, FormGroupDirective, FormControlName, NgControlStatus };";
+
+const PROJECT_COMPONENT: &str = "import { ReactiveFormsModule } from '@angular/forms';\n\
+import { MyStandaloneDir } from './my-dir';\n\
+\n\
+class DialogComponent {}\n\
+DialogComponent.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: DialogComponent, selectors: [[\"app-dialog\"]], standalone: true, dependencies: [ReactiveFormsModule, MyStandaloneDir], template: function DialogComponent_Template() {} });\n\
+\n\
+export { DialogComponent };";
+
+#[test]
+fn link_modules_flattens_reactive_forms_module_imports() {
+    let mut modules = HashMap::new();
+    modules.insert(
+        PathBuf::from("/project/node_modules/@angular/forms/fesm2022/forms.mjs"),
+        FORMS_MJS.to_string(),
+    );
+    modules.insert(
+        PathBuf::from("/project/src/app/dialog.component.ts"),
+        PROJECT_COMPONENT.to_string(),
+    );
+
+    let stats = link_modules(&mut modules, Path::new("/project")).expect("link_modules");
+
+    // The forms.mjs file had ɵɵngDeclare* calls and should have been rewritten.
+    assert_eq!(stats.files_scanned, 1);
+    assert_eq!(stats.files_linked, 1);
+    // Pass A re-scans the now-linked forms module and the raw project component.
+    assert!(stats.modules_registered >= 2, "{stats:?}");
+    assert_eq!(stats.components_flattened, 1);
+
+    // The component's dependencies array is now a flat directive list with
+    // ReactiveFormsModule expanded transitively (InternalFormsSharedModule →
+    // NgControlStatus, plus ReactiveFormsModule's own three directives).
+    let dialog = modules
+        .get(Path::new("/project/src/app/dialog.component.ts"))
+        .expect("dialog present");
+    assert!(
+        dialog.contains(
+            "dependencies: [NgControlStatus, FormGroupDirective, FormControlName, MyStandaloneDir]"
+        ),
+        "unexpected dependencies array: {dialog}"
+    );
+    // The factory wrapper must not appear anywhere.
+    assert!(
+        !dialog.contains("getComponentDepsFactory"),
+        "factory wrapper leaked: {dialog}"
+    );
+    // The npm forms module must have been rewritten to ɵɵdefineNgModule.
+    let forms = modules
+        .get(Path::new(
+            "/project/node_modules/@angular/forms/fesm2022/forms.mjs",
+        ))
+        .expect("forms present");
+    assert!(!forms.contains("\u{0275}\u{0275}ngDeclare"));
+    assert!(forms.contains("\u{0275}\u{0275}defineNgModule"));
+}
+
+#[test]
+fn link_modules_noop_when_no_modules_or_components() {
+    let mut modules = HashMap::new();
+    modules.insert(
+        PathBuf::from("/project/src/plain.ts"),
+        "export function add(a, b) { return a + b; }".to_string(),
+    );
+
+    let stats = link_modules(&mut modules, Path::new("/project")).expect("link_modules");
+    assert_eq!(stats.files_linked, 0);
+    assert_eq!(stats.modules_registered, 0);
+    assert_eq!(stats.components_flattened, 0);
+}

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -157,19 +157,12 @@ pub fn generate_ivy(
     dc.push_str(&template_body);
     dc.push_str("    }");
 
-    // Resolve component dependencies. Angular's AOT compiler resolves NgModule
-    // imports to individual directive/pipe classes at build time.  ngc-rs sets
-    // the component's rawImports so Angular's standalone resolution pipeline
-    // handles NgModule expansion at runtime, then provides the raw imports as
-    // dependencies for directive/pipe matching.
+    // Component dependencies. Emit the imports array verbatim here; the linker's
+    // post-pass (crates/linker/src/module_registry.rs) walks every
+    // ɵɵdefineComponent and flattens any NgModule identifiers in this array to
+    // their transitively-exported directive/pipe classes — mirroring ng build.
     if let Some(ref imports_src) = component.imports_source {
-        // Set rawImports on the component class for Angular's depsTracker
-        dc.push_str(&format!(
-            ",\n    dependencies: \u{0275}\u{0275}getComponentDepsFactory({}, {imports_src})",
-            component.class_name
-        ));
-        gen.ivy_imports
-            .insert("\u{0275}\u{0275}getComponentDepsFactory".to_string());
+        dc.push_str(&format!(",\n    dependencies: {imports_src}"));
     }
     if let Some(ref styles_src) = component.styles_source {
         // Pre-scope CSS with %COMP% placeholders for Angular's emulated ViewEncapsulation.


### PR DESCRIPTION
Closes #19

## Summary

- Replaces Angular's runtime `ɵɵgetComponentDepsFactory` helper with build-time NgModule flattening that mirrors what `ng build` does. Root-cause fix for #19 (`NG01050 — formControlName must be used with a parent formGroup`) in reactive-forms dialogs.
- Along the way, fixes three long-standing gaps in the npm linker surfaced by the same test project:
  - directive `providers` are now wired via `ɵɵProvidersFeature` (was previously dead-weight — `NG0201: No provider for NgControl`).
  - `ɵɵngDeclareDirective` inputs in 2-element array form are upgraded to the 3-element runtime format `[flags, publicName, declaredName]` (silent input-binding failure otherwise — `[formGroup]` never reached `FormGroupDirective.form`).
  - `ɵɵngDeclareFactory` with `deps: null` emits the inherited-factory chain via `ɵɵgetInheritedFactory` (previously produced a no-args factory, breaking any subclass that expected parent-injected dependencies — e.g. `SelectControlValueAccessor` → `BaseControlValueAccessor`).

## Design (flatten pipeline)

1. **Module registry** (`crates/linker/src/module_registry.rs`) — lazy, cycle-safe transitive flattening of every `ɵɵdefineNgModule`/`ɵɵngDeclareNgModule` encountered.
2. **Public-exports map** (`crates/linker/src/public_exports.rs`) — scans every npm file's top-level `export { … }` list to know the *actual* import specifier for each identifier. Needed because an NgModule's `ɵmod.exports` list can contain classes that live in a different subpath (`@angular/cdk/dialog` re-exports `PortalModule`, whose members live in `@angular/cdk/portal`) or aren't publicly exported at all (e.g. `_EmptyOutletComponent` in `@angular/router`).
3. **Flatten pass** (`crates/linker/src/flatten.rs`) — per project file, walks every `ɵɵdefineComponent`'s `dependencies: [...]` array, expands each NgModule identifier to its transitive directive/pipe leaves, dedups across siblings, drops underscore-prefixed private names, and either extends the existing import from the correct package or injects a new `import { … } from '…'` statement at the top of the file.
4. **CLI post-link resolution** (`crates/cli/src/main.rs`) — re-scans project files (not npm files) for bare specifiers introduced by step 3 and runs npm resolution + linking again for the delta.
5. **Template compiler** emits plain `dependencies: [ReactiveFormsModule, …]` arrays instead of the factory wrapper. `ɵɵgetComponentDepsFactory` is no longer imported in project files.

## Test plan

- [x] `cargo test --workspace` — all 93 linker unit tests + 2 integration tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] End-to-end verification against `treasr-frontend` (Angular 21, standalone, zoneless, reactive forms in dialogs). Previously a click on a portfolio table row triggered `NG01050` and no form field rendered; now the ETF / Holding dialogs render fully and form controls work.
- [x] Filename hash check — `ɵɵgetComponentDepsFactory` call sites removed from emitted project code (only remaining references are the runtime's own definition inside `@angular/core`, which is unused).
- [ ] Reviewer: re-run full `treasr-frontend` walk-through and diff a baseline `ng build` against `ngc-rs build` for a reactive-forms component.