### PR TITLE
fix: tree shaking + dynamic import rewrite conflict (v0.7.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "criterion",
  "glob",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "clap",
  "colored",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "petgraph",
  "regex",
  "sha2",
+ "tempfile",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/Cargo.toml
+++ b/crates/bundler/Cargo.toml
@@ -27,3 +27,4 @@ tracing = "0.1"
 ngc-ts-transform = { path = "../ts-transform" }
 ngc-template-compiler = { path = "../template-compiler" }
 insta = { version = "1.46", features = ["glob"] }
+tempfile = "3"

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -93,11 +93,26 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     // Process main chunk first to get specifier→namespace mapping
     let main_chunk = &chunk_graph.chunks[0];
     let main_unused = if input.options.tree_shake {
+        // Lazy chunks consume symbols from main cross-chunk; those consumptions
+        // are invisible to the per-chunk shake analysis below. Precompute them
+        // so the analyzer won't mark them unused and strip their declarations.
+        let mut lazy_consumers: Vec<PathBuf> = Vec::new();
+        for chunk in &chunk_graph.chunks[1..] {
+            lazy_consumers.extend(chunk.modules.iter().cloned());
+        }
+        let externally_used = shake::collect_cross_chunk_used_names(
+            &lazy_consumers,
+            &main_chunk.modules,
+            &input.modules,
+            &prefix_refs,
+        )?;
+
         shake::analyze_unused_exports(
             &main_chunk.modules,
             &input.modules,
             &main_chunk.entry,
             &prefix_refs,
+            Some(&externally_used),
         )?
     } else {
         HashMap::new()
@@ -137,6 +152,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
                 &input.modules,
                 &chunk.entry,
                 &prefix_refs,
+                None,
             )?
         } else {
             HashMap::new()

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -748,4 +748,127 @@ mod tests {
         assert!(result.code.contains("'./chunk-lazy.js'"));
         assert_eq!(result.dynamic_imports.len(), 1);
     }
+
+    #[test]
+    fn test_unused_export_const_with_nested_dynamic_import_fully_removed() {
+        // Issue #13 repro: a tree-shaken export containing a dynamic import
+        // must not produce both a removal edit and a lengthening specifier
+        // rewrite — the removal's `end` offset would point inside the grown
+        // replacement, leaving a stray `export` keyword.
+        let code =
+            "export const routes = [{ loadComponent: () => import('./lazy').then(m => m.C) }];\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
+        let mut unused = HashSet::new();
+        unused.insert("routes".to_string());
+
+        let result = rewrite_module_with_shaking(
+            code,
+            "test.js",
+            &["."],
+            &rewrites,
+            Some(&unused),
+            &HashSet::new(),
+            &HashMap::new(),
+            false,
+        )
+        .expect("should rewrite");
+
+        assert!(
+            result.code.trim().is_empty(),
+            "expected empty output, got: {:?}",
+            result.code
+        );
+        assert!(!result.code.contains("export"));
+        assert!(!result.code.contains("chunk-lazy.js"));
+        assert!(!result.code.contains("./lazy"));
+        assert!(result.dynamic_imports.is_empty());
+    }
+
+    #[test]
+    fn test_used_export_const_with_nested_dynamic_import_is_rewritten() {
+        // Opposite of the prior test: when the export is used, the body is
+        // kept (only `export ` stripped) and the nested dynamic import is
+        // rewritten to its chunk filename.
+        let code =
+            "export const routes = [{ loadComponent: () => import('./lazy').then(m => m.C) }];\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
+        let empty_unused: HashSet<String> = HashSet::new();
+
+        let result = rewrite_module_with_shaking(
+            code,
+            "test.js",
+            &["."],
+            &rewrites,
+            Some(&empty_unused),
+            &HashSet::new(),
+            &HashMap::new(),
+            false,
+        )
+        .expect("should rewrite");
+
+        assert!(result.code.contains("const routes"));
+        assert!(!result.code.contains("export"));
+        assert!(result.code.contains("'./chunk-lazy.js'"));
+        assert!(!result.code.contains("import('./lazy')"));
+        assert_eq!(result.dynamic_imports.len(), 1);
+    }
+
+    #[test]
+    fn test_unused_export_function_with_nested_dynamic_import_fully_removed() {
+        let code = "export function loadIt() { return import('./lazy'); }\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
+        let mut unused = HashSet::new();
+        unused.insert("loadIt".to_string());
+
+        let result = rewrite_module_with_shaking(
+            code,
+            "test.js",
+            &["."],
+            &rewrites,
+            Some(&unused),
+            &HashSet::new(),
+            &HashMap::new(),
+            false,
+        )
+        .expect("should rewrite");
+
+        assert!(
+            result.code.trim().is_empty(),
+            "expected empty output, got: {:?}",
+            result.code
+        );
+        assert!(!result.code.contains("export"));
+        assert!(!result.code.contains("chunk-lazy.js"));
+        assert!(!result.code.contains("./lazy"));
+        assert!(result.dynamic_imports.is_empty());
+    }
+
+    #[test]
+    fn test_used_export_function_with_nested_dynamic_import_is_rewritten() {
+        let code = "export function loadIt() { return import('./lazy'); }\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
+        let empty_unused: HashSet<String> = HashSet::new();
+
+        let result = rewrite_module_with_shaking(
+            code,
+            "test.js",
+            &["."],
+            &rewrites,
+            Some(&empty_unused),
+            &HashSet::new(),
+            &HashMap::new(),
+            false,
+        )
+        .expect("should rewrite");
+
+        assert!(result.code.contains("function loadIt"));
+        assert!(!result.code.contains("export"));
+        assert!(result.code.contains("'./chunk-lazy.js'"));
+        assert!(!result.code.contains("import('./lazy')"));
+        assert_eq!(result.dynamic_imports.len(), 1);
+    }
 }

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -102,8 +102,12 @@ pub fn rewrite_module_with_shaking(
     let mut dynamic_imports: Vec<DynamicImportInfo> = Vec::new();
 
     for stmt in &parsed.program.body {
-        // Walk top-level module declarations (import/export)
-        if let Some(module_decl) = stmt.as_module_declaration() {
+        // Walk top-level module declarations (import/export).
+        // `fully_removed` is true when the statement's span was elided or
+        // entirely replaced, so nested dynamic imports are dead code and
+        // must not be rewritten — their length-changing edits would shift
+        // byte offsets and break the removal edit.
+        let fully_removed = if let Some(module_decl) = stmt.as_module_declaration() {
             collect_module_decl_edits(
                 module_decl,
                 local_prefixes,
@@ -113,16 +117,19 @@ pub fn rewrite_module_with_shaking(
                 bundled_specifiers,
                 namespace_map,
                 preserve_exports,
+            )
+        } else {
+            false
+        };
+
+        if !fully_removed {
+            collect_dynamic_import_edits(
+                stmt,
+                dynamic_import_rewrites,
+                &mut edits,
+                &mut dynamic_imports,
             );
         }
-
-        // Walk all expressions recursively for dynamic import()
-        collect_dynamic_import_edits(
-            stmt,
-            dynamic_import_rewrites,
-            &mut edits,
-            &mut dynamic_imports,
-        );
     }
 
     let code = apply_edits(js_code, &mut edits);
@@ -135,6 +142,13 @@ pub fn rewrite_module_with_shaking(
 }
 
 /// Process a top-level module declaration (import/export) and collect edits.
+///
+/// Returns `true` when the statement's full span was elided from output
+/// (either removed outright or replaced wholesale). The caller uses this
+/// signal to skip nested dynamic-import rewriting for that statement —
+/// nested `import()` calls inside a fully-removed span are dead code, and
+/// their length-changing edits would shift byte offsets and corrupt the
+/// removal edit's `end` position.
 #[allow(clippy::too_many_arguments)]
 fn collect_module_decl_edits(
     module_decl: &ModuleDeclaration,
@@ -145,7 +159,7 @@ fn collect_module_decl_edits(
     bundled_specifiers: &HashSet<String>,
     namespace_map: &HashMap<String, String>,
     preserve_exports: bool,
-) {
+) -> bool {
     match module_decl {
         ModuleDeclaration::ImportDeclaration(import) => {
             let source = import.source.value.as_str();
@@ -233,16 +247,19 @@ fn collect_module_decl_edits(
                     replacement: None,
                 });
             }
+            true
         }
         ModuleDeclaration::ExportNamedDeclaration(export) => {
             if preserve_exports {
                 // Keep exports intact for lazy chunk entry modules
+                false
             } else if export.source.is_some() {
                 edits.push(TextEdit {
                     start: export.span.start,
                     end: export.span.end,
                     replacement: None,
                 });
+                true
             } else if let Some(decl) = &export.declaration {
                 // Check if this export's declaration name is in the unused set
                 let decl_name = get_declaration_name(decl);
@@ -257,34 +274,41 @@ fn collect_module_decl_edits(
                         end: export.span.end,
                         replacement: None,
                     });
+                    true
                 } else {
-                    // Just strip the "export " keyword
+                    // Just strip the "export " keyword; body is preserved
+                    // so nested dynamic imports still need rewriting.
                     edits.push(TextEdit {
                         start: export.span.start,
                         end: export.span.start + 7, // "export "
                         replacement: None,
                     });
+                    false
                 }
-            } else if !preserve_exports {
+            } else {
                 edits.push(TextEdit {
                     start: export.span.start,
                     end: export.span.end,
                     replacement: None,
                 });
+                true
             }
         }
         ModuleDeclaration::ExportDefaultDeclaration(export) => {
             if preserve_exports {
                 // Keep exports intact for lazy chunk entry modules
+                false
             } else {
                 match &export.declaration {
                     ExportDefaultDeclarationKind::FunctionDeclaration(_)
                     | ExportDefaultDeclarationKind::ClassDeclaration(_) => {
+                        // Only strip "export default "; body preserved.
                         edits.push(TextEdit {
                             start: export.span.start,
                             end: export.span.start + 15, // "export default "
                             replacement: None,
                         });
+                        false
                     }
                     _ => {
                         edits.push(TextEdit {
@@ -292,9 +316,10 @@ fn collect_module_decl_edits(
                             end: export.span.end,
                             replacement: None,
                         });
+                        true
                     }
                 }
-            } // close else block for preserve_exports
+            }
         }
         ModuleDeclaration::ExportAllDeclaration(export)
             if is_local(
@@ -308,8 +333,9 @@ fn collect_module_decl_edits(
                 end: export.span.end,
                 replacement: None,
             });
+            true
         }
-        _ => {}
+        _ => false,
     }
 }
 

