### PR TITLE
fix(template-compiler): unify pipe slot-offset counter (closes #69)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "clap",
  "colored",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.19"
+version = "0.7.20"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1424,10 +1424,14 @@ impl IvyCodegen {
             let compiled_base = self.replace_pipes_in_expr(&base);
             let pipe_slot = self.slot_index;
             self.slot_index += 1;
-            // Capture binding start BEFORE incrementing
-            let pipe_var_slot = self.var_count;
-            // Each pipe uses 2 + args binding slots: input + pure cache + extra args
-            self.var_count += 2 + args.len() as u32;
+            // Use the pipe-specific offset counter so pipe binding slots are
+            // packed contiguously (0, 2, 5, …) across the whole template.
+            // `rewrite_pipe_offsets` later shifts these by the sequential
+            // binding count so they sit after all sequential bindings in LView.
+            let pipe_var_slot = self.pipe_var_offset;
+            let slots = 2 + args.len() as u32;
+            self.pipe_var_offset += slots;
+            self.var_count += slots;
             self.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
 
             let bind_fn = match args.len() {
@@ -1999,8 +2003,13 @@ fn replace_nested_pipe_parens(expr: &str, gen: &mut IvyCodegen) -> String {
 
                 let pipe_slot = gen.slot_index;
                 gen.slot_index += 1;
-                let pipe_var_slot = gen.var_count;
-                gen.var_count += 2 + args.len() as u32;
+                // Same pipe-offset counter as replace_pipes_in_expr /
+                // wrap_with_pipes — keep all three paths consistent so
+                // rewrite_pipe_offsets shifts every pipe slot uniformly.
+                let pipe_var_slot = gen.pipe_var_offset;
+                let slots = 2 + args.len() as u32;
+                gen.pipe_var_offset += slots;
+                gen.var_count += slots;
                 gen.ivy_imports.insert("\u{0275}\u{0275}pipe".to_string());
 
                 let bind_fn = match args.len() {
@@ -3225,5 +3234,129 @@ mod tests {
             dc.contains("elementStart(0, 'canvas', 0)"),
             "elementStart should reference consts index for baseChart attr: {dc}"
         );
+    }
+
+    /// Regression: GitHub #69 — property-binding pipe and interpolation pipe in
+    /// the same template must receive distinct `slotOffset` arguments. Before
+    /// the fix, `replace_pipes_in_expr` used `var_count` as the pipe offset
+    /// while `wrap_with_pipes` used `pipe_var_offset`; `rewrite_pipe_offsets`
+    /// then double-counted the sequential bindings and both pipes landed on
+    /// the same LView slot, triggering NG0100.
+    #[test]
+    fn test_article_shaped_pipes_have_distinct_slot_offsets() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "a".to_string(),
+            attributes: vec![TemplateAttribute::Property {
+                name: "href".to_string(),
+                expression: "article.url | safeUrl".to_string(),
+            }],
+            children: vec![TemplateNode::Element(ElementNode {
+                tag: "span".to_string(),
+                attributes: Vec::new(),
+                children: vec![TemplateNode::Interpolation(InterpolationNode {
+                    expression: "article.datetime * 1000".to_string(),
+                    pipes: vec![PipeCall {
+                        name: "date".to_string(),
+                        args: vec!["'short'".to_string()],
+                    }],
+                })],
+                is_void: false,
+            })],
+            is_void: false,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        let dc = &output.static_fields[0];
+
+        let offsets = collect_pipe_slot_offsets(dc);
+        assert_eq!(
+            offsets.len(),
+            2,
+            "expected two pipeBind* calls in the template: {dc}"
+        );
+        assert_ne!(
+            offsets[0], offsets[1],
+            "pipeBind slot offsets must be distinct (got {offsets:?}): {dc}"
+        );
+
+        // vars: must cover seq bindings (1 property + 1 textInterpolate = 2)
+        // plus pipe slots (2 for pipeBind1 + 3 for pipeBind2 = 5) = 7.
+        assert!(
+            dc.contains("vars: 7"),
+            "vars: should equal total binding slots (2 seq + 5 pipe = 7): {dc}"
+        );
+
+        // Both pipe offsets must fall inside the binding range, strictly after
+        // the sequential bindings (which occupy slots 0..=1).
+        for off in &offsets {
+            assert!(
+                *off >= 2,
+                "pipe offset {off} must sit after sequential bindings: {dc}"
+            );
+            assert!(
+                *off < 7,
+                "pipe offset {off} must fit in vars: 7 range: {dc}"
+            );
+        }
+    }
+
+    /// Regression: two top-level pipes in successive property bindings on the
+    /// same element (both flowing through `replace_pipes_in_expr`) must also
+    /// receive distinct `slotOffset` values.
+    #[test]
+    fn test_two_property_binding_pipes_have_distinct_slot_offsets() {
+        let comp = test_component();
+        let nodes = vec![TemplateNode::Element(ElementNode {
+            tag: "img".to_string(),
+            attributes: vec![
+                TemplateAttribute::Property {
+                    name: "src".to_string(),
+                    expression: "photo.url | safeUrl".to_string(),
+                },
+                TemplateAttribute::Property {
+                    name: "alt".to_string(),
+                    expression: "photo.caption | translate".to_string(),
+                },
+            ],
+            children: Vec::new(),
+            is_void: true,
+        })];
+        let output = generate_ivy(&comp, &nodes).expect("should generate");
+        let dc = &output.static_fields[0];
+        let offsets = collect_pipe_slot_offsets(dc);
+        assert_eq!(offsets.len(), 2, "expected two pipeBind* calls: {dc}");
+        assert_ne!(
+            offsets[0], offsets[1],
+            "successive property pipes must have distinct offsets (got {offsets:?}): {dc}"
+        );
+    }
+
+    fn collect_pipe_slot_offsets(code: &str) -> Vec<u32> {
+        let mut out = Vec::new();
+        for marker in [
+            "\u{0275}\u{0275}pipeBind1(",
+            "\u{0275}\u{0275}pipeBind2(",
+            "\u{0275}\u{0275}pipeBind3(",
+            "\u{0275}\u{0275}pipeBindV(",
+        ] {
+            let mut cursor = 0;
+            while let Some(rel) = code[cursor..].find(marker) {
+                let after = cursor + rel + marker.len();
+                let rest = &code[after..];
+                let comma = rest.find(',').expect("pipeBind* should have ≥ 2 args");
+                let offset_region = rest[comma + 1..].trim_start();
+                let digits: String = offset_region
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect();
+                out.push(
+                    digits
+                        .parse::<u32>()
+                        .expect("second arg to pipeBind* must be a literal offset"),
+                );
+                cursor = after;
+            }
+        }
+        out
     }
 }


### PR DESCRIPTION
## Summary

- Fixes NG0100 (`ExpressionChangedAfterItHasBeenCheckedError`) on `ArticleComponent` when expanding a stock card under `ngc-rs build`.
- Unifies the three pipe emission paths in `crates/template-compiler/src/codegen.rs` on a single pipe-only slot counter so `rewrite_pipe_offsets` shifts every `ɵɵpipeBindN` offset uniformly.
- Adds two regression tests covering the article-shaped template and successive property-pipe attributes.
- Bumps workspace version to `0.7.20`.

## Root cause

`wrap_with_pipes` (for interpolation-level pipes) allocated `slotOffset` from the 0-based `pipe_var_offset` counter, while `replace_pipes_in_expr` (top-level pipes inside a binding expression) and `replace_nested_pipe_parens` (pipes inside parenthesised sub-expressions) used `self.var_count` — which already accumulates sequential binding slots. Since `rewrite_pipe_offsets` unconditionally adds `seq_bindings` to every emitted pipeBind offset, the mismatch double-counted sequential bindings for the `var_count`-based paths.

For a template with `[href]="article.url | safeUrl"` alongside `{{ article.datetime * 1000 | date: 'short' }}`, both `ɵɵpipeBind1` and `ɵɵpipeBind2` ended up at the same `slotOffset`, so their cached previous values overwrote each other. The CD verification pass read back a URL where the timestamp had been (and vice versa), triggering NG0100.

## Fix

Both `replace_pipes_in_expr` and `replace_nested_pipe_parens` now draw their `pipe_var_slot` from `self.pipe_var_offset` and advance it by `2 + args.len()`, matching `wrap_with_pipes`. The shared counter guarantees every pipe slot is unique, contiguous, and correctly shifted by the single rewrite pass.

## Test plan

- [x] `cargo test --workspace` — 334 tests pass (incl. 2 new regressions)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New test reproduces the exact bug without the fix: offsets `[2, 2]` in emitted `pipeBind1`/`pipeBind2`, matching the issue's `ArticleComponent` symptom
- [x] Verified on `treasr-frontend` `/news`: expanding a stock card renders `ArticleComponent` instances without NG0100

Closes #69. Supersedes #71 (auto-closed when the head branch was renamed).