### PR TITLE
test: verify `public/` folder parity with `src/assets/` (v0.7.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "clap",
  "colored",
  "glob",
+ "insta",
  "ngc-bundler",
  "ngc-diagnostics",
  "ngc-linker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "criterion",
  "glob",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "clap",
  "colored",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.9"
+version = "0.7.10"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,3 +31,4 @@ oxc_sourcemap = "6.1"
 
 [dev-dependencies]
 tempfile = "3"
+insta = { version = "1.46", features = ["glob"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1393,4 +1393,74 @@ mod tests {
         // Path key should remain the original
         assert_eq!(result[0].0, env_file);
     }
+
+    /// Scaffold a `public/` tree mirroring the treasr-frontend shape.
+    fn scaffold_public_tree(root: &Path) -> PathBuf {
+        let public = root.join("public");
+        std::fs::create_dir_all(public.join("i18n")).unwrap();
+        std::fs::create_dir_all(public.join("nested/deep")).unwrap();
+        std::fs::write(public.join("i18n/de.json"), r#"{"hello":"hallo"}"#).unwrap();
+        std::fs::write(public.join("i18n/en.json"), r#"{"hello":"hello"}"#).unwrap();
+        std::fs::write(public.join("appleid_button@4x.png"), b"\x89PNG\r\n").unwrap();
+        std::fs::write(public.join("nested/deep/file.txt"), "leaf").unwrap();
+        public
+    }
+
+    /// Collect files under `dir`, returning paths relative to `dir` with
+    /// forward-slash separators — deterministic output for snapshots.
+    fn collect_relative_files(dir: &Path) -> Vec<String> {
+        fn walk(dir: &Path, base: &Path, out: &mut Vec<String>) {
+            for entry in std::fs::read_dir(dir).unwrap().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, base, out);
+                } else {
+                    let rel = path.strip_prefix(base).unwrap();
+                    out.push(rel.to_string_lossy().replace('\\', "/"));
+                }
+            }
+        }
+        let mut files = Vec::new();
+        walk(dir, dir, &mut files);
+        files.sort();
+        files
+    }
+
+    #[test]
+    fn test_copy_assets_public_folder_glob() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let public = scaffold_public_tree(dir.path());
+        let out = dir.path().join("dist");
+        std::fs::create_dir_all(&out).unwrap();
+
+        let asset = ResolvedAsset::Glob {
+            pattern: "**/*".to_string(),
+            input: public,
+            output: "/".to_string(),
+            ignore: vec![],
+        };
+        copy_assets(&[asset], &out).expect("copy_assets should succeed");
+
+        let files = collect_relative_files(&out);
+        insta::assert_snapshot!("public_folder_glob_dist", files.join("\n"));
+    }
+
+    #[test]
+    fn test_copy_assets_glob_with_output_subdir() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let public = scaffold_public_tree(dir.path());
+        let out = dir.path().join("dist");
+        std::fs::create_dir_all(&out).unwrap();
+
+        let asset = ResolvedAsset::Glob {
+            pattern: "**/*".to_string(),
+            input: public,
+            output: "/assets/".to_string(),
+            ignore: vec![],
+        };
+        copy_assets(&[asset], &out).expect("copy_assets should succeed");
+
+        let files = collect_relative_files(&out);
+        insta::assert_snapshot!("public_folder_glob_output_subdir", files.join("\n"));
+    }
 }

--- a/crates/cli/src/snapshots/ngc_rs__tests__public_folder_glob_dist.snap
+++ b/crates/cli/src/snapshots/ngc_rs__tests__public_folder_glob_dist.snap
@@ -1,0 +1,8 @@
+---
+source: crates/cli/src/main.rs
+expression: "files.join(\"\\n\")"
+---
+appleid_button@4x.png
+i18n/de.json
+i18n/en.json
+nested/deep/file.txt

--- a/crates/cli/src/snapshots/ngc_rs__tests__public_folder_glob_output_subdir.snap
+++ b/crates/cli/src/snapshots/ngc_rs__tests__public_folder_glob_output_subdir.snap
@@ -1,0 +1,8 @@
+---
+source: crates/cli/src/main.rs
+expression: "files.join(\"\\n\")"
+---
+assets/appleid_button@4x.png
+assets/i18n/de.json
+assets/i18n/en.json
+assets/nested/deep/file.txt


### PR DESCRIPTION
## Summary
- Adds snapshot-based tests in `crates/cli/src/main.rs` that exercise `copy_assets()` with a `ResolvedAsset::Glob` matching treasr-frontend's `{ glob: "**/*", input: "public" }` shape (output defaults to `/`) and a second shape with `output: "/assets/"`.
- Confirms that files under `public/` (including nested directories and `@`-in-name assets) land at the correct `dist/` paths.
- Backs the CLAUDE.md claim that `public/` is the default static-asset root in Angular 17+ with working, regression-locked code.

## Context
Issue #35 flagged that `public/` parity with legacy `src/assets/` was only documented, not tested. The audit found the parsing (`crates/project-resolver/src/angular_json.rs:125-142`, `:423-440`) and copying (`crates/cli/src/main.rs:821-879`) code already handled both asset forms correctly — the gap was test coverage.

## Test plan
- [x] `cargo test --workspace` (all suites green, incl. 2 new tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end: `ngc-rs build` on treasr-frontend produces `dist/treasr-frontend/i18n/{de,en}.json` and `dist/treasr-frontend/appleid_button@4x.png`

Closes #35