### PR TITLE
feat(cli): baseHref, deployUrl, crossOrigin, subresourceIntegrity from angular.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ dependencies = [
 name = "ngc-rs"
 version = "0.7.21"
 dependencies = [
+ "base64",
  "clap",
  "colored",
  "glob",
@@ -677,6 +678,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "clap",
  "colored",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.20"
+version = "0.7.21"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,8 @@ serde_json = "1.0"
 glob = "0.3"
 regex = "1.12"
 oxc_sourcemap = "6.1"
+sha2 = "0.10"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use ngc_bundler::{BundleInput, BundleOptions};
 use ngc_diagnostics::{NgcError, NgcResult};
 use ngc_project_resolver::angular_json::{
-    FileReplacement, ResolvedAngularProject, ResolvedAsset, ResolvedStyle,
+    CrossOrigin, FileReplacement, ResolvedAngularProject, ResolvedAsset, ResolvedStyle,
 };
 
 /// Result of the bundled build pipeline.
@@ -509,6 +509,12 @@ fn run_build(
     // Step 11: Generate index.html
     if let Some(ref ap) = angular_project {
         if let Some(ref index_path) = ap.index_html {
+            let index_opts = IndexHtmlOptions {
+                base_href: ap.base_href.as_deref(),
+                deploy_url: ap.deploy_url.as_deref(),
+                cross_origin: ap.cross_origin,
+                subresource_integrity: ap.subresource_integrity,
+            };
             let path = generate_index_html(
                 index_path,
                 &ap.index_output,
@@ -516,6 +522,7 @@ fn run_build(
                 !ap.polyfills.is_empty(),
                 &out_dir,
                 &bundle_output.main_filename,
+                &index_opts,
             )?;
             output_files.push(path);
         }
@@ -951,7 +958,29 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> NgcResult<Vec<PathBuf>> {
     Ok(output_paths)
 }
 
+/// Options controlling how `index.html` is rewritten during injection.
+///
+/// Each field mirrors the corresponding `angular.json` build option. See
+/// [`generate_index_html`] for how they're applied to the emitted HTML.
+#[derive(Debug, Default, Clone, Copy)]
+struct IndexHtmlOptions<'a> {
+    /// `baseHref` — value written into `<base href="...">`.
+    base_href: Option<&'a str>,
+    /// `deployUrl` — absolute URL prefix prepended to injected `src`/`href`.
+    deploy_url: Option<&'a str>,
+    /// `crossOrigin` attribute for injected `<script>` / `<link>` tags.
+    cross_origin: CrossOrigin,
+    /// When true, compute SHA-384 integrity hashes of emitted artifacts and
+    /// inject `integrity="sha384-..."` attributes on the tags that load them.
+    subresource_integrity: bool,
+}
+
 /// Read source index.html, inject stylesheet and script tags, write to out_dir.
+///
+/// Applies the `baseHref`, `deployUrl`, `crossOrigin`, and
+/// `subresourceIntegrity` options during injection. SRI hashes are computed
+/// over the files on disk in `out_dir`, so this must run after the bundler,
+/// polyfills, and CSS pipeline have emitted their artifacts.
 fn generate_index_html(
     index_source: &Path,
     output_filename: &str,
@@ -959,28 +988,75 @@ fn generate_index_html(
     has_polyfills: bool,
     out_dir: &Path,
     main_filename: &str,
+    options: &IndexHtmlOptions,
 ) -> NgcResult<PathBuf> {
     let mut html = std::fs::read_to_string(index_source).map_err(|e| NgcError::Io {
         path: index_source.to_path_buf(),
         source: e,
     })?;
 
+    // Rewrite or inject <base href="..."> per baseHref option.
+    if let Some(base_href) = options.base_href {
+        html = apply_base_href(&html, base_href);
+    }
+
+    let deploy_url = options.deploy_url.unwrap_or("");
+    let crossorigin_attr = options
+        .cross_origin
+        .attribute_value()
+        .map(|v| format!(" crossorigin=\"{v}\""))
+        .unwrap_or_default();
+
     // Inject stylesheet link before </head>
     if has_styles {
-        html = html.replace(
-            "</head>",
-            "  <link rel=\"stylesheet\" href=\"styles.css\">\n</head>",
+        let href = format!("{deploy_url}styles.css");
+        let integrity = if options.subresource_integrity {
+            Some(compute_sri_hash(&out_dir.join("styles.css"))?)
+        } else {
+            None
+        };
+        let integrity_attr = integrity
+            .as_deref()
+            .map(|i| format!(" integrity=\"{i}\""))
+            .unwrap_or_default();
+        let tag = format!(
+            "  <link rel=\"stylesheet\" href=\"{href}\"{crossorigin_attr}{integrity_attr}>\n"
         );
+        html = html.replace("</head>", &format!("{tag}</head>"));
     }
 
     // Inject script tags before </body>
     let mut scripts = String::new();
     if has_polyfills {
-        scripts.push_str("  <script src=\"polyfills.js\" type=\"module\"></script>\n");
+        let src = format!("{deploy_url}polyfills.js");
+        let integrity = if options.subresource_integrity {
+            Some(compute_sri_hash(&out_dir.join("polyfills.js"))?)
+        } else {
+            None
+        };
+        let integrity_attr = integrity
+            .as_deref()
+            .map(|i| format!(" integrity=\"{i}\""))
+            .unwrap_or_default();
+        scripts.push_str(&format!(
+            "  <script src=\"{src}\" type=\"module\"{crossorigin_attr}{integrity_attr}></script>\n"
+        ));
     }
-    scripts.push_str(&format!(
-        "  <script src=\"{main_filename}\" type=\"module\"></script>\n"
-    ));
+    {
+        let src = format!("{deploy_url}{main_filename}");
+        let integrity = if options.subresource_integrity {
+            Some(compute_sri_hash(&out_dir.join(main_filename))?)
+        } else {
+            None
+        };
+        let integrity_attr = integrity
+            .as_deref()
+            .map(|i| format!(" integrity=\"{i}\""))
+            .unwrap_or_default();
+        scripts.push_str(&format!(
+            "  <script src=\"{src}\" type=\"module\"{crossorigin_attr}{integrity_attr}></script>\n"
+        ));
+    }
     html = html.replace("</body>", &format!("{scripts}</body>"));
 
     let path = out_dir.join(output_filename);
@@ -989,6 +1065,47 @@ fn generate_index_html(
         source: e,
     })?;
     Ok(path)
+}
+
+/// Rewrite an existing `<base href="...">` tag, or inject one after `<head>`.
+///
+/// Matches any existing tag with flexible whitespace and quote styles so we
+/// don't create a duplicate when the source index already declares one.
+fn apply_base_href(html: &str, base_href: &str) -> String {
+    let base_re = regex::Regex::new(r#"<base\s+[^>]*href\s*=\s*["'][^"']*["'][^>]*>"#)
+        .expect("valid base-href regex");
+    let replacement = format!("<base href=\"{base_href}\">");
+    if base_re.is_match(html) {
+        return base_re.replace(html, replacement.as_str()).into_owned();
+    }
+
+    // No existing <base> tag — inject after the opening <head>.
+    let head_re = regex::Regex::new(r"(?i)<head(\s[^>]*)?>").expect("valid head regex");
+    if let Some(m) = head_re.find(html) {
+        let end = m.end();
+        let mut out = String::with_capacity(html.len() + replacement.len() + 4);
+        out.push_str(&html[..end]);
+        out.push_str("\n  ");
+        out.push_str(&replacement);
+        out.push_str(&html[end..]);
+        return out;
+    }
+    // No <head> at all — fall back to prepending so the tag still lands.
+    format!("{replacement}\n{html}")
+}
+
+/// Compute a `sha384-<base64>` SRI digest for a file on disk.
+fn compute_sri_hash(path: &Path) -> NgcResult<String> {
+    use base64::Engine;
+    use sha2::{Digest, Sha384};
+
+    let bytes = std::fs::read(path).map_err(|e| NgcError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let digest = Sha384::digest(&bytes);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(digest);
+    Ok(format!("sha384-{b64}"))
 }
 
 /// Scan the bundle's external imports, find LICENSE files in node_modules,
@@ -1411,8 +1528,19 @@ mod tests {
             "<!doctype html>\n<html>\n<head>\n</head>\n<body>\n  <app-root></app-root>\n</body>\n</html>\n",
         )
         .unwrap();
-        let out = generate_index_html(&index_src, "index.html", true, true, dir.path(), "main.js")
-            .unwrap();
+        std::fs::write(dir.path().join("styles.css"), "").unwrap();
+        std::fs::write(dir.path().join("polyfills.js"), "").unwrap();
+        std::fs::write(dir.path().join("main.js"), "").unwrap();
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &IndexHtmlOptions::default(),
+        )
+        .unwrap();
         let content = std::fs::read_to_string(out).unwrap();
         assert!(content.contains(r#"<link rel="stylesheet" href="styles.css">"#));
         assert!(content.contains(r#"<script src="polyfills.js" type="module"></script>"#));
@@ -1424,6 +1552,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let index_src = dir.path().join("index.html");
         std::fs::write(&index_src, "<html><head></head><body></body></html>").unwrap();
+        std::fs::write(dir.path().join("main.js"), "").unwrap();
         let out = generate_index_html(
             &index_src,
             "index.html",
@@ -1431,12 +1560,211 @@ mod tests {
             false,
             dir.path(),
             "main.js",
+            &IndexHtmlOptions::default(),
         )
         .unwrap();
         let content = std::fs::read_to_string(out).unwrap();
         assert!(!content.contains("styles.css"));
         assert!(!content.contains("polyfills.js"));
         assert!(content.contains(r#"<script src="main.js" type="module"></script>"#));
+    }
+
+    /// Fixture helper: writes a minimal index + artifact files and returns
+    /// `(dir, index_src)` for reuse across option-specific tests.
+    fn setup_index_fixture(artifact_bytes: &[u8]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let index_src = dir.path().join("index.html");
+        std::fs::write(
+            &index_src,
+            "<!doctype html>\n<html>\n<head>\n</head>\n<body>\n  <app-root></app-root>\n</body>\n</html>\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("styles.css"), artifact_bytes).unwrap();
+        std::fs::write(dir.path().join("polyfills.js"), artifact_bytes).unwrap();
+        std::fs::write(dir.path().join("main.js"), artifact_bytes).unwrap();
+        (dir, index_src)
+    }
+
+    #[test]
+    fn test_index_html_base_href_injection() {
+        let (dir, index_src) = setup_index_fixture(b"");
+        let opts = IndexHtmlOptions {
+            base_href: Some("/app/"),
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert!(content.contains(r#"<base href="/app/">"#));
+    }
+
+    #[test]
+    fn test_index_html_base_href_rewrites_existing() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let index_src = dir.path().join("index.html");
+        std::fs::write(
+            &index_src,
+            "<!doctype html>\n<html>\n<head><base href=\"/\"></head>\n<body></body>\n</html>\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("main.js"), b"").unwrap();
+        let opts = IndexHtmlOptions {
+            base_href: Some("/app/"),
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            false,
+            false,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert!(content.contains(r#"<base href="/app/">"#));
+        // Original href=/ should be gone — only one <base> tag remains.
+        assert_eq!(content.matches("<base ").count(), 1);
+    }
+
+    #[test]
+    fn test_index_html_deploy_url_prefixing() {
+        let (dir, index_src) = setup_index_fixture(b"");
+        let opts = IndexHtmlOptions {
+            deploy_url: Some("https://cdn.example.com/"),
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert!(content.contains(r#"href="https://cdn.example.com/styles.css""#));
+        assert!(content.contains(r#"src="https://cdn.example.com/polyfills.js""#));
+        assert!(content.contains(r#"src="https://cdn.example.com/main.js""#));
+    }
+
+    #[test]
+    fn test_index_html_cross_origin_anonymous() {
+        let (dir, index_src) = setup_index_fixture(b"");
+        let opts = IndexHtmlOptions {
+            cross_origin: CrossOrigin::Anonymous,
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert_eq!(content.matches(r#"crossorigin="anonymous""#).count(), 3);
+    }
+
+    #[test]
+    fn test_index_html_cross_origin_use_credentials() {
+        let (dir, index_src) = setup_index_fixture(b"");
+        let opts = IndexHtmlOptions {
+            cross_origin: CrossOrigin::UseCredentials,
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert!(content.contains(r#"crossorigin="use-credentials""#));
+    }
+
+    #[test]
+    fn test_index_html_subresource_integrity() {
+        use base64::Engine;
+        use sha2::{Digest, Sha384};
+        let payload = b"hello";
+        let (dir, index_src) = setup_index_fixture(payload);
+        let digest = Sha384::digest(payload);
+        let expected = format!(
+            "sha384-{}",
+            base64::engine::general_purpose::STANDARD.encode(digest)
+        );
+        let opts = IndexHtmlOptions {
+            subresource_integrity: true,
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert_eq!(content.matches(expected.as_str()).count(), 3);
+    }
+
+    #[test]
+    fn test_index_html_all_deploy_options_together() {
+        let (dir, index_src) = setup_index_fixture(b"payload");
+        let opts = IndexHtmlOptions {
+            base_href: Some("/app/"),
+            deploy_url: Some("https://cdn.example.com/"),
+            cross_origin: CrossOrigin::Anonymous,
+            subresource_integrity: true,
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            true,
+            true,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert!(content.contains(r#"<base href="/app/">"#));
+        assert!(content.contains(r#"href="https://cdn.example.com/styles.css""#));
+        assert!(content.contains(r#"src="https://cdn.example.com/polyfills.js""#));
+        assert!(content.contains(r#"src="https://cdn.example.com/main.js""#));
+        assert_eq!(content.matches(r#"crossorigin="anonymous""#).count(), 3);
+
+        // Verify SRI hashes match what openssl would emit for the payload.
+        use base64::Engine;
+        use sha2::{Digest, Sha384};
+        let digest = Sha384::digest(b"payload");
+        let expected = format!(
+            "sha384-{}",
+            base64::engine::general_purpose::STANDARD.encode(digest)
+        );
+        assert_eq!(content.matches(expected.as_str()).count(), 3);
     }
 
     #[test]

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -72,6 +72,15 @@ pub struct RawBuildOptions {
     pub styles: Option<Vec<RawStyleEntry>>,
     /// Asset entries.
     pub assets: Option<Vec<RawAssetEntry>>,
+    /// Base URL prefix injected into `<base href>` in `index.html`.
+    pub base_href: Option<String>,
+    /// Absolute URL prefix prepended to emitted script/style URLs.
+    pub deploy_url: Option<String>,
+    /// `crossorigin` attribute value for injected script/link tags
+    /// (`"none"`, `"anonymous"`, or `"use-credentials"`).
+    pub cross_origin: Option<String>,
+    /// Whether to compute and inject SRI `integrity` attributes.
+    pub subresource_integrity: Option<bool>,
 }
 
 /// Output path can be a simple string or an object for SSR setups.
@@ -157,6 +166,14 @@ pub struct FileReplacement {
 pub struct RawBuildConfiguration {
     /// File replacement entries.
     pub file_replacements: Option<Vec<FileReplacement>>,
+    /// Override for `baseHref`.
+    pub base_href: Option<String>,
+    /// Override for `deployUrl`.
+    pub deploy_url: Option<String>,
+    /// Override for `crossOrigin`.
+    pub cross_origin: Option<String>,
+    /// Override for `subresourceIntegrity`.
+    pub subresource_integrity: Option<bool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -192,6 +209,30 @@ pub enum ResolvedAsset {
     },
 }
 
+/// Value of the `crossOrigin` attribute applied to injected tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CrossOrigin {
+    /// No `crossorigin` attribute emitted (Angular default).
+    #[default]
+    None,
+    /// `crossorigin="anonymous"`.
+    Anonymous,
+    /// `crossorigin="use-credentials"`.
+    UseCredentials,
+}
+
+impl CrossOrigin {
+    /// The attribute value as it appears in the rendered HTML, or `None`
+    /// when no attribute should be emitted.
+    pub fn attribute_value(self) -> Option<&'static str> {
+        match self {
+            CrossOrigin::None => None,
+            CrossOrigin::Anonymous => Some("anonymous"),
+            CrossOrigin::UseCredentials => Some("use-credentials"),
+        }
+    }
+}
+
 /// A fully resolved Angular project build configuration.
 #[derive(Debug, Clone)]
 pub struct ResolvedAngularProject {
@@ -219,6 +260,14 @@ pub struct ResolvedAngularProject {
     pub polyfills: Vec<String>,
     /// File replacements for the active configuration.
     pub file_replacements: Vec<FileReplacement>,
+    /// `baseHref` value to inject into `<base href>`, if any.
+    pub base_href: Option<String>,
+    /// `deployUrl` prefix for injected asset URLs, if any.
+    pub deploy_url: Option<String>,
+    /// `crossOrigin` attribute for injected script/link tags.
+    pub cross_origin: CrossOrigin,
+    /// Whether SRI `integrity` attributes should be injected.
+    pub subresource_integrity: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +392,27 @@ pub fn resolve_angular_project(
         .and_then(|bc| bc.file_replacements.clone())
         .unwrap_or_default();
 
+    // Merge baseHref / deployUrl / crossOrigin / subresourceIntegrity with
+    // configuration values taking precedence over base options.
+    let base_href = build_config
+        .and_then(|bc| bc.base_href.clone())
+        .or_else(|| options.and_then(|o| o.base_href.clone()));
+    let deploy_url = build_config
+        .and_then(|bc| bc.deploy_url.clone())
+        .or_else(|| options.and_then(|o| o.deploy_url.clone()));
+    let cross_origin_raw = build_config
+        .and_then(|bc| bc.cross_origin.clone())
+        .or_else(|| options.and_then(|o| o.cross_origin.clone()));
+    let cross_origin = match cross_origin_raw.as_deref() {
+        Some("anonymous") => CrossOrigin::Anonymous,
+        Some("use-credentials") => CrossOrigin::UseCredentials,
+        _ => CrossOrigin::None,
+    };
+    let subresource_integrity = build_config
+        .and_then(|bc| bc.subresource_integrity)
+        .or_else(|| options.and_then(|o| o.subresource_integrity))
+        .unwrap_or(false);
+
     debug!(
         project = %name,
         output_path = %output_path.display(),
@@ -363,6 +433,10 @@ pub fn resolve_angular_project(
         assets,
         polyfills,
         file_replacements,
+        base_href,
+        deploy_url,
+        cross_origin,
+        subresource_integrity,
     })
 }
 
@@ -649,6 +723,113 @@ mod tests {
         // No explicit configuration — should use defaultConfiguration
         let result = resolve_angular_project(f.path(), None, None).unwrap();
         assert_eq!(result.file_replacements.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_deploy_options() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "baseHref": "/app/",
+                                "deployUrl": "https://cdn.example.com/",
+                                "crossOrigin": "anonymous",
+                                "subresourceIntegrity": true
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.base_href.as_deref(), Some("/app/"));
+        assert_eq!(
+            result.deploy_url.as_deref(),
+            Some("https://cdn.example.com/")
+        );
+        assert_eq!(result.cross_origin, CrossOrigin::Anonymous);
+        assert!(result.subresource_integrity);
+    }
+
+    #[test]
+    fn test_cross_origin_use_credentials() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "crossOrigin": "use-credentials"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.cross_origin, CrossOrigin::UseCredentials);
+    }
+
+    #[test]
+    fn test_deploy_options_default_to_none() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.base_href.is_none());
+        assert!(result.deploy_url.is_none());
+        assert_eq!(result.cross_origin, CrossOrigin::None);
+        assert!(!result.subresource_integrity);
+    }
+
+    #[test]
+    fn test_configuration_overrides_deploy_options() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "baseHref": "/default/",
+                                "subresourceIntegrity": false
+                            },
+                            "configurations": {
+                                "production": {
+                                    "baseHref": "/prod/",
+                                    "subresourceIntegrity": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, Some("production")).unwrap();
+        assert_eq!(result.base_href.as_deref(), Some("/prod/"));
+        assert!(result.subresource_integrity);
     }
 
     #[test]


### PR DESCRIPTION
Closes #67.

## Summary
- Parse `baseHref`, `deployUrl`, `crossOrigin`, and `subresourceIntegrity` from `angular.json` build options (and per-configuration overrides).
- Wire them into the `index.html` injection step so Angular apps deployed under sub-paths, behind CDNs, or under CORS/SRI-strict hosts get the correct attributes on their injected `<base>`, `<link>`, and `<script>` tags.
- SHA-384 hashes are computed over the files actually written to `out_dir`, so they verify against `openssl dgst -sha384 -binary … | openssl base64 -A`.

## Behavior
- `baseHref: /app/` rewrites an existing `<base href>` or injects one right after `<head>`.
- `deployUrl: https://cdn.example.com/` is prepended to `src`/`href` on the injected `styles.css`, `polyfills.js`, and main bundle tags.
- `crossOrigin: "anonymous" | "use-credentials"` emits `crossorigin="…"` on every injected `<link>` / `<script>`; `"none"` (default) emits no attribute.
- `subresourceIntegrity: true` emits `integrity="sha384-<base64>"` on every injected tag.
- All four options are read from `options` and can be overridden per-configuration (e.g. `production`).

## Test plan
- [x] Unit tests in `crates/project-resolver` cover each option, the default-none case, and configuration override.
- [x] Unit tests in `crates/cli` cover `baseHref` injection, `baseHref` rewrite of an existing tag, `deployUrl` prefixing, `crossOrigin` both variants, and SRI hashing.
- [x] Integration-style unit test (`test_index_html_all_deploy_options_together`) exercises all four options together and recomputes the SRI digest with `sha2`+`base64` to match what `openssl dgst` would produce.
- [x] `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` pass.