### PR TITLE
feat(npm-resolver): full exports conditional resolution (v0.7.22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.21"
+version = "0.7.22"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -66,6 +66,11 @@ pub struct BundleInput {
     /// Bare specifiers that have been resolved and included in the graph.
     /// The rewriter treats imports of these specifiers as local (strips them).
     pub bundled_specifiers: HashSet<String>,
+    /// Active `exports` conditions (e.g. `browser`, `import`, `production`).
+    /// Forwarded to the npm resolver when re-resolving specifiers during
+    /// bundling so the same branch of conditional exports selected during
+    /// dependency collection is selected again here.
+    pub export_conditions: Vec<String>,
 }
 
 /// Merge result for a single source: all imports grouped.
@@ -107,6 +112,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     let specifier_rewrites = build_specifier_rewrite_map(input, &chunk_graph.dynamic_import_map)?;
 
     let prefix_refs: Vec<&str> = input.local_prefixes.iter().map(|s| s.as_str()).collect();
+    let condition_refs: Vec<&str> = input.export_conditions.iter().map(|s| s.as_str()).collect();
     let mut output_chunks: HashMap<String, String> = HashMap::new();
     let mut chunk_source_maps: HashMap<String, SourceMap> = HashMap::new();
     let canon_cache: CanonCache = DashMap::new();
@@ -156,6 +162,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         main_file_to_ns: &HashMap::new(),
         main_chunk_module_set: &main_module_set,
         canon_cache: &canon_cache,
+        export_conditions: &condition_refs,
     })?;
     let main_spec_to_ns = main_result.specifier_to_namespace;
     let main_file_to_ns = main_result.file_to_namespace;
@@ -200,6 +207,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
                 main_file_to_ns: &main_file_to_ns,
                 main_chunk_module_set: &main_module_set,
                 canon_cache: &canon_cache,
+                export_conditions: &condition_refs,
             })?;
             Ok((chunk.filename.clone(), result))
         })
@@ -398,6 +406,8 @@ struct ChunkBundleParams<'a> {
     main_chunk_module_set: &'a HashSet<PathBuf>,
     /// Shared cache of `canonicalize()` results across all per-chunk work.
     canon_cache: &'a CanonCache,
+    /// Active `exports` conditions, forwarded to the npm resolver.
+    export_conditions: &'a [&'a str],
 }
 
 /// Result of bundling a single chunk, including cross-chunk dependency info.
