### PR TITLE
fix(linker): emit ɵɵattribute for [attr.X] host bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "criterion",
  "glob",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "clap",
  "colored",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -874,6 +874,34 @@ mod tests {
     }
 
     #[test]
+    fn test_host_binding_attr() {
+        let result = parse_and_transform(
+            "{ type: RouterLink, selector: 'a[routerLink]', host: { properties: { 'attr.href': 'href' } } }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}attribute(\"href\", ctx.href)"),
+            "expected ɵɵattribute call for attr.href, got: {result}"
+        );
+        assert!(!result.contains("\u{0275}\u{0275}property(\"attr.href\""));
+        assert!(result.contains("hostVars: 1"));
+    }
+
+    #[test]
+    fn test_host_binding_attr_mixed() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', host: { properties: { 'attr.href': 'href', 'class.active': 'isActive', 'disabled': 'isDisabled' } } }",
+        );
+        assert!(result.contains("i0.\u{0275}\u{0275}attribute(\"href\", ctx.href)"));
+        assert!(result.contains("i0.\u{0275}\u{0275}classProp(\"active\", ctx.isActive)"));
+        assert!(result.contains("i0.\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"));
+        // attr (1) + class (2) + property (1) = 4
+        assert!(
+            result.contains("hostVars: 4"),
+            "expected hostVars: 4, got: {result}"
+        );
+    }
+
+    #[test]
     fn test_compile_host_expression_simple() {
         assert_eq!(compile_host_expression("checked"), "ctx.checked");
     }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -340,6 +340,18 @@ pub fn build_host_bindings(
                         };
                         binding_stmts.push(format!("{fn_name}({expr})"));
                         host_vars += 2;
+                    } else if let Some(attr_name) = key.strip_prefix("attr.") {
+                        // attr.X → ɵɵattribute (1 var). Without this branch,
+                        // RouterLink's `[attr.href]` falls through to
+                        // ɵɵproperty, which sets a JS property named
+                        // "attr.href" instead of the HTML attribute.
+                        let fn_name = if ng_import.is_empty() {
+                            "\u{0275}\u{0275}attribute".to_string()
+                        } else {
+                            format!("{ng_import}.\u{0275}\u{0275}attribute")
+                        };
+                        binding_stmts.push(format!("{fn_name}(\"{attr_name}\", {expr})"));
+                        host_vars += 1;
                     } else {
                         // Regular property → ɵɵproperty (1 var)
                         let fn_name = if ng_import.is_empty() {


### PR DESCRIPTION
## Summary
- The linker's `build_host_bindings()` had no branch for the `attr.` prefix, so declarations like `host: { properties: { 'attr.href': 'reactiveHref()' } }` (used by `@angular/router`'s `RouterLink`) fell through to `ɵɵproperty("attr.href", …)`. At runtime Angular then sets a JS property literally named `"attr.href"` on the element — the DOM `href` attribute is never written, so `<a routerLink>` renders without `href` and the browser omits the default pointer cursor on hover.
- Adds an `attr.X` branch that emits `ɵɵattribute("X", ctx.expr)` with `hostVars += 1`, mirroring the existing template-compiler path at `crates/template-compiler/src/codegen.rs:1538`.
- Adds two linker unit tests covering a single `attr.href` host binding and a mixed case (`attr.href` + `class.active` + plain property) with correct `hostVars` accounting.

## Why only the footer surfaced the bug
- `<a routerLink>` in the sidenav carries explicit `cursor: pointer` (either via `.sidebar-nav-item` CSS or Tailwind `cursor-pointer`), so missing `href` was masked.
- The header uses `<button>` elements, not `<a routerLink>`.
- The footer (and cookie-consent "Learn more") use plain `<a [routerLink]>` with no explicit cursor styling and relied on the browser's `<a[href]>:hover` default — which never applied because `href` wasn't set.

## Before / after in treasr-frontend
- Before (deployed container bundle): `ɵɵproperty("attr.href", ctx.reactiveHref())`
- After (rebuilt with this branch): `` ɵɵattribute(`href`, ctx.reactiveHref()) ``

Closes #22

## Test plan
- [x] `cargo test --workspace` — green (including two new tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Rebuilt treasr-frontend with patched `ngc-rs`; confirmed `ɵɵattribute("href", …)` + `ɵɵattribute("target", …)` now emitted for `RouterLink`
- [x] Load the rebuilt dist in a browser; footer `<a>` shows `href` in DevTools and pointer cursor on hover