### PR TITLE
perf(npm-resolver): frontier-level parallel BFS crawl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "ngc-diagnostics",
  "ngc-project-resolver",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "criterion",
  "glob",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "clap",
  "colored",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "insta",
  "ngc-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.15"
+version = "0.7.16"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/npm-resolver/src/lib.rs
+++ b/crates/npm-resolver/src/lib.rs
@@ -4,11 +4,12 @@
 //! their ESM entry points in `node_modules`, then recursively crawls all
 //! transitive imports to discover every file that needs to be bundled.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::NgcResult;
 use ngc_project_resolver::ImportKind;
+use rayon::prelude::*;
 use tracing::debug;
 
 pub mod package_json;
@@ -51,81 +52,114 @@ pub fn resolve_npm_dependencies(
     let mut edges: Vec<(PathBuf, PathBuf, ImportKind)> = Vec::new();
     let mut resolved_specifiers: HashSet<String> = HashSet::new();
     let mut visited: HashSet<PathBuf> = HashSet::new();
-    let mut queue: VecDeque<PathBuf> = VecDeque::new();
 
-    // Map from bare specifier to its resolved entry file
-    let mut specifier_to_entry: HashMap<String, PathBuf> = HashMap::new();
-
-    // Phase 1: Resolve initial bare specifiers to entry files
-    for spec in specifiers {
-        match resolve::resolve_bare_specifier(spec, project_root) {
-            Ok(entry_path) => {
-                let canonical = entry_path.canonicalize().unwrap_or(entry_path);
-                resolved_specifiers.insert(spec.clone());
-                specifier_to_entry.insert(spec.clone(), canonical.clone());
-                if visited.insert(canonical.clone()) {
-                    queue.push_back(canonical);
+    // Phase 1: Resolve initial bare specifiers to entry files in parallel.
+    // Each lookup hits node_modules/<pkg>/package.json plus a few is_file
+    // probes — fully independent per specifier.
+    let initial_entries: Vec<(String, PathBuf)> = specifiers
+        .par_iter()
+        .filter_map(
+            |spec| match resolve::resolve_bare_specifier(spec, project_root) {
+                Ok(entry_path) => {
+                    let canonical = entry_path.canonicalize().unwrap_or(entry_path);
+                    Some((spec.clone(), canonical))
                 }
-            }
-            Err(e) => {
-                debug!(specifier = spec, error = %e, "skipping unresolvable npm package");
-            }
+                Err(e) => {
+                    debug!(specifier = spec, error = %e, "skipping unresolvable npm package");
+                    None
+                }
+            },
+        )
+        .collect();
+
+    let mut frontier: Vec<PathBuf> = Vec::new();
+    for (spec, entry) in initial_entries {
+        resolved_specifiers.insert(spec);
+        if visited.insert(entry.clone()) {
+            frontier.push(entry);
         }
     }
 
-    // Phase 2: BFS crawl — read files, scan imports, resolve, repeat
-    while let Some(file_path) = queue.pop_front() {
-        let source = match std::fs::read_to_string(&file_path) {
-            Ok(s) => s,
-            Err(e) => {
-                debug!(path = %file_path.display(), error = %e, "skipping unreadable npm file");
-                continue;
-            }
-        };
+    // One import discovered during a frontier parse, already resolved to a
+    // canonicalised file on disk. Carries its specifier text (only for bare
+    // imports — relative ones don't expose a specifier to the bundler).
+    type ResolvedImport = (Option<String>, PathBuf, ImportKind);
 
-        let scanned = scanner::scan_npm_imports(&source);
-
-        for import in &scanned {
-            let kind = if import.is_dynamic {
-                ImportKind::Dynamic
-            } else {
-                ImportKind::Static
-            };
-
-            let resolved = if import.specifier.starts_with('.') {
-                // Relative import within the package
-                resolve::resolve_relative_import(&import.specifier, &file_path).ok()
-            } else {
-                // Bare specifier — transitive npm dependency
-                match resolve::resolve_bare_specifier(&import.specifier, project_root) {
-                    Ok(path) => {
-                        resolved_specifiers.insert(import.specifier.clone());
-                        specifier_to_entry.insert(import.specifier.clone(), path.clone());
-                        Some(path)
+    // Phase 2: frontier-level parallel BFS. Each level's per-file work —
+    // read source, scan imports, resolve each — is embarrassingly parallel;
+    // between levels we merge into shared state serially so `visited`,
+    // `modules`, `edges`, and `resolved_specifiers` stay coherent and
+    // deterministic. Level N+1 is the set of newly-discovered files from
+    // level N.
+    while !frontier.is_empty() {
+        let per_file: Vec<(PathBuf, String, Vec<ResolvedImport>)> = frontier
+            .par_iter()
+            .filter_map(|file_path| {
+                let source = match std::fs::read_to_string(file_path) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        debug!(path = %file_path.display(), error = %e, "skipping unreadable npm file");
+                        return None;
                     }
-                    Err(_) => {
-                        debug!(
-                            specifier = import.specifier,
-                            from = %file_path.display(),
-                            "skipping unresolvable transitive npm dependency"
-                        );
-                        None
+                };
+
+                let scanned = scanner::scan_npm_imports(&source);
+                let mut resolved_imports: Vec<ResolvedImport> = Vec::with_capacity(scanned.len());
+
+                for import in &scanned {
+                    let kind = if import.is_dynamic {
+                        ImportKind::Dynamic
+                    } else {
+                        ImportKind::Static
+                    };
+
+                    let (target, specifier_tag) = if import.specifier.starts_with('.') {
+                        (
+                            resolve::resolve_relative_import(&import.specifier, file_path).ok(),
+                            None,
+                        )
+                    } else {
+                        match resolve::resolve_bare_specifier(&import.specifier, project_root) {
+                            Ok(p) => (Some(p), Some(import.specifier.clone())),
+                            Err(_) => {
+                                debug!(
+                                    specifier = import.specifier,
+                                    from = %file_path.display(),
+                                    "skipping unresolvable transitive npm dependency"
+                                );
+                                (None, None)
+                            }
+                        }
+                    };
+
+                    if let Some(target_path) = target {
+                        // Canonicalize to avoid duplicate entries from
+                        // different relative paths (e.g.
+                        // `../Subscription.js` vs
+                        // `../observable/../Subscription.js`).
+                        let canonical = target_path.canonicalize().unwrap_or(target_path);
+                        resolved_imports.push((specifier_tag, canonical, kind));
                     }
                 }
-            };
 
-            if let Some(target_path) = resolved {
-                // Canonicalize to avoid duplicate entries from different relative paths
-                // (e.g. "../Subscription.js" vs "../observable/../Subscription.js")
-                let canonical = target_path.canonicalize().unwrap_or(target_path);
-                edges.push((file_path.clone(), canonical.clone(), kind));
-                if visited.insert(canonical.clone()) {
-                    queue.push_back(canonical);
+                Some((file_path.clone(), source, resolved_imports))
+            })
+            .collect();
+
+        let mut next_frontier: Vec<PathBuf> = Vec::new();
+        for (file_path, source, imports) in per_file {
+            for (specifier_tag, target, kind) in imports {
+                edges.push((file_path.clone(), target.clone(), kind));
+                if let Some(spec) = specifier_tag {
+                    resolved_specifiers.insert(spec);
+                }
+                if visited.insert(target.clone()) {
+                    next_frontier.push(target);
                 }
             }
+            modules.insert(file_path, source);
         }
-
-        modules.insert(file_path.clone(), source);
+        frontier = next_frontier;
     }
 
     debug!(


### PR DESCRIPTION
Stacked on #50. Addresses lever #5 from #47.

## Result on treasr-frontend (production)

|  | Wall | Parallelism | Speedup vs \`ng build\` |
|---|---|---|---|
| Main | 883 ms | 1.14× | 4.2× |
| #48 (bundler + postcss) | 640 ms | 1.57× | 5.9× |
| #49 (linker) | 606 ms | — | 6.6× |
| #50 (tree-shake) | 582 ms | 1.84× | 6.8× |
| **This PR (npm-resolve)** | **530 ms** | **2.07×** | **7.2×** |

Span timing for \`npm_resolve\`: **86 ms → 50 ms** (~36 ms saved).

## Changes

\`crates/npm-resolver/src/lib.rs\` — \`resolve_npm_dependencies\` was previously a single-threaded BFS with a \`VecDeque\` frontier. It's now a **frontier-level parallel BFS**:

- **Phase 1** — initial bare-specifier resolution is a pure \`par_iter\`. Each \`resolve_bare_specifier\` call is independent (package.json read + a handful of \`is_file\` probes).
- **Phase 2** — each frontier level's per-file work (read source → \`scan_npm_imports\` → resolve every import to a canonical path) runs in \`par_iter\`. Between levels, a serial merge step updates the shared \`visited\`, \`modules\`, \`edges\`, and \`resolved_specifiers\` and computes the next frontier.

A level N+1 cannot start before level N finishes (data dependency: we don't know level N+1's members until level N's files have been parsed), so the serial merge per frontier is a necessary barrier. Within a level, work is embarrassingly parallel.

Also drops the unused \`specifier_to_entry\` map (leftover from an earlier design — only written to, never read).

## Verification

- \`cargo test --workspace\` — 365 passed, 0 failed (includes the npm-resolver's own 6 tests covering transitive deps, dedup, and missing-package cases)
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean
- Container smoke test: copied binary output into \`treasr-frontend-ngc-rs\`; app serves HTTP 200; \`main.js\` still 3.6 MB.

## Determinism

Edge order within a file is source-order (preserved by the scanner). File order within a frontier is preserved by \`par_iter().collect::<Vec<_>>\`. Between frontiers, the serial merge pushes newly-visited files in per-file order. Net result: \`edges\` and \`modules\` end up in the same order as the serial BFS on a given input.

## Test plan

- [x] Merge after #50
- [x] Bench locally (\`scripts/bench_local.sh\`) — expect ~530 ms ngc-rs vs ~3800 ms ng build
- [x] Exercise lazy routes on the treasr-frontend-ngc-rs app (the npm resolver feeds the bundler's module map, so any resolution regression would show up as \`ReferenceError\` at runtime)