### PR TITLE
perf(bundler): parallelize tree-shake module parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "criterion",
  "glob",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "clap",
  "colored",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/shake.rs
+++ b/crates/bundler/src/shake.rs
@@ -14,6 +14,7 @@ use oxc_ast::ast::{
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use rayon::prelude::*;
 use tracing::debug;
 
 /// Information about a module's exports and imports for tree shaking analysis.
@@ -47,18 +48,16 @@ pub fn analyze_unused_exports(
     local_prefixes: &[&str],
     externally_used: Option<&HashSet<String>>,
 ) -> NgcResult<HashMap<PathBuf, HashSet<String>>> {
-    // Step 1: Parse each module and collect export/import information
-    let mut module_infos: HashMap<PathBuf, ModuleInfo> = HashMap::new();
-
-    for module_path in module_paths {
-        let code = match all_code.get(module_path) {
-            Some(c) => c,
-            None => continue,
-        };
-
-        let info = analyze_module(code, module_path)?;
-        module_infos.insert(module_path.clone(), info);
-    }
+    // Step 1: Parse each module in parallel and collect export/import info.
+    // `analyze_module` only reads its inputs, so per-module work is independent.
+    let module_infos: HashMap<PathBuf, ModuleInfo> = module_paths
+        .par_iter()
+        .filter_map(|path| all_code.get(path).map(|code| (path, code)))
+        .map(|(path, code)| -> NgcResult<(PathBuf, ModuleInfo)> {
+            let info = analyze_module(code, path)?;
+            Ok((path.clone(), info))
+        })
+        .collect::<NgcResult<HashMap<_, _>>>()?;
 
     // Step 2: Build usage map — which exports are actually referenced
     let mut used_exports: HashMap<PathBuf, HashSet<String>> = HashMap::new();
@@ -324,43 +323,60 @@ pub fn collect_cross_chunk_used_names(
     all_code: &HashMap<PathBuf, String>,
     local_prefixes: &[&str],
 ) -> NgcResult<HashSet<String>> {
-    let mut used: HashSet<String> = HashSet::new();
     let provider_set: HashSet<&PathBuf> = provider_modules.iter().collect();
 
-    // Cache provider exports so we only parse each once when expanding namespace imports.
-    let mut provider_exports: HashMap<PathBuf, HashSet<String>> = HashMap::new();
+    // Phase A (parallel): parse each consumer and extract the named symbols
+    // it imports from provider modules. The parse dominates, so fanning this
+    // out across rayon workers recovers most of the tree-shake wall time.
+    let per_consumer: Vec<HashSet<String>> = consumer_modules
+        .par_iter()
+        .filter_map(|consumer_path| {
+            all_code
+                .get(consumer_path)
+                .map(|code| (consumer_path, code))
+        })
+        .map(|(consumer_path, code)| -> NgcResult<HashSet<String>> {
+            let info = analyze_module(code, consumer_path)?;
+            let mut local_used: HashSet<String> = HashSet::new();
+            for (specifier, imported_names) in &info.local_imports {
+                let Some(target) = resolve_local_specifier(
+                    specifier,
+                    consumer_path,
+                    provider_modules,
+                    local_prefixes,
+                ) else {
+                    continue;
+                };
+                if !provider_set.contains(&target) {
+                    continue;
+                }
+                for name in imported_names {
+                    if name == "* as " || name.starts_with("* as ") {
+                        // ImportNamespaceSpecifier — `analyze_module` currently
+                        // drops these (returns None). Left defensive; the
+                        // namespace pass below handles the real case.
+                        continue;
+                    }
+                    local_used.insert(name.clone());
+                }
+            }
+            Ok(local_used)
+        })
+        .collect::<NgcResult<Vec<_>>>()?;
 
+    let mut used: HashSet<String> = HashSet::new();
+    for names in per_consumer {
+        used.extend(names);
+    }
+
+    // Phase B (serial): namespace-import expansion. Kept serial so the
+    // `provider_exports` cache parses each provider at most once even when
+    // several consumers import the same namespace.
+    let mut provider_exports: HashMap<PathBuf, HashSet<String>> = HashMap::new();
     for consumer_path in consumer_modules {
         let Some(code) = all_code.get(consumer_path) else {
             continue;
         };
-
-        let info = analyze_module(code, consumer_path)?;
-        for (specifier, imported_names) in &info.local_imports {
-            let Some(target) =
-                resolve_local_specifier(specifier, consumer_path, provider_modules, local_prefixes)
-            else {
-                continue;
-            };
-
-            if !provider_set.contains(&target) {
-                continue;
-            }
-
-            for name in imported_names {
-                if name == "* as " || name.starts_with("* as ") {
-                    // ImportNamespaceSpecifier — `analyze_module` currently drops these
-                    // (returns None), so this branch is defensive. Fall through to the
-                    // dedicated namespace pass below when the signal is present.
-                    continue;
-                }
-                used.insert(name.clone());
-            }
-        }
-
-        // ImportNamespaceSpecifier is not captured by `analyze_module` (which
-        // returns None for namespace imports). Re-parse here to expand them
-        // into the full provider export set for each such import.
         expand_namespace_imports(
             code,
             consumer_path,


### PR DESCRIPTION
Stacked on #49. Addresses a follow-up lever from the #47 deep-dive — not one of the original seven, but came out of sub-span profiling of the bundle phase showing \`main_tree_shake\` = 100 ms serial.

## Result on treasr-frontend (production)

|  | Wall | Parallelism | Speedup vs \`ng build\` |
|---|---|---|---|
| Main | 883 ms | 1.14× | 4.2× |
| #48 (bundler + postcss) | 640 ms | 1.57× | 5.9× |
| #49 (linker) | 606 ms | — | 6.6× |
| **This PR (tree-shake)** | **582 ms** | **1.84×** | **6.8×** |

## Changes

In \`crates/bundler/src/shake.rs\`:

### \`analyze_unused_exports\` — Step 1 parse loop
Replaces the serial \`for module_path in module_paths\` parse loop with a \`par_iter\` that produces a \`HashMap<PathBuf, ModuleInfo>\`. Each \`analyze_module\` call only reads its inputs, so per-module work is independent. Steps 2 and 3 (usage map construction and unused-name computation) stay serial — they touch shared HashMap state and are already cheap.

### \`collect_cross_chunk_used_names\` — split into phase A (parallel) + phase B (serial)
- **Phase A** (new \`par_iter\`): parse each consumer module and extract the set of provider-export names it imports, returning per-consumer name sets.
- **Phase B** (kept serial): namespace-import expansion via \`expand_namespace_imports\`, which mutates a \`provider_exports\` cache that ensures each provider is parsed at most once. Parallelising this would either duplicate parse work or require locking — net-neutral at best.

After the parallel phase, per-consumer sets are unioned into the final \`used\` set.

## Verification

- \`cargo test --workspace\` — 365 passed, 0 failed
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean
- Container smoke test: copied binary output into \`treasr-frontend-ngc-rs\`; app still serves HTTP 200 on port 4203 with identical \`main.js\` byte-size (3.6 MB).

## Test plan

- [x] Merge after #49
- [x] Bench locally (\`scripts/bench_local.sh\`) — expect ~580 ms ngc-rs vs ~3800 ms ng build
- [x] Exercise a lazy route on the treasr-frontend-ngc-rs app to confirm tree-shake decisions still match (no \`ReferenceError\` on dialog-opened components)