### PR TITLE
fix: resolve @for listener loop variables and nested iterable references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "criterion",
  "glob",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "clap",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -908,7 +908,7 @@ impl IvyCodegen {
         self.add_advance(slot);
         self.update.push(format!(
             "\u{0275}\u{0275}repeater({});",
-            ctx_expr(&block.iterable)
+            ctx_expr_with_locals(&block.iterable, &self.local_vars)
         ));
         self.var_count += 1;
     }
@@ -982,7 +982,7 @@ impl IvyCodegen {
             }
             cond.push_str(&format!(
                 "{} === {} ? {}",
-                ctx_expr(&block.expression),
+                ctx_expr_with_locals(&block.expression, &self.local_vars),
                 expr,
                 case_slot
             ));

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1461,21 +1461,60 @@ impl IvyCodegen {
 
     /// Generate the preamble code for a listener closure inside an embedded view.
     ///
-    /// Produces: `ɵɵrestoreView(_r); const h = _r.$implicit; const ctx = ɵɵnextContext(N);`
-    /// where `h` is extracted from the innermost @for scope and `ctx` is the component.
+    /// Produces: `ɵɵrestoreView(_r); const inner = _ctx.$implicit;
+    /// [const _outer_ctx = ɵɵnextContext(); const outer = _outer_ctx.$implicit; …]
+    /// const ctx = ɵɵnextContext(N);`
+    ///
+    /// Walks the full `scope_stack` so listeners inside nested `@for` blocks
+    /// see every in-scope loop variable — mirrors `generate_context_navigation`
+    /// with listener-appropriate single-line formatting.
     fn generate_listener_preamble(&self) -> String {
-        let depth = self.scope_stack.len();
         let mut code = String::from("\u{0275}\u{0275}restoreView(_r); ");
-
-        // If the innermost scope is a @for, extract the item from the restored view
-        if let Some(ScopeEntry::Repeater { item_name }) = self.scope_stack.last() {
-            code.push_str(&format!("const {item_name} = _r.$implicit; "));
+        if self.scope_stack.is_empty() {
+            return code;
         }
 
-        // Navigate to the component context
-        code.push_str(&format!(
-            "const ctx = \u{0275}\u{0275}nextContext({depth}); "
-        ));
+        let depth = self.scope_stack.len();
+        let mut levels_consumed: usize = 0;
+
+        // Walk innermost → outermost. i=0 is the current scope (use _ctx directly,
+        // the closure-captured template function parameter). i>0 are ancestor scopes
+        // reached via ɵɵnextContext(steps).
+        for (i, entry) in self.scope_stack.iter().rev().enumerate() {
+            match entry {
+                ScopeEntry::Repeater { item_name } if i == 0 => {
+                    code.push_str(&format!("const {item_name} = _ctx.$implicit; "));
+                }
+                ScopeEntry::Repeater { item_name } => {
+                    let steps = i - levels_consumed;
+                    if steps == 1 {
+                        code.push_str(&format!(
+                            "const _{item_name}_ctx = \u{0275}\u{0275}nextContext(); "
+                        ));
+                    } else if steps > 1 {
+                        code.push_str(&format!(
+                            "const _{item_name}_ctx = \u{0275}\u{0275}nextContext({steps}); "
+                        ));
+                    }
+                    if steps > 0 {
+                        code.push_str(&format!("const {item_name} = _{item_name}_ctx.$implicit; "));
+                    }
+                    levels_consumed = i;
+                }
+                ScopeEntry::Conditional => {
+                    // No implicit variable — still counts toward navigation depth.
+                }
+            }
+        }
+
+        let remaining = depth - levels_consumed;
+        if remaining <= 1 {
+            code.push_str("const ctx = \u{0275}\u{0275}nextContext(); ");
+        } else {
+            code.push_str(&format!(
+                "const ctx = \u{0275}\u{0275}nextContext({remaining}); "
+            ));
+        }
 
         code
     }

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -780,6 +780,58 @@ export class TestComponent {
     }
 
     #[test]
+    fn nested_for_iterable_does_not_prefix_outer_loop_variable_with_ctx() {
+        // Regression: in @for (inner of outer.items), the iterable passed to
+        // ɵɵrepeater() was being compiled with a `ctx.` prefix even though
+        // `outer` is an outer @for's loop variable (a local), producing
+        // `ɵɵrepeater(ctx.outer.items)` — which throws at runtime.
+        let source = r#"import { Component } from '@angular/core';
+
+interface Group { items: string[]; }
+
+@Component({
+  selector: 'app-test',
+  standalone: true,
+  template: `
+    @for (outer of groups; track outer) {
+      @for (inner of outer.items; track inner) {
+        <span>{{ inner }}</span>
+      }
+    }
+  `,
+})
+export class TestComponent {
+  groups: Group[] = [];
+}
+"#;
+        let path = PathBuf::from("nested-for-iterable.component.ts");
+        let result = compile_component(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(
+            result
+                .source
+                .contains("\u{0275}\u{0275}repeater(outer.items)"),
+            "inner @for iterable must read outer.items without ctx. prefix; got:\n{}",
+            result.source
+        );
+        assert!(
+            !result
+                .source
+                .contains("\u{0275}\u{0275}repeater(ctx.outer.items)"),
+            "inner @for iterable must NOT get ctx. prefix on outer loop variable; got:\n{}",
+            result.source
+        );
+
+        let js =
+            ngc_ts_transform::transform_source(&result.source, "nested-for-iterable.component.ts");
+        assert!(
+            js.is_ok(),
+            "compiled source should be valid JS: {:?}",
+            js.err()
+        );
+    }
+
+    #[test]
     fn nested_for_block_listener_resolves_ancestor_loop_variables() {
         // Regression test for #40 (nested case): inside nested @for blocks,
         // listeners must also resolve *ancestor* loop variables via the

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -735,4 +735,110 @@ export class AppModule {}
         assert!(!result.compiled);
         assert_eq!(result.source, source);
     }
+
+    #[test]
+    fn for_block_listener_resolves_loop_variable_via_ctx() {
+        // Regression test for #40: a (click) handler inside @for was receiving
+        // `undefined` for the loop variable because the listener preamble read
+        // `_r.$implicit` (LView) instead of `_ctx.$implicit` (template context).
+        let source = r#"import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test',
+  standalone: true,
+  template: `
+    @for (group of items; track group) {
+      <button (click)="onClick(group)">{{ group }}</button>
+    }
+  `,
+})
+export class TestComponent {
+  items: string[] = [];
+  onClick(_group: string) {}
+}
+"#;
+        let path = PathBuf::from("for-listener.component.ts");
+        let result = compile_component(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(
+            result.source.contains("const group = _ctx.$implicit"),
+            "listener preamble must read the loop item from _ctx.$implicit; got:\n{}",
+            result.source
+        );
+        assert!(
+            !result.source.contains("const group = _r.$implicit"),
+            "listener preamble must NOT read from _r.$implicit (LView has no $implicit); got:\n{}",
+            result.source
+        );
+
+        let js = ngc_ts_transform::transform_source(&result.source, "for-listener.component.ts");
+        assert!(
+            js.is_ok(),
+            "compiled source should be valid JS: {:?}",
+            js.err()
+        );
+    }
+
+    #[test]
+    fn nested_for_block_listener_resolves_ancestor_loop_variables() {
+        // Regression test for #40 (nested case): inside nested @for blocks,
+        // listeners must also resolve *ancestor* loop variables via the
+        // ɵɵnextContext chain, not just the innermost one.
+        let source = r#"import { Component } from '@angular/core';
+
+interface Group { items: string[]; }
+
+@Component({
+  selector: 'app-test',
+  standalone: true,
+  template: `
+    @for (outer of groups; track outer) {
+      @for (inner of outer.items; track inner) {
+        <button (click)="onClick(outer, inner)">{{ inner }}</button>
+      }
+    }
+  `,
+})
+export class TestComponent {
+  groups: Group[] = [];
+  onClick(_outer: Group, _inner: string) {}
+}
+"#;
+        let path = PathBuf::from("nested-for-listener.component.ts");
+        let result = compile_component(source, &path).expect("should compile");
+        assert!(result.compiled);
+        assert!(
+            result.source.contains("const inner = _ctx.$implicit"),
+            "innermost @for item must be read from _ctx.$implicit; got:\n{}",
+            result.source
+        );
+        assert!(
+            result
+                .source
+                .contains("const _outer_ctx = \u{0275}\u{0275}nextContext()")
+                || result
+                    .source
+                    .contains("const _outer_ctx = \u{0275}\u{0275}nextContext(1)"),
+            "ancestor @for must be reached via ɵɵnextContext; got:\n{}",
+            result.source
+        );
+        assert!(
+            result.source.contains("const outer = _outer_ctx.$implicit"),
+            "ancestor @for item must be read from the ɵɵnextContext()'d context; got:\n{}",
+            result.source
+        );
+        assert!(
+            !result.source.contains("_r.$implicit"),
+            "listener preamble must never dereference $implicit on _r (LView); got:\n{}",
+            result.source
+        );
+
+        let js =
+            ngc_ts_transform::transform_source(&result.source, "nested-for-listener.component.ts");
+        assert!(
+            js.is_ok(),
+            "compiled source should be valid JS: {:?}",
+            js.err()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Rewrite `generate_listener_preamble` so event handlers inside `@for` blocks resolve every in-scope loop variable from `_ctx.$implicit` (+ `ɵɵnextContext()` chains for ancestor scopes) instead of dereferencing `$implicit` on the LView returned by `ɵɵgetCurrentView()`.
- Pass `self.local_vars` to the expression rewriter for `@for` iterables and `@switch` expressions so outer `@for` loop variables aren't clobbered with a stray `ctx.` prefix.
- Add three regression tests: single-level `@for` listener, nested `@for` listener, nested `@for` iterable. None of these paths had coverage before.
- Bump workspace version to `0.7.9`.

Closes #40.

## Test plan

- [x] `cargo test --workspace` — all green, new tests among them
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Rebuild treasr-frontend with the patched binary, swap into `treasr-frontend-ngc-rs` nginx container, verify that (a) clicking a news card expands it without the `Cannot read properties of undefined (reading 'expanded')` throw, and (b) fetched articles from `/news/<SYMBOL>` render inside the expanded card (user-confirmed).
- [x] Emitted chunk contains `ɵɵlistener('click', function($event){ ɵɵrestoreView(_r); const group=_ctx.$implicit; … })` and `ɵɵrepeater(group.articles)` (unprefixed).