--- a/crates/bundler/src/shake.rs
+++ b/crates/bundler/src/shake.rs
@@ -34,11 +34,18 @@ struct ModuleInfo {
 /// Modules with no used exports, no side effects, and that are not the entry point
 /// are indicated by having ALL their exports listed as unused — the caller can
 /// choose to drop them entirely.
+///
+/// `externally_used` optionally carries a flat set of names that must be preserved
+/// across every module in the chunk regardless of intra-chunk usage. Callers pass
+/// this for the main chunk to reflect symbols consumed cross-chunk by lazy chunks
+/// — such consumption is invisible to the per-chunk analysis below and would
+/// otherwise leave dangling names in the bundler's final `export { ... }` block.
 pub fn analyze_unused_exports(
     module_paths: &[PathBuf],
     all_code: &HashMap<PathBuf, String>,
     entry: &PathBuf,
     local_prefixes: &[&str],
+    externally_used: Option<&HashSet<String>>,
 ) -> NgcResult<HashMap<PathBuf, HashSet<String>>> {
     // Step 1: Parse each module and collect export/import information
     let mut module_infos: HashMap<PathBuf, ModuleInfo> = HashMap::new();
@@ -105,7 +112,8 @@ pub fn analyze_unused_exports(
 
         for name in &info.exported_names {
             let is_used = used.is_some_and(|u| u.contains(name));
-            if !is_used {
+            let is_externally_used = externally_used.is_some_and(|set| set.contains(name));
+            if !is_used && !is_externally_used {
                 unused_names.insert(name.clone());
             }
         }
@@ -250,14 +258,19 @@ fn resolve_local_specifier(
     // For relative imports, resolve against the importer's directory
     let importer_dir = importer.parent()?;
 
-    // Try various extensions and index file patterns
+    // Try various extensions and index file patterns.
+    //
+    // Append extensions by string concatenation rather than `Path::with_extension`,
+    // because filenames like `analytics.service` contain a dot that would
+    // otherwise be treated as an existing extension and replaced.
     let candidates: Vec<PathBuf> = if specifier.starts_with('.') {
         let base = importer_dir.join(specifier);
+        let base_str = base.to_string_lossy().into_owned();
         vec![
             base.clone(),
-            base.with_extension("ts"),
-            base.with_extension("tsx"),
-            base.with_extension("js"),
+            PathBuf::from(format!("{base_str}.ts")),
+            PathBuf::from(format!("{base_str}.tsx")),
+            PathBuf::from(format!("{base_str}.js")),
             base.join("index.ts"),
             base.join("index.js"),
         ]
@@ -291,6 +304,129 @@ fn resolve_local_specifier(
     None
 }
 
+/// Collect symbol names imported by `consumer_modules` from any module in
+/// `provider_modules`, by parsing each consumer's source for `ImportDeclaration`
+/// statements and resolving their specifiers against the provider set.
+///
+/// Used by the bundler to tell the main-chunk tree-shaker which symbols are
+/// consumed by lazy chunks and must therefore be preserved — such consumption
+/// is invisible when shaking each chunk in isolation, and would otherwise
+/// leave the cross-chunk `export { ... }` block referring to names whose
+/// declarations have been tree-shaken away.
+///
+/// For named and default imports, the specific name is collected. For
+/// namespace imports (`import * as X from '...'`), every exported name of
+/// the target provider module is collected since individual accesses can't
+/// be known statically here.
+pub fn collect_cross_chunk_used_names(
+    consumer_modules: &[PathBuf],
+    provider_modules: &[PathBuf],
+    all_code: &HashMap<PathBuf, String>,
+    local_prefixes: &[&str],
+) -> NgcResult<HashSet<String>> {
+    let mut used: HashSet<String> = HashSet::new();
+    let provider_set: HashSet<&PathBuf> = provider_modules.iter().collect();
+
+    // Cache provider exports so we only parse each once when expanding namespace imports.
+    let mut provider_exports: HashMap<PathBuf, HashSet<String>> = HashMap::new();
+
+    for consumer_path in consumer_modules {
+        let Some(code) = all_code.get(consumer_path) else {
+            continue;
+        };
+
+        let info = analyze_module(code, consumer_path)?;
+        for (specifier, imported_names) in &info.local_imports {
+            let Some(target) =
+                resolve_local_specifier(specifier, consumer_path, provider_modules, local_prefixes)
+            else {
+                continue;
+            };
+
+            if !provider_set.contains(&target) {
+                continue;
+            }
+
+            for name in imported_names {
+                if name == "* as " || name.starts_with("* as ") {
+                    // ImportNamespaceSpecifier — `analyze_module` currently drops these
+                    // (returns None), so this branch is defensive. Fall through to the
+                    // dedicated namespace pass below when the signal is present.
+                    continue;
+                }
+                used.insert(name.clone());
+            }
+        }
+
+        // ImportNamespaceSpecifier is not captured by `analyze_module` (which
+        // returns None for namespace imports). Re-parse here to expand them
+        // into the full provider export set for each such import.
+        expand_namespace_imports(
+            code,
+            consumer_path,
+            provider_modules,
+            local_prefixes,
+            all_code,
+            &mut provider_exports,
+            &mut used,
+        )?;
+    }
+
+    Ok(used)
+}
+
+fn expand_namespace_imports(
+    code: &str,
+    consumer_path: &Path,
+    provider_modules: &[PathBuf],
+    local_prefixes: &[&str],
+    all_code: &HashMap<PathBuf, String>,
+    provider_exports: &mut HashMap<PathBuf, HashSet<String>>,
+    used: &mut HashSet<String>,
+) -> NgcResult<()> {
+    let allocator = Allocator::new();
+    let parsed = Parser::new(&allocator, code, SourceType::mjs()).parse();
+    if parsed.panicked {
+        return Ok(());
+    }
+
+    for stmt in &parsed.program.body {
+        let Some(ModuleDeclaration::ImportDeclaration(import)) = stmt.as_module_declaration()
+        else {
+            continue;
+        };
+        let Some(specifiers) = &import.specifiers else {
+            continue;
+        };
+        let has_namespace = specifiers
+            .iter()
+            .any(|s| matches!(s, ImportDeclarationSpecifier::ImportNamespaceSpecifier(_)));
+        if !has_namespace {
+            continue;
+        }
+        let source = import.source.value.to_string();
+        let Some(target) =
+            resolve_local_specifier(&source, consumer_path, provider_modules, local_prefixes)
+        else {
+            continue;
+        };
+        let exports = match provider_exports.get(&target) {
+            Some(e) => e.clone(),
+            None => {
+                let Some(provider_code) = all_code.get(&target) else {
+                    continue;
+                };
+                let info = analyze_module(provider_code, &target)?;
+                provider_exports.insert(target.clone(), info.exported_names.clone());
+                info.exported_names
+            }
+        };
+        used.extend(exports);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,9 +449,14 @@ mod tests {
             PathBuf::from("/root/main.js"),
         ];
 
-        let result =
-            analyze_unused_exports(&paths, &modules, &PathBuf::from("/root/main.js"), &["."])
-                .expect("should analyze");
+        let result = analyze_unused_exports(
+            &paths,
+            &modules,
+            &PathBuf::from("/root/main.js"),
+            &["."],
+            None,
+        )
+        .expect("should analyze");
 
         let utils_unused = result.get(&PathBuf::from("/root/utils.js"));
         assert!(utils_unused.is_some(), "utils should have unused exports");
@@ -339,9 +480,14 @@ mod tests {
 
         let paths = vec![PathBuf::from("/root/main.ts")];
 
-        let result =
-            analyze_unused_exports(&paths, &modules, &PathBuf::from("/root/main.ts"), &["."])
-                .expect("should analyze");
+        let result = analyze_unused_exports(
+            &paths,
+            &modules,
+            &PathBuf::from("/root/main.ts"),
+            &["."],
+            None,
+        )
+        .expect("should analyze");
 
         assert!(
             !result.contains_key(&PathBuf::from("/root/main.ts")),
@@ -366,13 +512,130 @@ mod tests {
             PathBuf::from("/root/main.ts"),
         ];
 
-        let result =
-            analyze_unused_exports(&paths, &modules, &PathBuf::from("/root/main.ts"), &["."])
-                .expect("should analyze");
+        let result = analyze_unused_exports(
+            &paths,
+            &modules,
+            &PathBuf::from("/root/main.ts"),
+            &["."],
+            None,
+        )
+        .expect("should analyze");
 
         assert!(
             !result.contains_key(&PathBuf::from("/root/side.ts")),
             "side-effect module should not have unused exports listed"
         );
+    }
+
+    #[test]
+    fn test_externally_used_preserves_export() {
+        // When a name is marked externally used (e.g. consumed by a lazy
+        // chunk cross-chunk), it must not be reported as unused even if
+        // no intra-chunk importer references it.
+        let mut modules = HashMap::new();
+        modules.insert(
+            PathBuf::from("/root/svc.js"),
+            "export class AnalyticsService {}\n".to_string(),
+        );
+        modules.insert(
+            PathBuf::from("/root/main.js"),
+            "// main has no import of AnalyticsService\n".to_string(),
+        );
+
+        let paths = vec![
+            PathBuf::from("/root/svc.js"),
+            PathBuf::from("/root/main.js"),
+        ];
+
+        let mut externally_used = HashSet::new();
+        externally_used.insert("AnalyticsService".to_string());
+
+        let result = analyze_unused_exports(
+            &paths,
+            &modules,
+            &PathBuf::from("/root/main.js"),
+            &["."],
+            Some(&externally_used),
+        )
+        .expect("should analyze");
+
+        let svc_unused = result.get(&PathBuf::from("/root/svc.js"));
+        assert!(
+            svc_unused.is_none() || !svc_unused.expect("checked").contains("AnalyticsService"),
+            "externally-used export must not be flagged unused"
+        );
+    }
+
+    #[test]
+    fn test_collect_cross_chunk_used_names_dotted_filename() {
+        // Regression: resolve_local_specifier previously used `with_extension`,
+        // which treated `.service` as an existing extension and replaced it.
+        // Imports like `./foo.service` then failed to resolve against
+        // `foo.service.ts` and cross-chunk consumption was missed.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let svc = dir.path().join("analytics.service.ts");
+        let comp = dir.path().join("comp.ts");
+        std::fs::write(&svc, "export class AnalyticsService {}\n").expect("write svc");
+        std::fs::write(
+            &comp,
+            "import { AnalyticsService } from './analytics.service';\nnew AnalyticsService();\n",
+        )
+        .expect("write comp");
+
+        let canon_svc = svc.canonicalize().expect("canon svc");
+        let canon_comp = comp.canonicalize().expect("canon comp");
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            canon_svc.clone(),
+            "export class AnalyticsService {}\n".into(),
+        );
+        modules.insert(
+            canon_comp.clone(),
+            "import { AnalyticsService } from './analytics.service';\nnew AnalyticsService();\n"
+                .into(),
+        );
+
+        let used = collect_cross_chunk_used_names(&[canon_comp], &[canon_svc], &modules, &["."])
+            .expect("should collect");
+        assert!(
+            used.contains("AnalyticsService"),
+            "import of ./foo.service must resolve to foo.service.ts"
+        );
+    }
+
+    #[test]
+    fn test_collect_cross_chunk_used_names_named_import() {
+        // A lazy-chunk module imports AnalyticsService from a main-chunk module;
+        // collect_cross_chunk_used_names must surface it. Uses a real tempdir
+        // so resolve_local_specifier's canonicalize step can succeed.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let main_svc = dir.path().join("svc.js");
+        let lazy_dir = dir.path().join("lazy");
+        std::fs::create_dir_all(&lazy_dir).expect("create lazy dir");
+        let lazy_comp = lazy_dir.join("comp.js");
+        std::fs::write(&main_svc, "export class AnalyticsService {}\n").expect("write svc");
+        std::fs::write(
+            &lazy_comp,
+            "import { AnalyticsService } from '../svc';\nnew AnalyticsService();\n",
+        )
+        .expect("write comp");
+
+        let canon_svc = main_svc.canonicalize().expect("canon svc");
+        let canon_comp = lazy_comp.canonicalize().expect("canon comp");
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            canon_svc.clone(),
+            "export class AnalyticsService {}\n".into(),
+        );
+        modules.insert(
+            canon_comp.clone(),
+            "import { AnalyticsService } from '../svc';\nnew AnalyticsService();\n".into(),
+        );
+
+        let used = collect_cross_chunk_used_names(&[canon_comp], &[canon_svc], &modules, &["."])
+            .expect("should collect");
+        assert!(used.contains("AnalyticsService"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -517,10 +517,7 @@ fn build_options(configuration: Option<&str>) -> BundleOptions {
             source_maps: true,
             minify: true,
             content_hash: true,
-            // Tree shaking disabled: conflicts with dynamic import rewrites
-            // when an export declaration contains import() expressions.
-            // TODO: fix tree shaker to skip declarations with nested dynamic imports
-            tree_shake: false,
+            tree_shake: true,
         },
         _ => BundleOptions::default(),
     }
@@ -1356,7 +1353,7 @@ mod tests {
         assert!(opts.source_maps);
         assert!(opts.minify);
         assert!(opts.content_hash);
-        assert!(!opts.tree_shake); // disabled: conflicts with dynamic import rewrites
+        assert!(opts.tree_shake);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Refactors `collect_module_decl_edits` to return a `bool` signalling when a statement's span was fully elided or replaced; the caller skips `collect_dynamic_import_edits` for those statements. Eliminates the byte-offset collision between tree-shake removal and dynamic-import-specifier rewrites that produced stray `export` tokens in output.
- Re-enables `tree_shake: true` in production `build_options` (previously disabled at `crates/cli/src/main.rs:523`).
- Bumps workspace version to `0.7.8`.

## Root cause

`apply_edits` sorts edits in reverse start order and applies them with `String::replace_range`. A length-changing replacement (e.g. `'./lazy'` → `'./chunk-abc123.js'`) inside a span that is then fully removed by tree shake shifted the removal edit's `end` offset past the declaration boundary, leaving the `export` keyword in the output. Skipping the walker on fully-removed statements prevents that class of collision — dynamic imports inside a dead declaration are dead code anyway.

## Test plan

- [x] `cargo test --workspace` — all 351 tests pass, including 4 new unit tests in `crates/bundler/src/rewrite.rs` covering used/unused × const/function × nested dynamic imports.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Integration build of treasr-frontend (Angular 21, 14 lazy routes) completes with `tree_shake: true`; all 16 emitted JS chunks pass `node --check`; no bare stray `export` keywords in output (only legitimate lazy-chunk preserve-exports and the main.js re-export aggregation).

## Follow-ups (out of scope, will file as separate issues)

- `export const a = 1, b = 2` multi-declarator handling in the rewriter — `get_declaration_name` only inspects the first declarator, so full-span removal can drop siblings when only one name is unused. Latent, not introduced by this PR.
- `chunk_graph.dynamic_import_map` is built before `analyze_unused_exports` runs; chunks referenced only by tree-shaken lazy imports are still emitted to disk. Wasted output, not incorrect.
- npm-module tree shaking via `sideEffects: false` (mentioned in the issue body).

Closes #13