### PR TITLE
fix: resolve `#ref` template variables and array-form `exportAs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "criterion",
  "glob",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "clap",
  "colored",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -72,8 +72,17 @@ pub fn build_define_call(
         }
     }
 
-    // Export as
-    if let Some(export_as) = metadata::get_string_prop(obj, "exportAs") {
+    // Export as — ɵɵngDeclareDirective emits `exportAs` as a string array
+    // (e.g. `exportAs: ["ngForm"]`) but legacy input may also be a single
+    // comma-separated string.  Accept both forms.
+    if let Some(export_as_names) = metadata::get_string_array_prop(obj, "exportAs") {
+        let arr = export_as_names
+            .iter()
+            .map(|s| format!("\"{s}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        props.push(format!("exportAs: [{arr}]"));
+    } else if let Some(export_as) = metadata::get_string_prop(obj, "exportAs") {
         let parts: Vec<&str> = export_as.split(',').map(|s| s.trim()).collect();
         let arr = parts
             .iter()
@@ -862,6 +871,43 @@ mod tests {
         assert!(result.contains("type: MyDir"));
         assert!(result.contains("selectors: [['', 'myDir', '']]"));
         assert!(result.contains("standalone: true"));
+    }
+
+    #[test]
+    fn test_directive_export_as_string_array() {
+        // `ɵɵngDeclareDirective` emits `exportAs` as a string array
+        // (e.g. @angular/forms' NgForm).  The linker must transfer it into
+        // the emitted `ɵɵdefineDirective` call, otherwise runtime
+        // ref lookups with `#ref="exportAsName"` fail with NG0301.
+        let result = parse_and_transform(
+            "{ type: NgForm, selector: 'form', exportAs: ['ngForm'] }",
+        );
+        assert!(
+            result.contains("exportAs: [\"ngForm\"]"),
+            "expected exportAs emitted from array form: {result}"
+        );
+    }
+
+    #[test]
+    fn test_directive_export_as_string_array_multiple() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', exportAs: ['a', 'b'] }",
+        );
+        assert!(
+            result.contains("exportAs: [\"a\", \"b\"]"),
+            "expected multi-name exportAs array: {result}"
+        );
+    }
+
+    #[test]
+    fn test_directive_export_as_string_legacy() {
+        // Legacy comma-separated string form must still work.
+        let result =
+            parse_and_transform("{ type: MyDir, selector: '[myDir]', exportAs: 'foo,bar' }");
+        assert!(
+            result.contains("exportAs: [\"foo\", \"bar\"]"),
+            "expected comma-split string exportAs: {result}"
+        );
     }
 
     #[test]

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -879,9 +879,8 @@ mod tests {
         // (e.g. @angular/forms' NgForm).  The linker must transfer it into
         // the emitted `ɵɵdefineDirective` call, otherwise runtime
         // ref lookups with `#ref="exportAsName"` fail with NG0301.
-        let result = parse_and_transform(
-            "{ type: NgForm, selector: 'form', exportAs: ['ngForm'] }",
-        );
+        let result =
+            parse_and_transform("{ type: NgForm, selector: 'form', exportAs: ['ngForm'] }");
         assert!(
             result.contains("exportAs: [\"ngForm\"]"),
             "expected exportAs emitted from array form: {result}"
@@ -890,9 +889,8 @@ mod tests {
 
     #[test]
     fn test_directive_export_as_string_array_multiple() {
-        let result = parse_and_transform(
-            "{ type: MyDir, selector: '[myDir]', exportAs: ['a', 'b'] }",
-        );
+        let result =
+            parse_and_transform("{ type: MyDir, selector: '[myDir]', exportAs: ['a', 'b'] }");
         assert!(
             result.contains("exportAs: [\"a\", \"b\"]"),
             "expected multi-name exportAs array: {result}"

--- a/crates/linker/src/metadata.rs
+++ b/crates/linker/src/metadata.rs
@@ -50,6 +50,34 @@ pub fn get_string_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<String> 
     None
 }
 
+/// Extract a string-array value for a named property.
+///
+/// Returns the string contents of each element if the property exists and
+/// its value is an array of string literals
+/// (e.g. `exportAs: ['ngForm', 'abc']`).  Returns `None` for non-array
+/// forms — callers that need to fall back to a string literal should
+/// check `get_string_prop` separately.
+pub fn get_string_array_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<Vec<String>> {
+    for prop in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(p) = prop {
+            if property_key_matches(&p.key, key) {
+                if let Expression::ArrayExpression(arr) = &p.value {
+                    let mut out = Vec::with_capacity(arr.elements.len());
+                    for elem in &arr.elements {
+                        if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
+                            out.push(s.value.to_string());
+                        } else {
+                            return None;
+                        }
+                    }
+                    return Some(out);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Extract a boolean literal value for a named property.
 pub fn get_bool_prop(obj: &ObjectExpression<'_>, key: &str) -> Option<bool> {
     for prop in &obj.properties {

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use ngc_diagnostics::NgcResult;
 
@@ -57,6 +57,10 @@ struct IvyCodegen {
     /// This counter tracks the pipe-relative offset (0, 2, 5, …) which
     /// `rewrite_pipe_offsets` later shifts by the sequential binding count.
     pipe_var_offset: u32,
+    /// Template reference variables declared in the current template scope.
+    /// Maps `#refName` → LView slot that stores the resolved ref value.
+    /// Binding expressions reading these names are rewritten to `ɵɵreference(slot)`.
+    template_refs: BTreeMap<String, u32>,
 }
 
 struct ChildTemplate {
@@ -87,6 +91,7 @@ pub fn generate_ivy(
         scope_stack: Vec::new(),
         last_update_slot: None,
         pipe_var_offset: 0,
+        template_refs: BTreeMap::new(),
     };
 
     gen.ivy_imports
@@ -387,19 +392,53 @@ impl IvyCodegen {
             None
         };
 
+        // Collect template reference variables on this element (e.g.
+        // `#profileForm="ngForm"`, `#fileInput`).  Register a consts entry
+        // `[name, exportAs]` per ref — Angular's runtime populates the ref
+        // value into the LView slot immediately following the element.
+        let refs: Vec<(String, String)> = el
+            .attributes
+            .iter()
+            .filter_map(|a| match a {
+                TemplateAttribute::Reference { name, export_as } => {
+                    Some((name.clone(), export_as.clone().unwrap_or_default()))
+                }
+                _ => None,
+            })
+            .collect();
+        let refs_const_idx = if refs.is_empty() {
+            None
+        } else {
+            Some(self.register_refs_const(&refs))
+        };
+
         if el.is_void && !is_ng_container && !has_events {
             let instr = "\u{0275}\u{0275}element";
             self.ivy_imports.insert(instr.to_string());
-            if let Some(ci) = const_idx {
-                self.creation
-                    .push(format!("{instr}({slot}, '{}', {ci});", el.tag));
-            } else {
-                self.creation
-                    .push(format!("{instr}({slot}, '{}');", el.tag));
+            match (const_idx, refs_const_idx) {
+                (Some(ci), Some(ri)) => self
+                    .creation
+                    .push(format!("{instr}({slot}, '{}', {ci}, {ri});", el.tag)),
+                (Some(ci), None) => self
+                    .creation
+                    .push(format!("{instr}({slot}, '{}', {ci});", el.tag)),
+                (None, Some(ri)) => self
+                    .creation
+                    .push(format!("{instr}({slot}, '{}', null, {ri});", el.tag)),
+                (None, None) => self
+                    .creation
+                    .push(format!("{instr}({slot}, '{}');", el.tag)),
             }
+
+            // Allocate ref slots BEFORE emitting bindings so that expressions
+            // using the ref name can resolve to the correct ɵɵreference(slot).
+            self.reserve_template_refs(&refs);
 
             // Bindings for void elements
             self.emit_element_bindings(el, slot);
+
+            // Emit ɵɵreference(slot) calls to register the refs at their slots.
+            self.emit_reference_calls(&refs);
         } else {
             let (start_instr, end_instr) = if is_ng_container {
                 (
@@ -412,18 +451,36 @@ impl IvyCodegen {
             self.ivy_imports.insert(start_instr.to_string());
             self.ivy_imports.insert(end_instr.to_string());
             if is_ng_container {
-                if let Some(ci) = const_idx {
-                    self.creation.push(format!("{start_instr}({slot}, {ci});"));
-                } else {
-                    self.creation.push(format!("{start_instr}({slot});"));
+                match (const_idx, refs_const_idx) {
+                    (Some(ci), Some(ri)) => self
+                        .creation
+                        .push(format!("{start_instr}({slot}, {ci}, {ri});")),
+                    (Some(ci), None) => self.creation.push(format!("{start_instr}({slot}, {ci});")),
+                    (None, Some(ri)) => self
+                        .creation
+                        .push(format!("{start_instr}({slot}, null, {ri});")),
+                    (None, None) => self.creation.push(format!("{start_instr}({slot});")),
                 }
-            } else if let Some(ci) = const_idx {
-                self.creation
-                    .push(format!("{start_instr}({slot}, '{}', {ci});", el.tag));
             } else {
-                self.creation
-                    .push(format!("{start_instr}({slot}, '{}');", el.tag));
+                match (const_idx, refs_const_idx) {
+                    (Some(ci), Some(ri)) => self
+                        .creation
+                        .push(format!("{start_instr}({slot}, '{}', {ci}, {ri});", el.tag)),
+                    (Some(ci), None) => self
+                        .creation
+                        .push(format!("{start_instr}({slot}, '{}', {ci});", el.tag)),
+                    (None, Some(ri)) => self
+                        .creation
+                        .push(format!("{start_instr}({slot}, '{}', null, {ri});", el.tag)),
+                    (None, None) => self
+                        .creation
+                        .push(format!("{start_instr}({slot}, '{}');", el.tag)),
+                }
             }
+
+            // Allocate ref slots BEFORE listeners, bindings, or children.
+            // Listener bodies and descendant bindings may reference these names.
+            self.reserve_template_refs(&refs);
 
             // Event listeners and two-way binding listeners in creation block
             for attr in &el.attributes {
@@ -431,7 +488,7 @@ impl IvyCodegen {
                     TemplateAttribute::Event { name, handler } => {
                         self.ivy_imports
                             .insert("\u{0275}\u{0275}listener".to_string());
-                        let compiled_handler = compile_event_handler(handler, &self.local_vars);
+                        let compiled_handler = self.compile_listener_handler(handler);
                         let depth = self.scope_depth();
                         if depth > 0 {
                             self.ivy_imports
@@ -454,6 +511,7 @@ impl IvyCodegen {
                         self.ivy_imports
                             .insert("\u{0275}\u{0275}listener".to_string());
                         let depth = self.scope_depth();
+                        let compiled_target = self.rewrite_refs_in_expr(&ctx_expr(expression));
                         if depth > 0 {
                             self.ivy_imports
                                 .insert("\u{0275}\u{0275}restoreView".to_string());
@@ -461,13 +519,13 @@ impl IvyCodegen {
                                 .insert("\u{0275}\u{0275}nextContext".to_string());
                             let listener_preamble = self.generate_listener_preamble();
                             self.creation.push(format!(
-                                "\u{0275}\u{0275}listener('{}Change', function($event) {{ {listener_preamble}return {} = $event; }});",
-                                name, ctx_expr(expression)
+                                "\u{0275}\u{0275}listener('{}Change', function($event) {{ {listener_preamble}return {compiled_target} = $event; }});",
+                                name,
                             ));
                         } else {
                             self.creation.push(format!(
-                                "\u{0275}\u{0275}listener('{}Change', function($event) {{ return {} = $event; }});",
-                                name, ctx_expr(expression)
+                                "\u{0275}\u{0275}listener('{}Change', function($event) {{ return {compiled_target} = $event; }});",
+                                name,
                             ));
                         }
                     }
@@ -484,18 +542,61 @@ impl IvyCodegen {
 
             self.creation.push(format!("{end_instr}();"));
 
-            // Template reference variables
-            for attr in &el.attributes {
-                if let TemplateAttribute::Reference { .. } = attr {
-                    self.ivy_imports
-                        .insert("\u{0275}\u{0275}reference".to_string());
-                    let ref_slot = self.slot_index;
-                    self.slot_index += 1;
-                    self.creation
-                        .push(format!("\u{0275}\u{0275}reference({ref_slot});"));
-                }
+            // Emit ɵɵreference(slot) calls after elementEnd to register the
+            // refs at their pre-reserved slots (matches Angular's output).
+            self.emit_reference_calls(&refs);
+        }
+    }
+
+    /// Reserve a slot for each template reference on the current element and
+    /// register the ref in `template_refs` + `local_vars` so binding
+    /// expressions can resolve it.
+    fn reserve_template_refs(&mut self, refs: &[(String, String)]) {
+        if refs.is_empty() {
+            return;
+        }
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}reference".to_string());
+        for (name, _) in refs {
+            let ref_slot = self.slot_index;
+            self.slot_index += 1;
+            self.template_refs.insert(name.clone(), ref_slot);
+            self.local_vars.insert(name.clone());
+        }
+    }
+
+    /// Emit `ɵɵreference(slot);` creation-mode calls for each ref in order.
+    fn emit_reference_calls(&mut self, refs: &[(String, String)]) {
+        for (name, _) in refs {
+            if let Some(&slot) = self.template_refs.get(name) {
+                self.creation
+                    .push(format!("\u{0275}\u{0275}reference({slot});"));
             }
         }
+    }
+
+    /// Compile an event-handler expression with current locals and apply
+    /// template-reference rewriting so `refName.foo()` becomes
+    /// `ɵɵreference(slot).foo()` instead of `ctx.refName.foo()`.
+    fn compile_listener_handler(&mut self, handler: &str) -> String {
+        let compiled = compile_event_handler(handler, &self.local_vars);
+        self.rewrite_refs_in_expr(&compiled)
+    }
+
+    /// Replace bare identifier uses of template-reference names in `expr`
+    /// with `ɵɵreference(slot)`.  Ref identifiers are registered in
+    /// `local_vars` so prior `ctx_expr_with_locals` calls leave them
+    /// untouched; this pass substitutes the actual runtime lookup.
+    fn rewrite_refs_in_expr(&mut self, expr: &str) -> String {
+        if self.template_refs.is_empty() {
+            return expr.to_string();
+        }
+        let rewritten = rewrite_ref_identifiers(expr, &self.template_refs);
+        if rewritten != expr {
+            self.ivy_imports
+                .insert("\u{0275}\u{0275}reference".to_string());
+        }
+        rewritten
     }
 
     /// Desugar a structural directive (*ngIf, *ngFor) to an ng-template wrapper.
@@ -582,6 +683,7 @@ impl IvyCodegen {
         let parent_update = std::mem::take(&mut self.update);
         let parent_consts = std::mem::take(&mut self.consts);
         let parent_lets = self.let_declarations.clone();
+        let parent_refs = std::mem::take(&mut self.template_refs);
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -635,6 +737,7 @@ impl IvyCodegen {
         self.update = parent_update;
         self.consts = parent_consts;
         self.let_declarations = parent_lets;
+        self.template_refs = parent_refs;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -1012,6 +1115,7 @@ impl IvyCodegen {
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_lets = self.let_declarations.clone();
+        let parent_refs = std::mem::take(&mut self.template_refs);
         self.scope_stack.push(ScopeEntry::Conditional);
 
         self.slot_index = 0;
@@ -1020,6 +1124,8 @@ impl IvyCodegen {
         self.last_update_slot = None;
         // Don't clear let_declarations, local_vars, or consts — children
         // inherit parent scope and share the component-level consts array.
+        // template_refs, however, is scoped per-template: refs live in a
+        // specific LView's slot space and can't cross TView boundaries.
 
         self.generate_nodes(children);
 
@@ -1086,6 +1192,7 @@ impl IvyCodegen {
         self.creation = parent_creation;
         self.update = parent_update;
         self.let_declarations = parent_lets;
+        self.template_refs = parent_refs;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -1109,6 +1216,7 @@ impl IvyCodegen {
         let parent_creation = std::mem::take(&mut self.creation);
         let parent_update = std::mem::take(&mut self.update);
         let parent_lets = self.let_declarations.clone();
+        let parent_refs = std::mem::take(&mut self.template_refs);
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -1193,6 +1301,7 @@ impl IvyCodegen {
         self.update = parent_update;
         self.let_declarations = parent_lets;
         self.local_vars = parent_locals;
+        self.template_refs = parent_refs;
 
         ChildTemplate {
             function_name: fn_name.to_string(),
@@ -1280,16 +1389,17 @@ impl IvyCodegen {
 
     fn compile_binding_expr(&mut self, expression: &str) -> String {
         let segments = extract_all_pipe_segments(expression);
-        if segments.is_empty() {
+        let compiled = if segments.is_empty() {
             // No pipes found — just compile with ctx. prefix
-            return ctx_expr_with_locals(expression, &self.local_vars);
-        }
-
-        // First segment is the base expression, rest are pipe names
-        // But pipes can be nested in sub-expressions. We need to replace
-        // pipe segments bottom-up. For simplicity, handle the common pattern:
-        // the entire expression or sub-expressions of form `(expr | pipe)`.
-        self.replace_pipes_in_expr(expression)
+            ctx_expr_with_locals(expression, &self.local_vars)
+        } else {
+            // First segment is the base expression, rest are pipe names
+            // But pipes can be nested in sub-expressions. We need to replace
+            // pipe segments bottom-up. For simplicity, handle the common pattern:
+            // the entire expression or sub-expressions of form `(expr | pipe)`.
+            self.replace_pipes_in_expr(expression)
+        };
+        self.rewrite_refs_in_expr(&compiled)
     }
 
     /// Replace all `expr | pipeName` patterns in an expression with `ɵɵpipeBind*` calls.
@@ -1355,6 +1465,22 @@ impl IvyCodegen {
         binding_names: &[&str],
     ) -> usize {
         let formatted = format_attrs_with_bindings(attrs, binding_names);
+        let idx = self.consts.len();
+        self.consts.push(formatted);
+        idx
+    }
+
+    /// Register a consts entry describing the template-reference variables
+    /// on an element, e.g. `['profileForm', 'ngForm']` or `['fileInput', '']`.
+    /// Multiple refs on the same element flatten into a single entry:
+    /// `['a', '', 'b', 'bDirective']`.
+    fn register_refs_const(&mut self, refs: &[(String, String)]) -> usize {
+        let mut parts = Vec::with_capacity(refs.len() * 2);
+        for (name, export_as) in refs {
+            parts.push(format!("'{}'", escape_js_string(name)));
+            parts.push(format!("'{}'", escape_js_string(export_as)));
+        }
+        let formatted = format!("[{}]", parts.join(", "));
         let idx = self.consts.len();
         self.consts.push(formatted);
         idx
@@ -1949,6 +2075,174 @@ fn compile_pipe_arg(arg: &str, locals: &BTreeSet<String>) -> String {
             .to_string()
     } else {
         ctx_expr_with_locals(arg, locals)
+    }
+}
+
+/// Replace bare-identifier uses of template reference names with
+/// `ɵɵreference(slot)` calls.  Operates on an expression that has already
+/// passed through `ctx_expr_with_locals`, so ref names appear unprefixed
+/// (they were registered in `local_vars`).  Uses oxc to walk identifiers
+/// in the AST — string literals and member-property names are left alone.
+fn rewrite_ref_identifiers(expr: &str, refs: &BTreeMap<String, u32>) -> String {
+    use oxc_ast::ast::*;
+
+    if refs.is_empty() {
+        return expr.to_string();
+    }
+    let trimmed = expr.trim();
+    if trimmed.is_empty() {
+        return expr.to_string();
+    }
+
+    let wrapper = format!("var __expr = {trimmed};");
+    let alloc = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&alloc, &wrapper, oxc_span::SourceType::tsx()).parse();
+    if !parsed.errors.is_empty() || parsed.panicked {
+        return expr.to_string();
+    }
+
+    let init_expr = match parsed.program.body.first() {
+        Some(Statement::VariableDeclaration(decl)) => {
+            decl.declarations.first().and_then(|d| d.init.as_ref())
+        }
+        _ => None,
+    };
+    let init_expr = match init_expr {
+        Some(e) => e,
+        None => return expr.to_string(),
+    };
+
+    // Collect (start, end, slot) spans for identifiers that match a ref name.
+    let mut replacements: Vec<(u32, u32, u32)> = Vec::new();
+    collect_ref_replacements(init_expr, refs, &mut replacements, false);
+
+    if replacements.is_empty() {
+        return expr.to_string();
+    }
+
+    // Sort by start descending so we can rewrite back-to-front without
+    // invalidating earlier offsets.  Map wrapper offsets to expression offsets.
+    let expr_offset = "var __expr = ".len() as u32;
+    let mut adj: Vec<(usize, usize, u32)> = replacements
+        .into_iter()
+        .map(|(s, e, slot)| ((s - expr_offset) as usize, (e - expr_offset) as usize, slot))
+        .collect();
+    adj.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+
+    let mut result = trimmed.to_string();
+    for (s, e, slot) in adj {
+        if s <= result.len()
+            && e <= result.len()
+            && result.is_char_boundary(s)
+            && result.is_char_boundary(e)
+        {
+            result.replace_range(s..e, &format!("\u{0275}\u{0275}reference({slot})"));
+        }
+    }
+    result
+}
+
+fn collect_ref_replacements(
+    expr: &oxc_ast::ast::Expression<'_>,
+    refs: &BTreeMap<String, u32>,
+    out: &mut Vec<(u32, u32, u32)>,
+    is_member_property: bool,
+) {
+    use oxc_ast::ast::*;
+
+    match expr {
+        Expression::Identifier(id) if !is_member_property => {
+            if let Some(&slot) = refs.get(id.name.as_str()) {
+                out.push((id.span.start, id.span.end, slot));
+            }
+        }
+        Expression::CallExpression(call) => {
+            collect_ref_replacements(&call.callee, refs, out, false);
+            for arg in &call.arguments {
+                if let Argument::SpreadElement(spread) = arg {
+                    collect_ref_replacements(&spread.argument, refs, out, false);
+                } else {
+                    collect_ref_replacements(arg.to_expression(), refs, out, false);
+                }
+            }
+        }
+        Expression::StaticMemberExpression(member) => {
+            collect_ref_replacements(&member.object, refs, out, false);
+        }
+        Expression::ComputedMemberExpression(member) => {
+            collect_ref_replacements(&member.object, refs, out, false);
+            collect_ref_replacements(&member.expression, refs, out, false);
+        }
+        Expression::UnaryExpression(unary) => {
+            collect_ref_replacements(&unary.argument, refs, out, false);
+        }
+        Expression::BinaryExpression(binary) => {
+            collect_ref_replacements(&binary.left, refs, out, false);
+            collect_ref_replacements(&binary.right, refs, out, false);
+        }
+        Expression::LogicalExpression(logical) => {
+            collect_ref_replacements(&logical.left, refs, out, false);
+            collect_ref_replacements(&logical.right, refs, out, false);
+        }
+        Expression::ConditionalExpression(cond) => {
+            collect_ref_replacements(&cond.test, refs, out, false);
+            collect_ref_replacements(&cond.consequent, refs, out, false);
+            collect_ref_replacements(&cond.alternate, refs, out, false);
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            collect_ref_replacements(&paren.expression, refs, out, false);
+        }
+        Expression::AssignmentExpression(assign) => {
+            collect_ref_replacements(&assign.right, refs, out, false);
+        }
+        Expression::TSNonNullExpression(non_null) => {
+            collect_ref_replacements(&non_null.expression, refs, out, is_member_property);
+        }
+        Expression::ObjectExpression(obj) => {
+            for prop in &obj.properties {
+                if let ObjectPropertyKind::ObjectProperty(p) = prop {
+                    collect_ref_replacements(&p.value, refs, out, false);
+                }
+            }
+        }
+        Expression::ArrayExpression(arr) => {
+            for elem in &arr.elements {
+                if let ArrayExpressionElement::SpreadElement(spread) = elem {
+                    collect_ref_replacements(&spread.argument, refs, out, false);
+                } else if !elem.is_elision() {
+                    collect_ref_replacements(elem.to_expression(), refs, out, false);
+                }
+            }
+        }
+        Expression::TemplateLiteral(tpl) => {
+            for e in &tpl.expressions {
+                collect_ref_replacements(e, refs, out, false);
+            }
+        }
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(call) => {
+                collect_ref_replacements(&call.callee, refs, out, false);
+                for arg in &call.arguments {
+                    if let Argument::SpreadElement(spread) = arg {
+                        collect_ref_replacements(&spread.argument, refs, out, false);
+                    } else {
+                        collect_ref_replacements(arg.to_expression(), refs, out, false);
+                    }
+                }
+            }
+            ChainElement::StaticMemberExpression(member) => {
+                collect_ref_replacements(&member.object, refs, out, false);
+            }
+            ChainElement::ComputedMemberExpression(member) => {
+                collect_ref_replacements(&member.object, refs, out, false);
+                collect_ref_replacements(&member.expression, refs, out, false);
+            }
+            ChainElement::TSNonNullExpression(non_null) => {
+                collect_ref_replacements(&non_null.expression, refs, out, false);
+            }
+            _ => {}
+        },
+        _ => {}
     }
 }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -2995,6 +2995,59 @@ mod tests {
     }
 
     #[test]
+    fn test_template_reference_var_resolves_via_ivy_reference() {
+        // `<form #profileForm="ngForm"><button [disabled]="!profileForm.form.valid"></button></form>`
+        // The ref must:
+        //   - appear in consts as ['profileForm','ngForm']
+        //   - be passed as the 4th arg to elementStart on the form
+        //   - resolve in the update block via ɵɵreference(slot) — NOT ctx.profileForm
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "form".to_string(),
+            attributes: vec![TemplateAttribute::Reference {
+                name: "profileForm".to_string(),
+                export_as: Some("ngForm".to_string()),
+            }],
+            children: vec![TemplateNode::Element(ElementNode {
+                tag: "button".to_string(),
+                attributes: vec![TemplateAttribute::Property {
+                    name: "disabled".to_string(),
+                    expression: "!profileForm.form.valid".to_string(),
+                }],
+                children: vec![],
+                is_void: false,
+            })],
+            is_void: false,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        let dc = &output.static_fields[0];
+        assert!(
+            output
+                .consts
+                .iter()
+                .any(|c| c.contains("'profileForm'") && c.contains("'ngForm'")),
+            "consts should include ref entry ['profileForm','ngForm']: {:?}",
+            output.consts
+        );
+        let form_start = dc
+            .lines()
+            .find(|l| l.contains("elementStart") && l.contains("'form'"))
+            .unwrap_or("");
+        assert!(
+            form_start.matches(',').count() >= 3,
+            "form elementStart must pass refsIdx as 4th arg: {form_start}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}reference("),
+            "update block should emit ɵɵreference(slot) for ref use: {dc}"
+        );
+        assert!(
+            !dc.contains("ctx.profileForm"),
+            "ref name must not be prefixed with ctx.: {dc}"
+        );
+    }
+
+    #[test]
     fn test_valueless_attribute_included_in_consts() {
         // Value-less attributes (e.g. `baseChart` on `<canvas baseChart>`)
         // must appear in the consts array with an empty-string value so that

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -118,6 +118,11 @@ pub fn generate_ivy(
     }
     if !gen.update.is_empty() {
         template_body.push_str("    if (rf & 2) {\n");
+        // Root template: `ctx` is the function parameter, so refs can be
+        // read anywhere — but emit them at the top so bindings below can
+        // use the bare identifier names and not refer to ɵɵreference().
+        let ref_prelude = gen.build_ref_reads_prelude("      ");
+        template_body.push_str(&ref_prelude);
         for instr in &gen.update {
             template_body.push_str("      ");
             let rewritten = rewrite_pipe_offsets(instr, seq_bindings);
@@ -511,7 +516,10 @@ impl IvyCodegen {
                         self.ivy_imports
                             .insert("\u{0275}\u{0275}listener".to_string());
                         let depth = self.scope_depth();
-                        let compiled_target = self.rewrite_refs_in_expr(&ctx_expr(expression));
+                        // Template refs stay as bare identifiers; they resolve
+                        // via the `const <name> = ɵɵreference(<slot>);` prelude
+                        // at the top of the update block / listener body.
+                        let compiled_target = ctx_expr_with_locals(expression, &self.local_vars);
                         if depth > 0 {
                             self.ivy_imports
                                 .insert("\u{0275}\u{0275}restoreView".to_string());
@@ -565,38 +573,39 @@ impl IvyCodegen {
         }
     }
 
-    /// Emit `ɵɵreference(slot);` creation-mode calls for each ref in order.
-    fn emit_reference_calls(&mut self, refs: &[(String, String)]) {
-        for (name, _) in refs {
-            if let Some(&slot) = self.template_refs.get(name) {
-                self.creation
-                    .push(format!("\u{0275}\u{0275}reference({slot});"));
-            }
-        }
-    }
+    /// No-op: ref slots are auto-allocated by Angular's runtime based on the
+    /// `localRefsIndex` arg passed to `ɵɵelementStart`.  Emitting an explicit
+    /// creation-mode `ɵɵreference(slot);` call causes double-registration and
+    /// trips the Angular `assertIndexInRange` check at runtime.
+    fn emit_reference_calls(&mut self, _refs: &[(String, String)]) {}
 
-    /// Compile an event-handler expression with current locals and apply
-    /// template-reference rewriting so `refName.foo()` becomes
-    /// `ɵɵreference(slot).foo()` instead of `ctx.refName.foo()`.
+    /// Compile an event-handler expression with current locals.
+    /// Template references inside the handler stay as bare identifiers;
+    /// they resolve through the `const <name> = ɵɵreference(<slot>);`
+    /// declarations injected at the top of the listener body by
+    /// `build_ref_reads_prelude()`.
     fn compile_listener_handler(&mut self, handler: &str) -> String {
-        let compiled = compile_event_handler(handler, &self.local_vars);
-        self.rewrite_refs_in_expr(&compiled)
+        compile_event_handler(handler, &self.local_vars)
     }
 
-    /// Replace bare identifier uses of template-reference names in `expr`
-    /// with `ɵɵreference(slot)`.  Ref identifiers are registered in
-    /// `local_vars` so prior `ctx_expr_with_locals` calls leave them
-    /// untouched; this pass substitutes the actual runtime lookup.
-    fn rewrite_refs_in_expr(&mut self, expr: &str) -> String {
+    /// Build the `const <name> = ɵɵreference(<slot>);` prelude that must be
+    /// emitted BEFORE any `ɵɵnextContext()` call (the latter changes the
+    /// context LView, so a subsequent `ɵɵreference()` would read from the
+    /// wrong LView).  Returns an empty string when there are no refs in
+    /// the current scope.
+    fn build_ref_reads_prelude(&mut self, indent: &str) -> String {
         if self.template_refs.is_empty() {
-            return expr.to_string();
+            return String::new();
         }
-        let rewritten = rewrite_ref_identifiers(expr, &self.template_refs);
-        if rewritten != expr {
-            self.ivy_imports
-                .insert("\u{0275}\u{0275}reference".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}reference".to_string());
+        let mut code = String::new();
+        for (name, slot) in &self.template_refs {
+            code.push_str(&format!(
+                "{indent}const {name} = \u{0275}\u{0275}reference({slot});\n"
+            ));
         }
-        rewritten
+        code
     }
 
     /// Desugar a structural directive (*ngIf, *ngFor) to an ng-template wrapper.
@@ -1157,6 +1166,10 @@ impl IvyCodegen {
             code.push_str("  if (rf & 2) {\n");
             self.ivy_imports
                 .insert("\u{0275}\u{0275}nextContext".to_string());
+            // Template-reference reads MUST come before ɵɵnextContext —
+            // ɵɵreference(slot) reads the current context LView, and
+            // nextContext switches that context to the parent.
+            code.push_str(&self.build_ref_reads_prelude("    "));
             // Use the scope stack to generate context navigation
             code.push_str(&self.generate_context_navigation());
             // Inject @let variable reads from parent context
@@ -1258,6 +1271,9 @@ impl IvyCodegen {
             // Extract item from _ctx and component context.
             // Order matches ng build: item first, then nextContext.
             code.push_str(&format!("    const {item_name} = _ctx.$implicit;\n"));
+            // Template-reference reads must run BEFORE ɵɵnextContext —
+            // ɵɵreference reads the current context LView.
+            code.push_str(&self.build_ref_reads_prelude("    "));
             let comp_depth = self.scope_stack.len() as u32;
             self.ivy_imports
                 .insert("\u{0275}\u{0275}nextContext".to_string());
@@ -1389,17 +1405,14 @@ impl IvyCodegen {
 
     fn compile_binding_expr(&mut self, expression: &str) -> String {
         let segments = extract_all_pipe_segments(expression);
-        let compiled = if segments.is_empty() {
-            // No pipes found — just compile with ctx. prefix
-            ctx_expr_with_locals(expression, &self.local_vars)
-        } else {
-            // First segment is the base expression, rest are pipe names
-            // But pipes can be nested in sub-expressions. We need to replace
-            // pipe segments bottom-up. For simplicity, handle the common pattern:
-            // the entire expression or sub-expressions of form `(expr | pipe)`.
-            self.replace_pipes_in_expr(expression)
-        };
-        self.rewrite_refs_in_expr(&compiled)
+        if segments.is_empty() {
+            // No pipes found — just compile with ctx. prefix.
+            // Template-reference names are in `local_vars` so they're left
+            // unprefixed; the `const <name> = ɵɵreference(<slot>);` prelude
+            // at the top of the update block resolves them at runtime.
+            return ctx_expr_with_locals(expression, &self.local_vars);
+        }
+        self.replace_pipes_in_expr(expression)
     }
 
     /// Replace all `expr | pipeName` patterns in an expression with `ɵɵpipeBind*` calls.
@@ -1568,6 +1581,14 @@ impl IvyCodegen {
     /// with listener-appropriate single-line formatting.
     fn generate_listener_preamble(&self) -> String {
         let mut code = String::from("\u{0275}\u{0275}restoreView(_r); ");
+        // Template-reference reads must come BEFORE ɵɵnextContext —
+        // `ɵɵreference(slot)` uses the current context LView, and
+        // nextContext switches that context to the parent.
+        for (name, slot) in &self.template_refs {
+            code.push_str(&format!(
+                "const {name} = \u{0275}\u{0275}reference({slot}); "
+            ));
+        }
         if self.scope_stack.is_empty() {
             return code;
         }
@@ -2075,174 +2096,6 @@ fn compile_pipe_arg(arg: &str, locals: &BTreeSet<String>) -> String {
             .to_string()
     } else {
         ctx_expr_with_locals(arg, locals)
-    }
-}
-
-/// Replace bare-identifier uses of template reference names with
-/// `ɵɵreference(slot)` calls.  Operates on an expression that has already
-/// passed through `ctx_expr_with_locals`, so ref names appear unprefixed
-/// (they were registered in `local_vars`).  Uses oxc to walk identifiers
-/// in the AST — string literals and member-property names are left alone.
-fn rewrite_ref_identifiers(expr: &str, refs: &BTreeMap<String, u32>) -> String {
-    use oxc_ast::ast::*;
-
-    if refs.is_empty() {
-        return expr.to_string();
-    }
-    let trimmed = expr.trim();
-    if trimmed.is_empty() {
-        return expr.to_string();
-    }
-
-    let wrapper = format!("var __expr = {trimmed};");
-    let alloc = oxc_allocator::Allocator::default();
-    let parsed = oxc_parser::Parser::new(&alloc, &wrapper, oxc_span::SourceType::tsx()).parse();
-    if !parsed.errors.is_empty() || parsed.panicked {
-        return expr.to_string();
-    }
-
-    let init_expr = match parsed.program.body.first() {
-        Some(Statement::VariableDeclaration(decl)) => {
-            decl.declarations.first().and_then(|d| d.init.as_ref())
-        }
-        _ => None,
-    };
-    let init_expr = match init_expr {
-        Some(e) => e,
-        None => return expr.to_string(),
-    };
-
-    // Collect (start, end, slot) spans for identifiers that match a ref name.
-    let mut replacements: Vec<(u32, u32, u32)> = Vec::new();
-    collect_ref_replacements(init_expr, refs, &mut replacements, false);
-
-    if replacements.is_empty() {
-        return expr.to_string();
-    }
-
-    // Sort by start descending so we can rewrite back-to-front without
-    // invalidating earlier offsets.  Map wrapper offsets to expression offsets.
-    let expr_offset = "var __expr = ".len() as u32;
-    let mut adj: Vec<(usize, usize, u32)> = replacements
-        .into_iter()
-        .map(|(s, e, slot)| ((s - expr_offset) as usize, (e - expr_offset) as usize, slot))
-        .collect();
-    adj.sort_by_key(|entry| std::cmp::Reverse(entry.0));
-
-    let mut result = trimmed.to_string();
-    for (s, e, slot) in adj {
-        if s <= result.len()
-            && e <= result.len()
-            && result.is_char_boundary(s)
-            && result.is_char_boundary(e)
-        {
-            result.replace_range(s..e, &format!("\u{0275}\u{0275}reference({slot})"));
-        }
-    }
-    result
-}
-
-fn collect_ref_replacements(
-    expr: &oxc_ast::ast::Expression<'_>,
-    refs: &BTreeMap<String, u32>,
-    out: &mut Vec<(u32, u32, u32)>,
-    is_member_property: bool,
-) {
-    use oxc_ast::ast::*;
-
-    match expr {
-        Expression::Identifier(id) if !is_member_property => {
-            if let Some(&slot) = refs.get(id.name.as_str()) {
-                out.push((id.span.start, id.span.end, slot));
-            }
-        }
-        Expression::CallExpression(call) => {
-            collect_ref_replacements(&call.callee, refs, out, false);
-            for arg in &call.arguments {
-                if let Argument::SpreadElement(spread) = arg {
-                    collect_ref_replacements(&spread.argument, refs, out, false);
-                } else {
-                    collect_ref_replacements(arg.to_expression(), refs, out, false);
-                }
-            }
-        }
-        Expression::StaticMemberExpression(member) => {
-            collect_ref_replacements(&member.object, refs, out, false);
-        }
-        Expression::ComputedMemberExpression(member) => {
-            collect_ref_replacements(&member.object, refs, out, false);
-            collect_ref_replacements(&member.expression, refs, out, false);
-        }
-        Expression::UnaryExpression(unary) => {
-            collect_ref_replacements(&unary.argument, refs, out, false);
-        }
-        Expression::BinaryExpression(binary) => {
-            collect_ref_replacements(&binary.left, refs, out, false);
-            collect_ref_replacements(&binary.right, refs, out, false);
-        }
-        Expression::LogicalExpression(logical) => {
-            collect_ref_replacements(&logical.left, refs, out, false);
-            collect_ref_replacements(&logical.right, refs, out, false);
-        }
-        Expression::ConditionalExpression(cond) => {
-            collect_ref_replacements(&cond.test, refs, out, false);
-            collect_ref_replacements(&cond.consequent, refs, out, false);
-            collect_ref_replacements(&cond.alternate, refs, out, false);
-        }
-        Expression::ParenthesizedExpression(paren) => {
-            collect_ref_replacements(&paren.expression, refs, out, false);
-        }
-        Expression::AssignmentExpression(assign) => {
-            collect_ref_replacements(&assign.right, refs, out, false);
-        }
-        Expression::TSNonNullExpression(non_null) => {
-            collect_ref_replacements(&non_null.expression, refs, out, is_member_property);
-        }
-        Expression::ObjectExpression(obj) => {
-            for prop in &obj.properties {
-                if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                    collect_ref_replacements(&p.value, refs, out, false);
-                }
-            }
-        }
-        Expression::ArrayExpression(arr) => {
-            for elem in &arr.elements {
-                if let ArrayExpressionElement::SpreadElement(spread) = elem {
-                    collect_ref_replacements(&spread.argument, refs, out, false);
-                } else if !elem.is_elision() {
-                    collect_ref_replacements(elem.to_expression(), refs, out, false);
-                }
-            }
-        }
-        Expression::TemplateLiteral(tpl) => {
-            for e in &tpl.expressions {
-                collect_ref_replacements(e, refs, out, false);
-            }
-        }
-        Expression::ChainExpression(chain) => match &chain.expression {
-            ChainElement::CallExpression(call) => {
-                collect_ref_replacements(&call.callee, refs, out, false);
-                for arg in &call.arguments {
-                    if let Argument::SpreadElement(spread) = arg {
-                        collect_ref_replacements(&spread.argument, refs, out, false);
-                    } else {
-                        collect_ref_replacements(arg.to_expression(), refs, out, false);
-                    }
-                }
-            }
-            ChainElement::StaticMemberExpression(member) => {
-                collect_ref_replacements(&member.object, refs, out, false);
-            }
-            ChainElement::ComputedMemberExpression(member) => {
-                collect_ref_replacements(&member.object, refs, out, false);
-                collect_ref_replacements(&member.expression, refs, out, false);
-            }
-            ChainElement::TSNonNullExpression(non_null) => {
-                collect_ref_replacements(&non_null.expression, refs, out, false);
-            }
-            _ => {}
-        },
-        _ => {}
     }
 }
 


### PR DESCRIPTION
Closes #44.

## Summary

Two independent bugs made `treasr-frontend`'s `/profile` Security Settings and Appearance cards render blank below the first two cards. Both are fixed here.

### 1. `exportAs` array form dropped by the linker (`crates/linker/src/directive.rs`)

`ɵɵngDeclareDirective` emits `exportAs` as a string array, e.g. `exportAs: ["ngForm"]` (see @angular/forms' `NgForm`). The old linker code only accepted a string literal via `get_string_prop`, so `NgForm.ɵdir` was emitted with `exportAs: null`. Runtime lookups for `#profileForm="ngForm"` then threw `NG0301: Export of name 'ngForm' not found`, halting the embedded view's creation pass.

A new `get_string_array_prop` helper returns the flat `Vec<String>` when the value is an array literal; the directive transform tries the array form first, then falls back to the legacy comma-separated string form.

### 2. `#ref` template variables emitted as `ctx.ref` (`crates/template-compiler/src/codegen.rs`)

Template references on an element (`<form #profileForm="ngForm">`, `<input #fileInput>`) were not recognised by codegen. The `Reference` attribute variant was pattern-matched in the creation block but its `name` / `export_as` were ignored, and binding expressions like `!profileForm.form.valid` compiled to `!ctx.profileForm.form.valid`. `ctx.profileForm` is `undefined`, the update block threw a `TypeError` on the submit button's `[disabled]` binding, and Angular aborted the remainder of the update pass — leaving every binding past that point (the Security Settings and Appearance cards) rendered in initial blank state.

Fix:

- Register each `Reference` as a consts entry `['name', 'exportAs']`, reserve a slot for it immediately after the element's own slot, and pass the refs consts index as the 4th arg to `ɵɵelementStart(slot, tag, attrsIdx, refsIdx)` — matching the shape `@angular/build:application` produces.
- Track refs in a scoped `template_refs: BTreeMap<String, u32>` (saved/restored across child-template boundaries so refs don't leak across TView boundaries).
- Emit a `const <name> = ɵɵreference(<slot>);` prelude at the top of every update block and listener body that has refs in scope — **before** `ɵɵnextContext()`, because `ɵɵnextContext()` switches the context LView to the parent and a subsequent `ɵɵreference()` would read the wrong LView (trips `assertIndexInRange` at runtime).
- Register ref names in `local_vars` so `ctx_expr_with_locals` leaves them as bare identifiers; they resolve through the local const.

Also bumps workspace version to 0.7.12.

## Verification

- `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` — green.
- Regression tests added:
  - `test_template_reference_var_resolves_via_ivy_reference` — `<form #profileForm="ngForm">` compiles to `elementStart(…, refsIdx)` + `ɵɵreference(slot)` with no `ctx.profileForm` in output.
  - `test_directive_export_as_string_array` / `test_directive_export_as_string_array_multiple` — linker emits `exportAs: [...]` from the array form.
  - `test_directive_export_as_string_legacy` — legacy comma-separated string form still works.
- Rebuilt `treasr-frontend` with the patched binary and loaded `/profile` in the browser:
  - Security Settings heading + body + "Manage Account in LogTo" button text now render.
  - Appearance heading + "Theme" label + "Light" / "Dark" / "System" button labels now render.
  - Selected-theme chip (System) shows the `border-primary-600` highlight and the `check_circle` indicator.
  - `[disabled]="!profileForm.form.valid || profileForm.form.pristine"` on the submit button no longer throws.

## Test plan

- [x] Unit tests cover `#ref` compilation to `ɵɵreference(slot)` + consts ref entry + refsIdx
- [x] Unit tests cover linker accepting array-form `exportAs`
- [x] Workspace tests, clippy, fmt clean
- [x] treasr-frontend `/profile` renders Security + Appearance cards; theme selection indicator visible; no runtime errors (other than the pre-existing unrelated NG0203 on the callback route)