@@ -455,6 +465,7 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
             if let Ok(entry_path) = ngc_npm_resolver::resolve::resolve_bare_specifier(
                 spec,
                 node_modules_dir.parent().unwrap_or(&node_modules_dir),
+                p.export_conditions,
             ) {
                 let canonical =
                     cached_canonicalize(p.canon_cache, &entry_path).unwrap_or(entry_path);
@@ -1096,6 +1107,7 @@ mod tests {
             options: BundleOptions::default(),
             per_module_maps: HashMap::new(),
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");
@@ -1142,6 +1154,7 @@ mod tests {
             options: BundleOptions::default(),
             per_module_maps: HashMap::new(),
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");
@@ -1184,6 +1197,7 @@ mod tests {
             options: BundleOptions::default(),
             per_module_maps: HashMap::new(),
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");
@@ -1227,6 +1241,7 @@ mod tests {
             options: BundleOptions::default(),
             per_module_maps: HashMap::new(),
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");
@@ -1354,6 +1369,7 @@ mod tests {
             },
             per_module_maps,
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");
@@ -1403,6 +1419,7 @@ mod tests {
             options: BundleOptions::default(),
             per_module_maps: HashMap::new(),
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");
@@ -1460,6 +1477,7 @@ mod tests {
             },
             per_module_maps: HashMap::new(),
             bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
         };
 
         let output = bundle(&input).expect("should bundle");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -260,8 +260,13 @@ fn run_build(
             bare_specifiers.push(spec);
         }
     }
-    let mut npm_resolution =
-        ngc_npm_resolver::resolve_npm_dependencies(&bare_specifiers, &config_dir)?;
+    let export_conditions =
+        ngc_npm_resolver::package_json::conditions_for_configuration(configuration);
+    let mut npm_resolution = ngc_npm_resolver::resolve_npm_dependencies(
+        &bare_specifiers,
+        &config_dir,
+        export_conditions,
+    )?;
 
     // Merge npm modules into the modules map (they're already JS — no transform needed)
     for (path, source) in &npm_resolution.modules {
@@ -318,7 +323,11 @@ fn run_build(
             new_specifiers
         );
         bare_specifiers.extend(new_specifiers.iter().cloned());
-        let extra = ngc_npm_resolver::resolve_npm_dependencies(&new_specifiers, &config_dir)?;
+        let extra = ngc_npm_resolver::resolve_npm_dependencies(
+            &new_specifiers,
+            &config_dir,
+            export_conditions,
+        )?;
         tracing::info!(
             "post-flatten npm resolution pulled in {} file(s)",
             extra.modules.len()
@@ -369,7 +378,14 @@ fn run_build(
         if let Some(entry_path) = npm_resolution
             .resolved_specifiers
             .contains(specifier)
-            .then(|| ngc_npm_resolver::resolve::resolve_bare_specifier(specifier, &config_dir).ok())
+            .then(|| {
+                ngc_npm_resolver::resolve::resolve_bare_specifier(
+                    specifier,
+                    &config_dir,
+                    export_conditions,
+                )
+                .ok()
+            })
             .flatten()
         {
             if let Some(&to_idx) = path_index.get(&entry_path) {
@@ -422,6 +438,7 @@ fn run_build(
         options: bundle_options,
         per_module_maps,
         bundled_specifiers,
+        export_conditions: export_conditions.iter().map(|s| (*s).to_string()).collect(),
     };
     drop(graph_span);
 

--- a/crates/npm-resolver/Cargo.toml
+++ b/crates/npm-resolver/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 ngc-diagnostics = { path = "../diagnostics" }
 ngc-project-resolver = { path = "../project-resolver" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 regex = "1.12"
 tracing = "0.1"
 rayon = "1.11"

--- a/crates/npm-resolver/src/lib.rs
+++ b/crates/npm-resolver/src/lib.rs
@@ -35,9 +35,14 @@ pub struct NpmResolution {
 /// its entry file via `package.json`, reads the source, scans for further
 /// imports, and recursively resolves those too. Returns all discovered files,
 /// edges, and the set of resolved specifiers.
+///
+/// `conditions` is forwarded to the `package.json` exports matcher: it
+/// determines which branch of a conditional exports object is selected
+/// (e.g. `browser` vs `node`, `production` vs `development`).
 pub fn resolve_npm_dependencies(
     specifiers: &[String],
     project_root: &Path,
+    conditions: &[&str],
 ) -> NgcResult<NpmResolution> {
     let node_modules = project_root.join("node_modules");
     if !node_modules.is_dir() {
@@ -76,7 +81,7 @@ pub fn resolve_npm_dependencies(
     let initial_entries: Vec<(String, PathBuf)> = specifiers
         .par_iter()
         .filter_map(
-            |spec| match resolve::resolve_bare_specifier(spec, project_root) {
+            |spec| match resolve::resolve_bare_specifier(spec, project_root, conditions) {
                 Ok(entry_path) => {
                     let canonical = canonicalize_cached(entry_path);
                     Some((spec.clone(), canonical))
@@ -136,7 +141,11 @@ pub fn resolve_npm_dependencies(
                             None,
                         )
                     } else {
-                        match resolve::resolve_bare_specifier(&import.specifier, project_root) {
+                        match resolve::resolve_bare_specifier(
+                            &import.specifier,
+                            project_root,
+                            conditions,
+                        ) {
                             Ok(p) => (Some(p), Some(import.specifier.clone())),
                             Err(_) => {
                                 debug!(
@@ -197,7 +206,10 @@ pub fn resolve_npm_dependencies(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::package_json::{DEVELOPMENT_BROWSER_CONDITIONS, PRODUCTION_BROWSER_CONDITIONS};
     use std::fs;
+
+    const DEV: &[&str] = DEVELOPMENT_BROWSER_CONDITIONS;
 
     fn setup_crawl_fixture(dir: &Path) {
         // Package "alpha" that imports from "beta" and has internal relative imports
@@ -235,8 +247,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_crawl_fixture(dir.path());
 
-        let result =
-            resolve_npm_dependencies(&["alpha".to_string()], dir.path()).expect("should resolve");
+        let result = resolve_npm_dependencies(&["alpha".to_string()], dir.path(), DEV)
+            .expect("should resolve");
 
         // Should have 3 files: alpha/dist/index.mjs, alpha/dist/utils.mjs, beta/index.mjs
         assert_eq!(result.modules.len(), 3, "should discover 3 npm files");
@@ -247,8 +259,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_crawl_fixture(dir.path());
 
-        let result =
-            resolve_npm_dependencies(&["alpha".to_string()], dir.path()).expect("should resolve");
+        let result = resolve_npm_dependencies(&["alpha".to_string()], dir.path(), DEV)
+            .expect("should resolve");
 
         // "beta" should be in resolved_specifiers even though only "alpha" was requested
         assert!(
@@ -266,8 +278,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_crawl_fixture(dir.path());
 
-        let result =
-            resolve_npm_dependencies(&["alpha".to_string()], dir.path()).expect("should resolve");
+        let result = resolve_npm_dependencies(&["alpha".to_string()], dir.path(), DEV)
+            .expect("should resolve");
 
         // Should have edges: index->utils (relative), index->beta (bare)
         assert_eq!(result.edges.len(), 2, "should have 2 dependency edges");
@@ -280,7 +292,7 @@ mod tests {
 
         // Request both alpha and beta — beta should not be crawled twice
         let result =
-            resolve_npm_dependencies(&["alpha".to_string(), "beta".to_string()], dir.path())
+            resolve_npm_dependencies(&["alpha".to_string(), "beta".to_string()], dir.path(), DEV)
                 .expect("should resolve");
 
         assert_eq!(result.modules.len(), 3, "should still have only 3 files");
@@ -290,7 +302,7 @@ mod tests {
     fn test_crawl_no_node_modules() {
         let dir = tempfile::tempdir().unwrap();
         // No node_modules directory
-        let result = resolve_npm_dependencies(&["anything".to_string()], dir.path())
+        let result = resolve_npm_dependencies(&["anything".to_string()], dir.path(), DEV)
             .expect("should succeed");
 
         assert!(result.modules.is_empty());
@@ -302,9 +314,86 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::create_dir_all(dir.path().join("node_modules")).unwrap();
 
-        let result = resolve_npm_dependencies(&["nonexistent".to_string()], dir.path())
+        let result = resolve_npm_dependencies(&["nonexistent".to_string()], dir.path(), DEV)
             .expect("should succeed with warning");
 
         assert!(result.modules.is_empty());
+    }
+
+    /// Integration test covering the end-to-end dev vs prod split: a package
+    /// exposes different entry files for the `development` and `production`
+    /// conditions, and each build mode pulls in its own transitive graph.
+    #[test]
+    fn test_crawl_dev_vs_prod_entry_split() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg_dir = dir.path().join("node_modules/envsplit");
+        fs::create_dir_all(pkg_dir.join("dev")).unwrap();
+        fs::create_dir_all(pkg_dir.join("prod")).unwrap();
+        fs::write(
+            pkg_dir.join("package.json"),
+            r#"{
+              "exports": {
+                ".": {
+                  "browser": {
+                    "development": "./dev/entry.mjs",
+                    "production": "./prod/entry.mjs"
+                  },
+                  "default": "./dev/entry.mjs"
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pkg_dir.join("dev/entry.mjs"),
+            "export const mode = 'dev';\nexport const verbose = true;\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg_dir.join("prod/entry.mjs"),
+            "export const mode = 'prod';\n",
+        )
+        .unwrap();
+
+        let prod = resolve_npm_dependencies(
+            &["envsplit".to_string()],
+            dir.path(),
+            PRODUCTION_BROWSER_CONDITIONS,
+        )
+        .expect("prod resolution");
+        let dev = resolve_npm_dependencies(
+            &["envsplit".to_string()],
+            dir.path(),
+            DEVELOPMENT_BROWSER_CONDITIONS,
+        )
+        .expect("dev resolution");
+
+        let prod_keys: Vec<String> = prod
+            .modules
+            .keys()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        let dev_keys: Vec<String> = dev
+            .modules
+            .keys()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            prod_keys.iter().any(|k| k.ends_with("prod/entry.mjs")),
+            "production build should include prod/entry.mjs, got {prod_keys:?}"
+        );
+        assert!(
+            !prod_keys.iter().any(|k| k.ends_with("dev/entry.mjs")),
+            "production build should NOT include dev/entry.mjs, got {prod_keys:?}"
+        );
+        assert!(
+            dev_keys.iter().any(|k| k.ends_with("dev/entry.mjs")),
+            "development build should include dev/entry.mjs, got {dev_keys:?}"
+        );
+        assert!(
+            !dev_keys.iter().any(|k| k.ends_with("prod/entry.mjs")),
+            "development build should NOT include prod/entry.mjs, got {dev_keys:?}"
+        );
     }
 }

--- a/crates/npm-resolver/src/package_json.rs
+++ b/crates/npm-resolver/src/package_json.rs
@@ -2,21 +2,54 @@
 //!
 //! Reads a package's `package.json` and resolves the ESM entry point for a
 //! given subpath using the `exports`, `module`, and `main` fields.
+//!
+//! Matches the Node.js Package Exports spec: the `exports` object is walked
+//! in the order its keys appear in the JSON source, and the first key that
+//! is either `"default"` or a member of the active condition set wins.
+//! Values may themselves be condition objects (nested), a string, or a
+//! `null` meaning the path is explicitly blocked.
 
 use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::{NgcError, NgcResult};
 
+/// Default conditions for a production browser bundle.
+///
+/// Order is immaterial — the exports object's key order is what Node uses
+/// to decide precedence. What matters here is membership.
+pub const PRODUCTION_BROWSER_CONDITIONS: &[&str] =
+    &["browser", "module", "import", "production", "default"];
+
+/// Default conditions for a development browser bundle.
+pub const DEVELOPMENT_BROWSER_CONDITIONS: &[&str] =
+    &["browser", "module", "import", "development", "default"];
+
+/// Pick the default condition set for a build configuration name.
+///
+/// `"production"` activates the `production` condition; anything else (including
+/// `"development"` or `None`) activates `development`. Both sets include
+/// `browser`, `module`, `import`, and `default`.
+pub fn conditions_for_configuration(configuration: Option<&str>) -> &'static [&'static str] {
+    match configuration {
+        Some("production") => PRODUCTION_BROWSER_CONDITIONS,
+        _ => DEVELOPMENT_BROWSER_CONDITIONS,
+    }
+}
+
 /// Resolve the ESM entry point for a package given its directory and a subpath.
 ///
 /// Follows the Node.js module resolution algorithm:
-/// 1. Check `exports` field for the subpath with `"default"` condition
+/// 1. Check `exports` field for the subpath under the active conditions
 /// 2. Fall back to `module` field (ESM entry)
 /// 3. Fall back to `main` field
-/// 4. Fall back to `index.js`
+/// 4. Fall back to `index.js` / `index.mjs`
 ///
 /// The `subpath` should be `"."` for the package root, or `"./sub"` for subpath imports.
-pub fn resolve_package_entry(pkg_dir: &Path, subpath: &str) -> NgcResult<PathBuf> {
+pub fn resolve_package_entry(
+    pkg_dir: &Path,
+    subpath: &str,
+    conditions: &[&str],
+) -> NgcResult<PathBuf> {
     let pkg_json_path = pkg_dir.join("package.json");
     let content = std::fs::read_to_string(&pkg_json_path).map_err(|e| NgcError::Io {
         path: pkg_json_path.clone(),
@@ -31,7 +64,7 @@ pub fn resolve_package_entry(pkg_dir: &Path, subpath: &str) -> NgcResult<PathBuf
 
     // 1. Try exports field
     if let Some(exports) = pkg.get("exports") {
-        if let Some(entry) = resolve_exports(exports, subpath) {
+        if let Some(entry) = resolve_exports(exports, subpath, conditions) {
             let resolved = pkg_dir.join(&entry);
             if resolved.is_file() {
                 return Ok(resolved);
@@ -81,46 +114,60 @@ pub fn resolve_package_entry(pkg_dir: &Path, subpath: &str) -> NgcResult<PathBuf
 ///
 /// Supports:
 /// - String exports: `"exports": "./dist/index.js"`
-/// - Object exports with conditions: `"exports": { ".": { "default": "./dist/index.js" } }`
-/// - Nested conditions: `"exports": { ".": { "import": { "default": "./dist/index.mjs" } } }`
-/// - Glob patterns: `"./locales/*": { "default": "./locales/*.js" }`
-fn resolve_exports(exports: &serde_json::Value, subpath: &str) -> Option<String> {
+/// - Sugar-form condition object at root: `"exports": { "import": "./m.mjs", "default": "./m.js" }`
+/// - Subpath map: `"exports": { ".": ..., "./sub": ... }`
+/// - Nested conditions: `{ "browser": { "import": "./b.mjs" } }`
+/// - Pattern trailers: `"./feature/*": { "default": "./feat/*.js" }` — the
+///   longest matching prefix wins, per the Node spec.
+fn resolve_exports(
+    exports: &serde_json::Value,
+    subpath: &str,
+    conditions: &[&str],
+) -> Option<String> {
     match exports {
         // "exports": "./dist/index.js" — only matches root subpath
         serde_json::Value::String(s) if subpath == "." => Some(s.clone()),
 
-        // "exports": { ".": ..., "./sub": ... }
+        // "exports": [...] — array sugar; first resolvable wins
+        serde_json::Value::Array(arr) if subpath == "." => {
+            arr.iter().find_map(|v| resolve_target(v, None, conditions))
+        }
+
+        // "exports": { ".": ..., "./sub": ... } OR condition-keyed sugar
         serde_json::Value::Object(map) => {
-            // Check if keys look like subpaths (start with ".")
             let has_subpath_keys = map.keys().any(|k| k.starts_with('.'));
 
             if has_subpath_keys {
-                // Direct lookup first
+                // Direct lookup first — pattern with no trailing "*"
                 if let Some(entry) = map.get(subpath) {
-                    return resolve_condition(entry);
+                    return resolve_target(entry, None, conditions);
                 }
 
-                // Try glob pattern matching: "./locales/*" matches "./locales/de"
+                // Pattern trailers: longest-prefix match wins, per Node spec.
+                let mut best: Option<(&str, &serde_json::Value)> = None;
                 for (pattern, value) in map {
-                    if let Some(prefix) = pattern.strip_suffix('*') {
-                        if let Some(rest) = subpath.strip_prefix(prefix) {
-                            if let Some(resolved) = resolve_condition(value) {
-                                // Replace * in the resolved path with the matched rest
-                                return Some(resolved.replace('*', rest));
-                            }
-                        }
+                    let Some(prefix) = pattern.strip_suffix('*') else {
+                        continue;
+                    };
+                    if !subpath.starts_with(prefix) {
+                        continue;
                     }
+                    match best {
+                        Some((cur, _)) if cur.len() >= prefix.len() => {}
+                        _ => best = Some((prefix, value)),
+                    }
+                }
+                if let Some((prefix, value)) = best {
+                    let rest = &subpath[prefix.len()..];
+                    return resolve_target(value, Some(rest), conditions);
                 }
 
                 None
+            } else if subpath == "." {
+                // Sugar: root entry whose keys are conditions.
+                resolve_target(exports, None, conditions)
             } else {
-                // Keys are conditions (e.g., "import", "default", "types")
-                // This is the root entry
-                if subpath == "." {
-                    resolve_condition(exports)
-                } else {
-                    None
-                }
+                None
             }
         }
 
@@ -128,40 +175,55 @@ fn resolve_exports(exports: &serde_json::Value, subpath: &str) -> Option<String>
     }
 }
 
-/// Resolve a conditional export value to a file path string.
+/// Resolve a conditional export value to a file path string, honouring the
+/// active condition set.
 ///
-/// Handles:
-/// - Direct string: `"./dist/index.js"`
-/// - Condition object: `{ "default": "./dist/index.js", "types": "./dist/index.d.ts" }`
-/// - Nested conditions: `{ "import": { "default": "./dist/index.mjs" } }`
-fn resolve_condition(value: &serde_json::Value) -> Option<String> {
+/// The rules mirror Node's [PACKAGE_EXPORTS_RESOLVE] /
+/// [PACKAGE_TARGET_RESOLVE] algorithm:
+/// - `String` → the target path (with `*` substituted if we're in a pattern match).
+/// - `Object` → iterate the keys in insertion order; the first key that is
+///   either `"default"` or a member of `conditions` whose value resolves to
+///   a non-null target wins. Non-string/non-object values are skipped.
+/// - `Array` → alternate targets; first resolvable wins.
+/// - `Null` → explicitly blocked; return None.
+fn resolve_target(
+    value: &serde_json::Value,
+    pattern_rest: Option<&str>,
+    conditions: &[&str],
+) -> Option<String> {
     match value {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Object(map) => {
-            // Prefer "module" (bundler ESM), then "import" (ESM), then "default"
-            for key in &["module", "import", "default", "require"] {
-                if let Some(val) = map.get(*key) {
-                    if let Some(resolved) = resolve_condition(val) {
-                        // Skip .d.ts files
-                        if !resolved.ends_with(".d.ts") {
-                            return Some(resolved);
-                        }
-                    }
-                }
+        serde_json::Value::String(s) => {
+            // Guard against accidentally picking up type declarations as a
+            // runtime entry. If the package only offers a .d.ts and no
+            // runtime alternative, this returns None and the caller falls
+            // back to `module` / `main`.
+            if s.ends_with(".d.ts") || s.ends_with(".d.mts") || s.ends_with(".d.cts") {
+                return None;
             }
-            // Try first non-types entry
+            Some(match pattern_rest {
+                Some(rest) => s.replace('*', rest),
+                None => s.clone(),
+            })
+        }
+        serde_json::Value::Object(map) => {
             for (key, val) in map {
-                if key == "types" {
+                // `types` never points at a runtime file; skip unless the
+                // caller explicitly asked for it.
+                if key == "types" && !conditions.contains(&"types") {
                     continue;
                 }
-                if let Some(resolved) = resolve_condition(val) {
-                    if !resolved.ends_with(".d.ts") {
+                if key == "default" || conditions.contains(&key.as_str()) {
+                    if let Some(resolved) = resolve_target(val, pattern_rest, conditions) {
                         return Some(resolved);
                     }
                 }
             }
             None
         }
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .find_map(|v| resolve_target(v, pattern_rest, conditions)),
+        serde_json::Value::Null => None,
         _ => None,
     }
 }
@@ -220,6 +282,9 @@ mod tests {
     use super::*;
     use std::fs;
 
+    const DEV: &[&str] = DEVELOPMENT_BROWSER_CONDITIONS;
+    const PROD: &[&str] = PRODUCTION_BROWSER_CONDITIONS;
+
     fn create_mock_package(dir: &Path, name: &str, pkg_json: &str, files: &[(&str, &str)]) {
         let pkg_dir = dir.join("node_modules").join(name);
         fs::create_dir_all(&pkg_dir).unwrap();
@@ -272,7 +337,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/simple-pkg");
-        let result = resolve_package_entry(&pkg_dir, ".").unwrap();
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(result.ends_with("dist/index.js"));
     }
 
@@ -287,7 +352,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/cond-pkg");
-        let result = resolve_package_entry(&pkg_dir, ".").unwrap();
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(result.ends_with("fesm2022/pkg.mjs"));
     }
 
@@ -305,7 +370,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/sub-pkg");
-        let result = resolve_package_entry(&pkg_dir, "./operators").unwrap();
+        let result = resolve_package_entry(&pkg_dir, "./operators", DEV).unwrap();
         assert!(result.ends_with("dist/operators/index.js"));
     }
 
@@ -320,7 +385,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/module-pkg");
-        let result = resolve_package_entry(&pkg_dir, ".").unwrap();
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(result.ends_with("esm/index.mjs"));
     }
 
@@ -335,7 +400,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/main-pkg");
-        let result = resolve_package_entry(&pkg_dir, ".").unwrap();
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(result.ends_with("lib/index.js"));
     }
 
@@ -350,7 +415,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/bare-pkg");
-        let result = resolve_package_entry(&pkg_dir, ".").unwrap();
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(result.ends_with("index.js"));
     }
 
@@ -369,7 +434,7 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/glob-pkg");
-        let result = resolve_package_entry(&pkg_dir, "./locales/de").unwrap();
+        let result = resolve_package_entry(&pkg_dir, "./locales/de", DEV).unwrap();
         assert!(result.ends_with("locales/de.js"));
     }
 
@@ -384,7 +449,281 @@ mod tests {
         );
 
         let pkg_dir = dir.path().join("node_modules/nested-pkg");
-        let result = resolve_package_entry(&pkg_dir, ".").unwrap();
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(result.ends_with("esm/index.mjs"));
+    }
+
+    // --- New coverage: browser / node / development / production ---
+
+    #[test]
+    fn test_browser_condition_picks_browser_over_default() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "browser-pkg",
+            r#"{ "exports": { ".": { "node": "./node/index.mjs", "browser": "./browser/index.mjs", "default": "./dist/index.mjs" } } }"#,
+            &[
+                ("node/index.mjs", "export const x = 'node';"),
+                ("browser/index.mjs", "export const x = 'browser';"),
+                ("dist/index.mjs", "export const x = 'default';"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/browser-pkg");
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(
+            result.ends_with("browser/index.mjs"),
+            "expected browser branch, got {}",
+            result.display()
+        );
+    }
+
+    #[test]
+    fn test_node_condition_picks_node_when_browser_inactive() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "node-pkg",
+            r#"{ "exports": { ".": { "node": "./node/index.mjs", "default": "./dist/index.mjs" } } }"#,
+            &[
+                ("node/index.mjs", "export const x = 'node';"),
+                ("dist/index.mjs", "export const x = 'default';"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/node-pkg");
+        let result = resolve_package_entry(&pkg_dir, ".", &["node", "import", "default"]).unwrap();
+        assert!(result.ends_with("node/index.mjs"));
+    }
+
+    #[test]
+    fn test_production_vs_development_pick_different_files() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "envmode-pkg",
+            r#"{ "exports": { ".": { "development": "./dev/index.mjs", "production": "./prod/index.mjs", "default": "./dist/index.mjs" } } }"#,
+            &[
+                ("dev/index.mjs", "export const x = 'dev';"),
+                ("prod/index.mjs", "export const x = 'prod';"),
+                ("dist/index.mjs", "export const x = 'default';"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/envmode-pkg");
+        let dev_res = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        let prod_res = resolve_package_entry(&pkg_dir, ".", PROD).unwrap();
+        assert!(dev_res.ends_with("dev/index.mjs"), "{}", dev_res.display());
+        assert!(
+            prod_res.ends_with("prod/index.mjs"),
+            "{}",
+            prod_res.display()
+        );
+    }
+
+    #[test]
+    fn test_deeply_nested_browser_production_import() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "deep-pkg",
+            r#"{
+              "exports": {
+                ".": {
+                  "browser": {
+                    "production": {
+                      "import": "./b-prod/index.mjs",
+                      "default": "./b-prod/fallback.js"
+                    },
+                    "development": {
+                      "import": "./b-dev/index.mjs"
+                    },
+                    "default": "./b/index.mjs"
+                  },
+                  "default": "./dist/index.mjs"
+                }
+              }
+            }"#,
+            &[
+                ("b-prod/index.mjs", "export const x = 'bp';"),
+                ("b-dev/index.mjs", "export const x = 'bd';"),
+                ("b/index.mjs", "export const x = 'b';"),
+                ("dist/index.mjs", "export const x = 'd';"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/deep-pkg");
+        let prod_res = resolve_package_entry(&pkg_dir, ".", PROD).unwrap();
+        let dev_res = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(prod_res.ends_with("b-prod/index.mjs"));
+        assert!(dev_res.ends_with("b-dev/index.mjs"));
+    }
+
+    #[test]
+    fn test_first_match_wins_order_sensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        // `module` comes before `default` in the source — module must win
+        // because both are active in the condition set.
+        create_mock_package(
+            dir.path(),
+            "order-pkg",
+            r#"{ "exports": { ".": { "module": "./esm/index.mjs", "default": "./cjs/index.js" } } }"#,
+            &[
+                ("esm/index.mjs", "export const x = 1;"),
+                ("cjs/index.js", "module.exports = {};"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/order-pkg");
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(result.ends_with("esm/index.mjs"));
+    }
+
+    #[test]
+    fn test_default_considered_last_even_if_listed_first() {
+        let dir = tempfile::tempdir().unwrap();
+        // "default" is in the JSON before "browser". Node spec says keys
+        // are still walked top-down; the first match wins. So `default`
+        // should win here because it matches first in source order.
+        create_mock_package(
+            dir.path(),
+            "default-first",
+            r#"{ "exports": { ".": { "default": "./dist/index.mjs", "browser": "./browser/index.mjs" } } }"#,
+            &[
+                ("dist/index.mjs", "export const x = 'd';"),
+                ("browser/index.mjs", "export const x = 'b';"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/default-first");
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(result.ends_with("dist/index.mjs"));
+    }
+
+    #[test]
+    fn test_null_target_is_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "blocked-pkg",
+            r#"{ "exports": { ".": { "browser": null, "default": "./dist/index.mjs" } } }"#,
+            &[("dist/index.mjs", "export const x = 1;")],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/blocked-pkg");
+        let result = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(result.ends_with("dist/index.mjs"));
+    }
+
+    #[test]
+    fn test_pattern_trailer_under_nested_conditions() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "pat-pkg",
+            r#"{ "exports": { "./feature/*": { "browser": { "import": "./browser/feat/*.mjs" }, "default": "./feat/*.js" } } }"#,
+            &[
+                ("browser/feat/foo.mjs", "export const x = 1;"),
+                ("feat/foo.js", "module.exports = {};"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/pat-pkg");
+        let result = resolve_package_entry(&pkg_dir, "./feature/foo", DEV).unwrap();
+        assert!(
+            result.ends_with("browser/feat/foo.mjs"),
+            "{}",
+            result.display()
+        );
+    }
+
+    #[test]
+    fn test_angular_package_shape() {
+        // Mirrors how @angular/core lays out its exports today.
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "@angular/core",
+            r#"{
+              "exports": {
+                "./package.json": { "default": "./package.json" },
+                ".": {
+                  "types": "./index.d.ts",
+                  "default": "./fesm2022/core.mjs"
+                },
+                "./testing": {
+                  "types": "./testing/index.d.ts",
+                  "default": "./fesm2022/testing.mjs"
+                }
+              }
+            }"#,
+            &[
+                ("fesm2022/core.mjs", "export const Component = {};"),
+                ("fesm2022/testing.mjs", "export const TestBed = {};"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/@angular/core");
+        let root = resolve_package_entry(&pkg_dir, ".", PROD).unwrap();
+        let testing = resolve_package_entry(&pkg_dir, "./testing", PROD).unwrap();
+        assert!(root.ends_with("fesm2022/core.mjs"));
+        assert!(testing.ends_with("fesm2022/testing.mjs"));
+    }
+
+    #[test]
+    fn test_react_like_dev_prod_split() {
+        // Mirrors react's exports shape: separate development and production
+        // files keyed by the `production` / `development` conditions.
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "reactish",
+            r#"{
+              "exports": {
+                ".": {
+                  "browser": {
+                    "development": "./dev/reactish.development.mjs",
+                    "production": "./prod/reactish.production.mjs",
+                    "default": "./prod/reactish.production.mjs"
+                  },
+                  "default": "./index.js"
+                }
+              }
+            }"#,
+            &[
+                ("dev/reactish.development.mjs", "export const v = 'dev';"),
+                ("prod/reactish.production.mjs", "export const v = 'prod';"),
+                ("index.js", "module.exports = {};"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/reactish");
+        let prod = resolve_package_entry(&pkg_dir, ".", PROD).unwrap();
+        let dev = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(prod.ends_with("reactish.production.mjs"));
+        assert!(dev.ends_with("reactish.development.mjs"));
+    }
+
+    #[test]
+    fn test_array_alternate_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        create_mock_package(
+            dir.path(),
+            "alt-pkg",
+            r#"{ "exports": { ".": [ { "browser": "./a.mjs" }, "./b.mjs" ] } }"#,
+            &[
+                ("a.mjs", "export const x = 'a';"),
+                ("b.mjs", "export const x = 'b';"),
+            ],
+        );
+
+        let pkg_dir = dir.path().join("node_modules/alt-pkg");
+        let browser = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
+        assert!(browser.ends_with("a.mjs"));
+        // Without the browser condition the first alt yields None, so the
+        // walker falls back to the string "./b.mjs".
+        let no_browser =
+            resolve_package_entry(&pkg_dir, ".", &["module", "import", "default"]).unwrap();
+        assert!(no_browser.ends_with("b.mjs"));
     }
 }

--- a/crates/npm-resolver/src/resolve.rs
+++ b/crates/npm-resolver/src/resolve.rs
@@ -13,7 +13,13 @@ use crate::package_json::{parse_specifier, resolve_package_entry};
 ///
 /// Parses the specifier into package name and subpath, locates the package
 /// in `node_modules`, and resolves its entry point via `package.json`.
-pub fn resolve_bare_specifier(specifier: &str, project_root: &Path) -> NgcResult<PathBuf> {
+/// `conditions` is the active condition set used by the exports field
+/// matcher — see [`crate::package_json`] for the built-in sets.
+pub fn resolve_bare_specifier(
+    specifier: &str,
+    project_root: &Path,
+    conditions: &[&str],
+) -> NgcResult<PathBuf> {
     let (pkg_name, subpath) = parse_specifier(specifier);
     let node_modules = project_root.join("node_modules");
     let pkg_dir = node_modules.join(&pkg_name);
@@ -25,7 +31,7 @@ pub fn resolve_bare_specifier(specifier: &str, project_root: &Path) -> NgcResult
         });
     }
 
-    resolve_package_entry(&pkg_dir, &subpath)
+    resolve_package_entry(&pkg_dir, &subpath, conditions)
 }
 
 /// Resolve a relative import specifier from within an npm package file.
@@ -85,7 +91,10 @@ pub fn resolve_relative_import(specifier: &str, from_file: &Path) -> NgcResult<P
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::package_json::DEVELOPMENT_BROWSER_CONDITIONS;
     use std::fs;
+
+    const DEV: &[&str] = DEVELOPMENT_BROWSER_CONDITIONS;
 
     fn setup_mock_packages(dir: &Path) {
         // @angular/core
@@ -127,7 +136,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_mock_packages(dir.path());
 
-        let result = resolve_bare_specifier("@angular/core", dir.path()).unwrap();
+        let result = resolve_bare_specifier("@angular/core", dir.path(), DEV).unwrap();
         assert!(result.ends_with("fesm2022/core.mjs"));
     }
 
@@ -136,7 +145,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_mock_packages(dir.path());
 
-        let result = resolve_bare_specifier("rxjs", dir.path()).unwrap();
+        let result = resolve_bare_specifier("rxjs", dir.path(), DEV).unwrap();
         assert!(result.ends_with("dist/esm5/index.js"));
     }
 
@@ -145,14 +154,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_mock_packages(dir.path());
 
-        let result = resolve_bare_specifier("rxjs/operators", dir.path()).unwrap();
+        let result = resolve_bare_specifier("rxjs/operators", dir.path(), DEV).unwrap();
         assert!(result.ends_with("dist/esm5/operators/index.js"));
     }
 
     #[test]
     fn test_resolve_missing_package() {
         let dir = tempfile::tempdir().unwrap();
-        let result = resolve_bare_specifier("nonexistent-pkg", dir.path());
+        let result = resolve_bare_specifier("nonexistent-pkg", dir.path(), DEV);
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
## Summary

Closes #64. Makes the npm resolver's `exports` field matcher honour the full Node.js Package Exports spec — the active condition set (`browser`, `node`, `development`, `production`, `module`, `import`, `default`) is now threaded through the resolver, and conditional-exports objects are walked in JSON source order with first-match-wins. Nested condition objects, pattern trailers, `null` (blocked) targets, and array alternates are all supported.

## Why

Before this change the matcher only looked at `module` / `import` / `default` / `require`, so packages shipping separate dev vs prod bundles, browser-only wrappers, or Node-only internals resolved to the wrong entry point. Symptoms: stray Node built-ins in the browser bundle, un-minified dev builds shipping to prod, and missing files for the `browser` condition.

## What changed

- `crates/npm-resolver`:
  - Rewrote `resolve_exports` / `resolve_target` (formerly `resolve_condition`) around an ordered active condition set. Iteration now walks the exports object in JSON source order (via serde_json's `preserve_order` feature) so the package author's ordering — `browser` before `default`, etc. — determines precedence, matching Node exactly.
  - Added `conditions_for_configuration` and the `PRODUCTION_BROWSER_CONDITIONS` / `DEVELOPMENT_BROWSER_CONDITIONS` sets.
  - `resolve_package_entry` / `resolve_bare_specifier` / `resolve_npm_dependencies` now take `conditions: &[&str]`.
  - New branches for nested condition objects, pattern-trailer targets under conditions, `null` (blocked) values, and array-of-alternates.
- `crates/bundler`: `BundleInput` gains `export_conditions`; the re-resolve inside `bundle_chunk` now passes them through.
- `crates/cli`: build configuration (`production` vs `development`) picks the condition set and forwards it into both npm resolution passes and the bundler.

## Tests

- Unit tests in `crates/npm-resolver/src/package_json.rs` cover:
  - `browser` beats `default` when active.
  - `node` picked when `browser` is inactive.
  - `production` vs `development` resolve to different files.
  - Deeply nested `browser` → `production` → `import` triple.
  - First-match-wins source-order semantics (and the `default`-listed-first caveat).
  - `null` target is blocked and falls through.
  - Pattern trailer `./feature/*` under nested conditions.
  - A `@angular/core`-shape fixture and a React-like dev/prod split fixture.
- Integration test in `crates/npm-resolver/src/lib.rs`: a package declares both `development` and `production` entries; the full crawler pulls in the matching file for each mode and nothing from the other.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Verify against a real Angular 21 app (dev + prod builds) once this lands in the staging harness.
