### PR TITLE
fix(linker): compile `$any()` as identity in host-binding expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "clap",
  "colored",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.18"
+version = "0.7.19"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -489,32 +489,45 @@ fn compile_host_expression(expr: &str) -> String {
 
     let mut result = expr.to_string();
 
-    // Sort insertions in reverse order to preserve offsets
     ctx_inserts.sort_unstable();
     ctx_inserts.dedup();
 
-    // Apply removals first (sorted reverse)
-    let mut sorted_removes: Vec<(u32, u32)> = remove_ranges
-        .iter()
-        .map(|(s, e)| (s - expr_offset, e - expr_offset))
-        .collect();
-    sorted_removes.sort_by_key(|e| std::cmp::Reverse(e.0));
-    for (s, e) in &sorted_removes {
-        let s = *s as usize;
-        let e = *e as usize;
-        if s <= result.len() && e <= result.len() {
-            result.replace_range(s..e, "");
-        }
+    // Merge inserts and removes into a single edit list, then apply from
+    // rightmost to leftmost so each edit only touches characters to the right
+    // of earlier (already-processed) edits — their positions in the mutated
+    // string still match the original offsets.
+    enum Edit {
+        Insert(u32),
+        Remove(u32, u32),
     }
+    let mut edits: Vec<Edit> = Vec::with_capacity(ctx_inserts.len() + remove_ranges.len());
+    for off in &ctx_inserts {
+        edits.push(Edit::Insert(off - expr_offset));
+    }
+    for (s, e) in &remove_ranges {
+        edits.push(Edit::Remove(s - expr_offset, e - expr_offset));
+    }
+    edits.sort_by_key(|e| {
+        std::cmp::Reverse(match e {
+            Edit::Insert(p) => *p,
+            Edit::Remove(s, _) => *s,
+        })
+    });
 
-    // Apply ctx. insertions (sorted reverse)
-    let mut sorted_inserts: Vec<u32> = ctx_inserts.iter().map(|off| off - expr_offset).collect();
-    sorted_inserts.sort_unstable();
-    sorted_inserts.reverse();
-    for off in &sorted_inserts {
-        let off = *off as usize;
-        if off <= result.len() {
-            result.insert_str(off, "ctx.");
+    for edit in edits {
+        match edit {
+            Edit::Insert(off) => {
+                let off = off as usize;
+                if off <= result.len() {
+                    result.insert_str(off, "ctx.");
+                }
+            }
+            Edit::Remove(s, e) => {
+                let (s, e) = (s as usize, e as usize);
+                if s <= result.len() && e <= result.len() {
+                    result.replace_range(s..e, "");
+                }
+            }
         }
     }
 
@@ -561,6 +574,7 @@ fn collect_ctx_rewrites(
                 | "Map"
                 | "Set"
                 | "$event"
+                | "ctx"
         )
     }
 
@@ -569,6 +583,26 @@ fn collect_ctx_rewrites(
             ctx_inserts.push(id.span.start);
         }
         Expression::CallExpression(call) => {
+            // `$any(x)` is a template-DSL type assertion; compile it as identity
+            // (emit `x` unchanged) rather than a call to a nonexistent ctx.$any.
+            if let Expression::Identifier(id) = &call.callee {
+                if id.name == "$any" && call.arguments.len() == 1 {
+                    if let Some(arg) = call.arguments.first() {
+                        if !matches!(arg, Argument::SpreadElement(_)) {
+                            let inner = arg.to_expression();
+                            remove_ranges.push((call.span.start, inner.span().start));
+                            remove_ranges.push((inner.span().end, call.span.end));
+                            collect_ctx_rewrites(
+                                inner,
+                                ctx_inserts,
+                                remove_ranges,
+                                is_member_property,
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
             collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false);
             for arg in &call.arguments {
                 if let Argument::SpreadElement(spread) = arg {
@@ -985,6 +1019,30 @@ mod tests {
             compile_host_expression("_getMinDate()!"),
             "ctx._getMinDate()"
         );
+    }
+
+    #[test]
+    fn test_compile_host_expression_any_in_listener() {
+        // `$any($event.target).checked` — the CheckboxControlValueAccessor pattern
+        // that regressed in issue #68.
+        assert_eq!(
+            compile_host_expression("onChange($any($event.target).checked)"),
+            "ctx.onChange($event.target.checked)"
+        );
+    }
+
+    #[test]
+    fn test_compile_host_expression_any_over_ctx() {
+        assert_eq!(
+            compile_host_expression("$any(ctx).foo.bar()"),
+            "ctx.foo.bar()"
+        );
+    }
+
+    #[test]
+    fn test_compile_host_expression_any_bare_identifier() {
+        // Just the argument — no member access, no call on the result.
+        assert_eq!(compile_host_expression("$any(value)"), "ctx.value");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `collect_ctx_rewrites` in `crates/linker/src/directive.rs` treated the `$any` callee like any user-defined function and prefixed it with `ctx.`, producing `ctx.$any(...)` at runtime and blowing up the first time an Angular `CheckboxControlValueAccessor`-bound input was toggled (`TypeError: ctx.$any is not a function`). `$any` is a template-DSL type-assertion — emit the argument unchanged instead.
- Detect `$any(arg)` (single, non-spread argument) in the `CallExpression` arm: mark the `$any(` and `)` spans for removal, recurse into the argument for the normal `ctx.` prefixing pass. Added `ctx` to the builtin skip set so `$any(ctx).foo` lowers to `ctx.foo`, not `ctx.ctx.foo`.
- Unified the apply logic into one rightmost-to-leftmost edit walk. The old pass applied all removes before all inserts using original offsets, which happened to work only because every TS non-null `!` removal sat to the right of every insert; with `$any` the invariant breaks.
- Added unit tests for the checkbox-listener case, `$any(ctx).foo.bar()`, and a bare `$any(value)`.
- Bumps workspace version to 0.7.19.

Closes #68.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Rebuilt a real Angular app with the new binary and confirmed the emitted host bindings compile `onChange($any($event.target).checked)` to `onChange($event.target.checked)` and no `ctx.$any` remains in the bundle.
- [x] Clicked the reproducer's `CheckboxControlValueAccessor`-bound checkboxes in a browser — no `ctx.$any is not a function` runtime error.