### PR TITLE
chore: gitignore scripts/deploy_to_container.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MILESTONES.md
 .env
 .env.*
 /scripts/bench_local.sh
+/scripts/deploy_to_container.sh


### PR DESCRIPTION
One-liner addition to `.gitignore` so the local convenience script at `scripts/deploy_to_container.sh` (rebuild + redeploy-into-container + smoke-test for treasr-frontend-ngc-rs) mirrors the existing treatment of `scripts/bench_local.sh` — personal paths, stays out of the tracked tree.