### PR TITLE
fix(template-compiler): preserve `@for` locals inside pipe arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "criterion",
  "glob",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "clap",
  "colored",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1234,20 +1234,7 @@ impl IvyCodegen {
                 let compiled_args: Vec<String> = pipe
                     .args
                     .iter()
-                    .map(|a| {
-                        let trimmed = a.trim();
-                        if trimmed.starts_with('{') {
-                            let wrapped = format!("({})", trimmed);
-                            let result = ctx_expr(&wrapped);
-                            result
-                                .strip_prefix('(')
-                                .and_then(|s| s.strip_suffix(')'))
-                                .unwrap_or(&result)
-                                .to_string()
-                        } else {
-                            ctx_expr(a)
-                        }
-                    })
+                    .map(|a| compile_pipe_arg(a, &self.local_vars))
                     .collect();
                 expr = format!(
                     "{bind_fn}({pipe_slot}, {pipe_var_slot}, {expr}, {})",
@@ -1336,22 +1323,7 @@ impl IvyCodegen {
             }
             let compiled_args: Vec<String> = args
                 .iter()
-                .map(|a| {
-                    let trimmed = a.trim();
-                    if trimmed.starts_with('{') {
-                        // Wrap object literals in parens so oxc parses them as
-                        // expressions, not block statements.
-                        let wrapped = format!("({})", trimmed);
-                        let result = ctx_expr(&wrapped);
-                        result
-                            .strip_prefix('(')
-                            .and_then(|s| s.strip_suffix(')'))
-                            .unwrap_or(&result)
-                            .to_string()
-                    } else {
-                        ctx_expr(a)
-                    }
-                })
+                .map(|a| compile_pipe_arg(a, &self.local_vars))
                 .collect();
             return format!(
                 "{bind_fn}({pipe_slot}, {pipe_var_slot}, {compiled_base}, {})",
@@ -1876,7 +1848,7 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
             if let Some((base, pipe_name, args)) = split_top_level_pipe_with_args(&inner) {
                 // Compile the base expression recursively
                 let compiled_base = replace_nested_pipe_parens(&base, gen);
-                let compiled_base = ctx_expr(&compiled_base);
+                let compiled_base = ctx_expr_with_locals(&compiled_base, &gen.local_vars);
 
                 let pipe_slot = gen.slot_index;
                 gen.slot_index += 1;
@@ -1900,22 +1872,7 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
                 } else {
                     let compiled_args: Vec<String> = args
                         .iter()
-                        .map(|a| {
-                            let trimmed = a.trim();
-                            if trimmed.starts_with('{') {
-                                // Wrap object literals in parens so oxc parses them as
-                                // expressions, not block statements.
-                                let wrapped = format!("({})", trimmed);
-                                let result = ctx_expr(&wrapped);
-                                result
-                                    .strip_prefix('(')
-                                    .and_then(|s| s.strip_suffix(')'))
-                                    .unwrap_or(&result)
-                                    .to_string()
-                            } else {
-                                ctx_expr(a)
-                            }
-                        })
+                        .map(|a| compile_pipe_arg(a, &gen.local_vars))
                         .collect();
                     result.push_str(&format!(
                         "{bind_fn}({pipe_slot}, {pipe_var_slot}, {compiled_base}, {})",
@@ -1972,6 +1929,27 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
 /// identifiers (not member properties, not builtins) get the `ctx.` prefix.
 fn ctx_expr(expr: &str) -> String {
     ctx_expr_with_locals(expr, &BTreeSet::new())
+}
+
+/// Compile a single pipe-call argument to JavaScript.
+///
+/// Object-literal arguments (e.g. `{ count: tier.count }`) are wrapped in
+/// parentheses so oxc parses them as expressions rather than block statements,
+/// then unwrapped again. Both forms preserve template-local variables from the
+/// enclosing `@for` / `@let` scope so they don't get a spurious `ctx.` prefix.
+fn compile_pipe_arg(arg: &str, locals: &BTreeSet<String>) -> String {
+    let trimmed = arg.trim();
+    if trimmed.starts_with('{') {
+        let wrapped = format!("({trimmed})");
+        let result = ctx_expr_with_locals(&wrapped, locals);
+        result
+            .strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .unwrap_or(&result)
+            .to_string()
+    } else {
+        ctx_expr_with_locals(arg, locals)
+    }
 }
 
 /// Rewrite an expression by adding `ctx.` prefix to top-level identifiers,

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -2953,6 +2953,70 @@ mod tests {
     }
 
     #[test]
+    fn test_pipe_object_arg_preserves_for_local() {
+        // `@for (tier of tiers()) { {{ 'K' | translate: { count: tier.features['portfolios'] } }} }`
+        // The pipe's second argument references the @for loop variable `tier`, which
+        // must stay unprefixed in the emitted code — NOT `ctx.tier.features[...]`.
+        let comp = test_component();
+        let nodes = vec![TemplateNode::ForBlock(ForBlockNode {
+            item_name: "tier".to_string(),
+            iterable: "tiers()".to_string(),
+            track_expression: "tier".to_string(),
+            children: vec![TemplateNode::Interpolation(InterpolationNode {
+                expression: "'PRICING.PORTFOLIO_COUNT'".to_string(),
+                pipes: vec![PipeCall {
+                    name: "translate".to_string(),
+                    args: vec!["{ count: tier.features['portfolios'] }".to_string()],
+                }],
+            })],
+            empty_children: None,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        let body = output.child_template_functions.join("\n");
+        assert!(
+            body.contains("pipeBind2"),
+            "single-arg translate pipe should compile to pipeBind2: {body}"
+        );
+        assert!(
+            body.contains("tier.features['portfolios']"),
+            "@for loop variable must stay unprefixed inside pipe arg: {body}"
+        );
+        assert!(
+            !body.contains("ctx.tier"),
+            "must not emit ctx.tier inside the @for body: {body}"
+        );
+    }
+
+    #[test]
+    fn test_pipe_positional_arg_preserves_for_local() {
+        // Same principle with a non-object positional argument.
+        let comp = test_component();
+        let nodes = vec![TemplateNode::ForBlock(ForBlockNode {
+            item_name: "item".to_string(),
+            iterable: "items()".to_string(),
+            track_expression: "item".to_string(),
+            children: vec![TemplateNode::Interpolation(InterpolationNode {
+                expression: "item.date".to_string(),
+                pipes: vec![PipeCall {
+                    name: "date".to_string(),
+                    args: vec!["item.format".to_string()],
+                }],
+            })],
+            empty_children: None,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        let body = output.child_template_functions.join("\n");
+        assert!(
+            body.contains("item.format"),
+            "@for loop variable used as positional pipe arg must stay unprefixed: {body}"
+        );
+        assert!(
+            !body.contains("ctx.item.format"),
+            "must not emit ctx.item.format: {body}"
+        );
+    }
+
+    #[test]
     fn test_valueless_attribute_included_in_consts() {
         // Value-less attributes (e.g. `baseChart` on `<canvas baseChart>`)
         // must appear in the consts array with an empty-string value so that


### PR DESCRIPTION
Closes #43.

## Summary

Pipe-call argument codegen in `crates/template-compiler/src/codegen.rs` was dereferencing template-local variables (e.g. `@for` item names) as if they were component properties, prefixing them with `ctx.` — so `{{ 'K' | translate: { count: tier.features['portfolios'] } }}` inside `@for (tier of tiers())` emitted `{ count: ctx.tier.features[...] }`, which is `undefined` at runtime and made the `TranslatePipe` fall back to an empty string.

Three call sites all called the locals-unaware `ctx_expr(a)` on pipe args (and on the base expression of the nested-paren pipe path). All three now share a new `compile_pipe_arg(arg, locals)` helper that threads the active `self.local_vars` / `gen.local_vars` set through `ctx_expr_with_locals`. The base-expression compilation in `replace_nested_pipe_parens` also switched to the locals-aware variant for consistency.

No behavior change for pipes whose args only reference component state — those identifiers still get the `ctx.` prefix. Only local-scoped references (active `@for` item + `@let` declarations) are now preserved.

## Verification

- `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` all green.
- Two new regression tests (`test_pipe_object_arg_preserves_for_local`, `test_pipe_positional_arg_preserves_for_local`) cover the object-literal and positional-arg paths.
- Rebuilt treasr-frontend with the patched binary and reloaded the nginx container; pricing cards now render `1 portfolio` and `Up to 10 holdings` on the Free tier — matching `@angular/build:application`.

## Test plan

- [x] Unit tests cover pipe arg with object literal referencing `@for` loop var
- [x] Unit tests cover positional pipe arg referencing `@for` loop var
- [x] Workspace tests, clippy, fmt clean
- [x] treasr-frontend `/pricing` renders identical text to `ng build`