### PR TITLE
perf(linker): parallelize all three linker passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_span",
+ "rayon",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "criterion",
  "glob",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "clap",
  "colored",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.13"
+version = "0.7.14"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/Cargo.toml
+++ b/crates/linker/Cargo.toml
@@ -14,6 +14,7 @@ oxc_allocator = "0.122"
 oxc_parser = "0.122"
 oxc_ast = "0.122"
 oxc_span = "0.122"
+rayon = "1.11"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -33,6 +33,7 @@ use oxc_ast::ast::{
 };
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType, Span};
+use rayon::prelude::*;
 
 use crate::module_registry::ModuleRegistry;
 use crate::public_exports::PublicExports;
@@ -81,19 +82,27 @@ pub fn flatten_component_dependencies(
     if registry.is_empty() {
         return Ok(0);
     }
-    let paths: Vec<PathBuf> = modules
+
+    // Snapshot the (path, source) pairs for every file that contains a
+    // ɵɵdefineComponent call so the parallel transform phase owns its inputs
+    // and the module map stays immutable during the fan-out.
+    let work: Vec<(PathBuf, String)> = modules
         .iter()
         .filter(|(_, source)| source.contains("\u{0275}\u{0275}defineComponent"))
-        .map(|(path, _)| path.clone())
+        .map(|(path, source)| (path.clone(), source.clone()))
         .collect();
 
+    let results: Vec<(PathBuf, Option<String>)> = work
+        .par_iter()
+        .map(|(path, source)| -> NgcResult<(PathBuf, Option<String>)> {
+            let updated = flatten_one(source, path, registry, public_exports)?;
+            Ok((path.clone(), updated))
+        })
+        .collect::<NgcResult<Vec<_>>>()?;
+
     let mut rewritten = 0;
-    for path in paths {
-        let source = match modules.get(&path) {
-            Some(s) => s.clone(),
-            None => continue,
-        };
-        if let Some(updated) = flatten_one(&source, &path, registry, public_exports)? {
+    for (path, maybe_updated) in results {
+        if let Some(updated) = maybe_updated {
             modules.insert(path.clone(), updated);
             rewritten += 1;
             tracing::debug!(path = %path.display(), "flattened component dependencies");

--- a/crates/linker/src/lib.rs
+++ b/crates/linker/src/lib.rs
@@ -42,6 +42,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::NgcResult;
+use rayon::prelude::*;
 
 pub use module_registry::ModuleRegistry;
 pub use public_exports::PublicExports;
@@ -74,36 +75,39 @@ pub fn link_npm_modules(
     _project_root: &Path,
     registry: &ModuleRegistry,
 ) -> NgcResult<LinkerStats> {
-    let mut files_scanned = 0;
-    let mut files_linked = 0;
-
-    // Collect paths that need linking (can't mutate while iterating)
-    let paths_to_link: Vec<PathBuf> = modules
+    // Snapshot (path, source) for every npm file, then narrow to those whose
+    // source contains ɵɵngDeclare. Two-step so we can report accurate
+    // scan/link counts and so the parallel transform phase owns its inputs.
+    let npm_files: Vec<(&PathBuf, &String)> = modules
         .iter()
-        .filter(|(path, source)| {
-            if !is_npm_module(path) {
-                return false;
-            }
-            files_scanned += 1;
-            needs_linking(source)
-        })
-        .map(|(path, _)| path.clone())
+        .filter(|(path, _)| is_npm_module(path))
+        .collect();
+    let files_scanned = npm_files.len();
+
+    let work: Vec<(PathBuf, String)> = npm_files
+        .into_iter()
+        .filter(|(_, source)| needs_linking(source))
+        .map(|(p, s)| (p.clone(), s.clone()))
         .collect();
 
-    for path in paths_to_link {
-        if let Some(source) = modules.get(&path) {
-            let source = source.clone();
-            match transform::link_source(&source, &path, registry)? {
-                Some(linked) => {
-                    modules.insert(path.clone(), linked);
-                    files_linked += 1;
-                    tracing::debug!(path = %path.display(), "linked Angular declarations");
-                }
-                None => {
-                    // Detection said yes but transform found nothing — shouldn't happen
-                    // but harmless
-                }
-            }
+    // Transform in parallel. `transform::link_source` only reads the source
+    // and writes into `ModuleRegistry` (internally RwLock-protected), so
+    // per-file work is independent.
+    let results: Vec<(PathBuf, Option<String>)> = work
+        .par_iter()
+        .map(|(path, source)| -> NgcResult<(PathBuf, Option<String>)> {
+            let linked = transform::link_source(source, path, registry)?;
+            Ok((path.clone(), linked))
+        })
+        .collect::<NgcResult<Vec<_>>>()?;
+
+    // Apply the rewrites back to the module map serially.
+    let mut files_linked = 0;
+    for (path, maybe_new) in results {
+        if let Some(new_source) = maybe_new {
+            modules.insert(path.clone(), new_source);
+            files_linked += 1;
+            tracing::debug!(path = %path.display(), "linked Angular declarations");
         }
     }
 
@@ -136,14 +140,14 @@ pub fn link_modules(
     let mut stats = link_npm_modules(modules, project_root, &registry)?;
 
     // Build the public-exports index by scanning every npm file's top-level
-    // `export { … }` statements. Needed so the flatten pass can target the
-    // correct import specifier for each directive it adds.
-    for (path, source) in modules.iter() {
-        if !is_npm_module(path) {
-            continue;
-        }
-        public_exports.scan_file(source, path);
-    }
+    // `export { … }` statements. `PublicExports` is RwLock-protected so the
+    // scan loop is a clean `par_iter` candidate.
+    modules
+        .par_iter()
+        .filter(|(path, _)| is_npm_module(path))
+        .for_each(|(path, source)| {
+            public_exports.scan_file(source, path);
+        });
 
     stats.modules_registered = module_registry::scan_define_ng_modules(modules, &registry)?;
     stats.components_flattened =


### PR DESCRIPTION
Stacked on #48. Addresses lever #4 from #47.

## Result on treasr-frontend (production)

Layering this on top of #48:

|  | Wall | Speedup vs \`ng build\` |
|---|---|---|
| Main | 883 ms | 4.2× |
| #48 (bundler + postcss) | 640 ms | 5.9× |
| **This PR (linker)** | **606 ms** | **6.6×** |

Span timing for the link stage: **149 ms → 113 ms** (~36 ms saved on main).

## Changes

All three passes in \`crates/linker/\` that iterate over \`modules\` are now parallelised via \`rayon::par_iter\`:

### Pass 0 — \`link_npm_modules\` (\`lib.rs:72\`)
Snapshots the (path, source) pairs of every \`needs_linking\` npm file, runs \`transform::link_source\` in parallel, then serially applies the rewrites back to the module map. The \`ModuleRegistry\` already uses \`RwLock\`, so the writes from \`ng_module::transform\` are already thread-safe — no refactor needed.

### Pass 1 — public-exports scan (\`lib.rs:138\`)
Pure \`par_iter().for_each()\` over \`modules\` — \`PublicExports::scan_file\` uses \`RwLock\` internally.

### Pass 2 — \`flatten_component_dependencies\` (\`flatten.rs:77\`)
Same shape as Pass 0: snapshot \`(path, source)\` pairs for every file containing \`ɵɵdefineComponent\`, run \`flatten_one\` in parallel, then apply results.

Adds \`rayon\` to the linker crate's dependencies.

## Verification

- \`cargo test --workspace\` — 365 passed, 0 failed
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean
- Built, deployed to \`treasr-frontend-ngc-rs\` container, app serves HTTP 200 on port 4203; \`main.js\` (3.6 MB) and \`styles.css\` (203 KB) byte-sizes unchanged.

## Test plan

- [x] Merge after #48
- [x] Bench locally (\`scripts/bench_local.sh\`) — expect ~600 ms ngc-rs vs ~3800 ms ng build
- [x] Container smoke test: visit the treasr-frontend-ngc-rs app and exercise a lazy route (login, navigate to a chunk-loaded page)