### PR TITLE
feat(bundler): web worker bundling (new Worker + new URL + import.meta.url)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.23"
+version = "0.7.24"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -62,14 +62,26 @@ pub fn build_chunk_graph(
         ),
     })?;
 
-    // Step 1: Identify split points (targets of dynamic import edges)
+    // Step 1: Identify split points (targets of dynamic import or worker edges)
+    // and remember which ones came from worker URLs so we can give them a
+    // `worker-` filename prefix instead of the generic `chunk-` prefix.
     let mut split_points: BTreeSet<NodeIndex> = BTreeSet::new();
+    let mut worker_split_points: HashSet<NodeIndex> = HashSet::new();
     for edge in graph.edge_indices() {
         if let Some(weight) = graph.edge_weight(edge) {
-            if *weight == ImportKind::Dynamic {
-                if let Some((_source, target)) = graph.edge_endpoints(edge) {
-                    split_points.insert(target);
+            match *weight {
+                ImportKind::Dynamic => {
+                    if let Some((_source, target)) = graph.edge_endpoints(edge) {
+                        split_points.insert(target);
+                    }
                 }
+                ImportKind::Worker => {
+                    if let Some((_source, target)) = graph.edge_endpoints(edge) {
+                        split_points.insert(target);
+                        worker_split_points.insert(target);
+                    }
+                }
+                ImportKind::Static => {}
             }
         }
     }
@@ -175,7 +187,11 @@ pub fn build_chunk_graph(
             continue;
         }
 
-        let filename = chunk_filename_from_path(&sp_path, root_dir);
+        let filename = if worker_split_points.contains(&sp) {
+            worker_chunk_filename_from_path(&sp_path, root_dir)
+        } else {
+            chunk_filename_from_path(&sp_path, root_dir)
+        };
 
         // Modules exclusive to this lazy chunk + the split point itself
         let mut chunk_nodes: HashSet<NodeIndex> = HashSet::new();
@@ -516,6 +532,38 @@ fn scc_emit_deps_first(
     }
 }
 
+/// Derive a worker chunk filename from a worker entry's file path.
+///
+/// Strips a trailing `.worker` segment so `foo.worker.ts` produces
+/// `worker-foo.js` rather than the redundant `worker-foo-worker.js`.
+/// Example: `/root/src/app/compute.worker.ts` → `"worker-compute.js"`
+fn worker_chunk_filename_from_path(path: &Path, root_dir: &Path) -> String {
+    let relative = path.strip_prefix(root_dir).unwrap_or(path);
+    let stem = relative.with_extension("");
+    let stem_str = stem.to_string_lossy();
+
+    let name = stem_str
+        .replace(['/', '\\'], "-")
+        .replace('.', "-")
+        .to_lowercase();
+
+    let mut parts: Vec<&str> = name.split('-').filter(|s| !s.is_empty()).collect();
+    if parts.last().is_some_and(|s| *s == "worker") {
+        parts.pop();
+    }
+    let short_name = if parts.len() > 2 {
+        parts[parts.len() - 2..].join("-")
+    } else {
+        parts.join("-")
+    };
+
+    if short_name.is_empty() {
+        "worker.js".to_string()
+    } else {
+        format!("worker-{short_name}.js")
+    }
+}
+
 /// Derive a chunk filename from a split point's file path.
 ///
 /// Example: `/root/src/app/admin/admin.component.ts` → `"chunk-admin-component.js"`
@@ -732,6 +780,53 @@ mod tests {
             .modules
             .iter()
             .any(|m| m.to_str().unwrap_or("").contains("admin")));
+    }
+
+    #[test]
+    fn test_worker_chunk_filename_from_path() {
+        let root = Path::new("/root/src");
+        assert_eq!(
+            worker_chunk_filename_from_path(Path::new("/root/src/compute.worker.ts"), root),
+            "worker-compute.js"
+        );
+        assert_eq!(
+            worker_chunk_filename_from_path(Path::new("/root/src/workers/compute.worker.ts"), root),
+            "worker-workers-compute.js"
+        );
+        // No trailing .worker segment — no strip.
+        assert_eq!(
+            worker_chunk_filename_from_path(Path::new("/root/src/foo.ts"), root),
+            "worker-foo.js"
+        );
+    }
+
+    #[test]
+    fn test_worker_edge_creates_worker_chunk() {
+        let mut graph = DiGraph::new();
+        let worker = graph.add_node(make_path("/root/src/compute.worker.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+        graph.add_edge(entry, worker, ImportKind::Worker);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        assert_eq!(result.chunks.len(), 2);
+        let worker_chunk = result
+            .chunks
+            .iter()
+            .find(|c| c.kind == ChunkKind::Lazy)
+            .expect("should have a lazy chunk for the worker");
+        assert_eq!(worker_chunk.filename, "worker-compute.js");
+        assert_eq!(
+            result
+                .dynamic_import_map
+                .get(&make_path("/root/src/compute.worker.ts")),
+            Some(&"worker-compute.js".to_string())
+        );
     }
 
     #[test]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -1279,6 +1279,84 @@ mod tests {
     }
 
     #[test]
+    fn test_worker_bundling_emits_separate_chunk_and_rewrites_url() {
+        // main --worker--> compute.worker
+        // compute.worker --static--> worker-dep
+        let mut graph = DiGraph::new();
+        let worker_dep = graph.add_node(make_path("/root/worker-dep.ts"));
+        let worker = graph.add_node(make_path("/root/compute.worker.ts"));
+        let entry = graph.add_node(make_path("/root/main.ts"));
+        graph.add_edge(entry, worker, ImportKind::Worker);
+        graph.add_edge(worker, worker_dep, ImportKind::Static);
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            make_path("/root/worker-dep.ts"),
+            "export function heavy(x) { return x * 2; }\n".to_string(),
+        );
+        modules.insert(
+            make_path("/root/compute.worker.ts"),
+            "import { heavy } from './worker-dep';\nself.onmessage = (e) => self.postMessage(heavy(e.data));\n"
+                .to_string(),
+        );
+        modules.insert(
+            make_path("/root/main.ts"),
+            "const w = new Worker(new URL('./compute.worker', import.meta.url), { type: 'module' });\nconsole.log(w);\n".to_string(),
+        );
+
+        let input = BundleInput {
+            modules,
+            graph,
+            entry: make_path("/root/main.ts"),
+            local_prefixes: vec![".".to_string()],
+            root_dir: make_path("/root"),
+            options: BundleOptions::default(),
+            per_module_maps: HashMap::new(),
+            bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
+        };
+
+        let output = bundle(&input).expect("should bundle");
+
+        // Exactly one main + one worker chunk.
+        assert_eq!(output.chunks.len(), 2, "should produce 2 chunks");
+        let worker_entry = output
+            .chunks
+            .iter()
+            .find(|(k, _)| k.starts_with("worker-"))
+            .expect("should have a worker chunk");
+        assert_eq!(worker_entry.0, "worker-compute.js");
+
+        // The worker chunk must contain both the worker module and its nested
+        // static dependency — the worker has its own dependency graph.
+        assert!(worker_entry.1.contains("onmessage"));
+        assert!(
+            worker_entry.1.contains("function heavy"),
+            "worker chunk should inline its nested static dependency"
+        );
+
+        let main_code = main_chunk(&output);
+        // Main should NOT contain the worker body.
+        assert!(
+            !main_code.contains("onmessage"),
+            "main chunk should not contain worker module's body"
+        );
+        // Main should have rewritten the URL specifier to the emitted filename.
+        assert!(
+            main_code.contains("'./worker-compute.js'"),
+            "main chunk should reference the worker chunk filename. Got:\n{main_code}"
+        );
+        assert!(
+            !main_code.contains("./compute.worker"),
+            "main chunk should no longer reference the raw worker source path"
+        );
+        // The `new Worker(new URL(...))` shell must remain intact — only the
+        // inner specifier was rewritten.
+        assert!(main_code.contains("new Worker(new URL("));
+        assert!(main_code.contains("import.meta.url"));
+    }
+
+    #[test]
     fn test_format_import_named() {
         let imp = MergedImport {
             source: "@angular/core".to_string(),

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -407,7 +407,8 @@ fn collect_dynamic_import_edits_from_decl(
     }
 }
 
-/// Recursively walk an expression tree to find `import()` calls.
+/// Recursively walk an expression tree to find `import()` calls and worker
+/// URL constructions (`new Worker(new URL(...))` / `new SharedWorker(...)`).
 fn walk_expr_for_dynamic_imports(
     expr: &Expression,
     rewrites: &HashMap<String, String>,
@@ -431,6 +432,45 @@ fn walk_expr_for_dynamic_imports(
                         end: lit.span.end,
                         replacement: Some(format!("'./{chunk_filename}'")),
                     });
+                }
+            }
+        }
+        Expression::NewExpression(new_expr) => {
+            // Detect `new Worker(new URL('<spec>', import.meta.url), ...)`
+            // and `new SharedWorker(...)`. Rewrite the inner URL string
+            // literal to point to the emitted worker chunk filename.
+            if is_worker_callee(&new_expr.callee) {
+                if let Some(Expression::NewExpression(url_expr)) =
+                    new_expr.arguments.first().and_then(|a| a.as_expression())
+                {
+                    if is_url_callee(&url_expr.callee)
+                        && url_expr
+                            .arguments
+                            .get(1)
+                            .and_then(|a| a.as_expression())
+                            .is_some_and(is_import_meta_url)
+                    {
+                        if let Some(Expression::StringLiteral(lit)) =
+                            url_expr.arguments.first().and_then(|a| a.as_expression())
+                        {
+                            let specifier = lit.value.as_str();
+                            if let Some(chunk_filename) = rewrites.get(specifier) {
+                                edits.push(TextEdit {
+                                    start: lit.span.start,
+                                    end: lit.span.end,
+                                    replacement: Some(format!("'./{chunk_filename}'")),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            // Still recurse into the callee + arguments so nested dynamic
+            // imports or worker URLs inside the arguments also get visited.
+            walk_expr_for_dynamic_imports(&new_expr.callee, rewrites, edits, dynamic_imports);
+            for arg in &new_expr.arguments {
+                if let Some(expr) = arg.as_expression() {
+                    walk_expr_for_dynamic_imports(expr, rewrites, edits, dynamic_imports);
                 }
             }
         }
@@ -529,6 +569,41 @@ fn walk_expr_for_dynamic_imports(
         // For other expression types, we don't recurse (no nested import() possible)
         _ => {}
     }
+}
+
+/// True when `expr` is a plain identifier reference to `Worker` or `SharedWorker`.
+fn is_worker_callee(expr: &Expression) -> bool {
+    if let Expression::Identifier(id) = expr {
+        matches!(id.name.as_str(), "Worker" | "SharedWorker")
+    } else {
+        false
+    }
+}
+
+/// True when `expr` is a plain identifier reference to `URL`.
+fn is_url_callee(expr: &Expression) -> bool {
+    matches!(expr, Expression::Identifier(id) if id.name.as_str() == "URL")
+}
+
+/// True when `expr` is the `import.meta.url` member expression.
+fn is_import_meta_url(expr: &Expression) -> bool {
+    let member = match expr.as_member_expression() {
+        Some(m) => m,
+        None => return false,
+    };
+    // Property must be `url`
+    let Some(prop_name) = member.static_property_name() else {
+        return false;
+    };
+    if prop_name != "url" {
+        return false;
+    }
+    // Object must be a MetaProperty whose meta is `import` and property is `meta`
+    matches!(
+        member.object(),
+        Expression::MetaProperty(mp)
+            if mp.meta.name.as_str() == "import" && mp.property.name.as_str() == "meta"
+    )
 }
 
 /// Extract the declared name from a declaration, if it has a single clear name.
@@ -747,6 +822,51 @@ mod tests {
         let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
         assert!(result.code.contains("'./chunk-lazy.js'"));
         assert_eq!(result.dynamic_imports.len(), 1);
+    }
+
+    #[test]
+    fn test_worker_url_specifier_rewritten() {
+        let code =
+            "const w = new Worker(new URL('./compute.worker', import.meta.url), { type: 'module' });\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert(
+            "./compute.worker".to_string(),
+            "worker-compute.js".to_string(),
+        );
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(result.code.contains("'./worker-compute.js'"));
+        assert!(!result.code.contains("./compute.worker"));
+        assert!(result.code.contains("new Worker(new URL("));
+        assert!(result.code.contains("import.meta.url"));
+    }
+
+    #[test]
+    fn test_shared_worker_url_specifier_rewritten() {
+        let code = r#"const w = new SharedWorker(new URL("./shared.worker", import.meta.url));"#;
+        let mut rewrites = HashMap::new();
+        rewrites.insert(
+            "./shared.worker".to_string(),
+            "worker-shared.js".to_string(),
+        );
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(result.code.contains("'./worker-shared.js'"));
+        assert!(!result.code.contains("./shared.worker"));
+    }
+
+    #[test]
+    fn test_worker_without_import_meta_url_not_rewritten() {
+        // A `new Worker(new URL(...))` that uses something other than
+        // `import.meta.url` as the base isn't a bundled worker entrypoint;
+        // leave the specifier alone.
+        let code = "const w = new Worker(new URL('./compute.worker', location.href));\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert(
+            "./compute.worker".to_string(),
+            "worker-compute.js".to_string(),
+        );
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(!result.code.contains("worker-compute.js"));
+        assert!(result.code.contains("./compute.worker"));
     }
 
     #[test]

--- a/crates/bundler/tests/worker_integration.rs
+++ b/crates/bundler/tests/worker_integration.rs
@@ -1,0 +1,143 @@
+//! End-to-end integration for web-worker bundling.
+//!
+//! Drives the full `resolve_project` → `bundle` pipeline on a synthetic project
+//! that uses `new Worker(new URL('./foo.worker', import.meta.url))`, and asserts
+//! that (1) a dedicated `worker-*.js` chunk is emitted containing both the worker
+//! module and its nested static dependency (the worker has its own chunk graph),
+//! and (2) the main bundle rewrites the URL specifier to the emitted filename.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use ngc_bundler::{bundle, BundleInput, BundleOptions};
+use ngc_project_resolver::resolve_project;
+use tempfile::tempdir;
+
+#[test]
+fn worker_new_url_is_bundled_as_separate_chunk_and_rewritten() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    // Minimal tsconfig.json — `include` globs for the synthetic sources.
+    let tsconfig = r#"{
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+
+    // main.ts spawns a worker and calls a function declared inside it.
+    fs::write(
+        src.join("main.ts"),
+        "const w = new Worker(new URL('./compute.worker', import.meta.url), { type: 'module' });\n\
+         console.log(w);\n",
+    )
+    .expect("write main.ts");
+
+    // compute.worker.ts statically imports a nested dependency — that nested
+    // file must travel into the worker chunk, not the main chunk.
+    fs::write(
+        src.join("compute.worker.ts"),
+        "import { heavy } from './worker-dep';\n\
+         self.onmessage = (e) => self.postMessage(heavy(e.data));\n",
+    )
+    .expect("write compute.worker.ts");
+
+    fs::write(
+        src.join("worker-dep.ts"),
+        "export function heavy(x) { return x * 2; }\n",
+    )
+    .expect("write worker-dep.ts");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    // The entry is main.ts — workers are not counted as top-level entry points
+    // (they have an incoming Worker edge from main).
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    // Pull the source text for each project file and hand it to the bundler
+    // as-is. This test exercises the graph + bundler, not the TS transform.
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in file_graph.graph.node_indices() {
+        let path = &file_graph.graph[idx];
+        let source = fs::read_to_string(path).expect("read project file");
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph: file_graph.graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions::default(),
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: Default::default(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    // Exactly two chunks: main + worker.
+    assert_eq!(
+        output.chunks.len(),
+        2,
+        "expected main + worker chunk; got {:?}",
+        output.chunks.keys().collect::<Vec<_>>()
+    );
+
+    // Locate the worker chunk by filename prefix.
+    let (worker_filename, worker_code) = output
+        .chunks
+        .iter()
+        .find(|(k, _)| k.starts_with("worker-"))
+        .expect("a worker-*.js chunk should have been emitted");
+    assert!(
+        worker_filename.ends_with(".js"),
+        "worker chunk filename should be a .js file"
+    );
+
+    // The worker chunk carries its own graph: the worker body AND its nested
+    // static dependency end up inside it.
+    assert!(
+        worker_code.contains("onmessage"),
+        "worker chunk should contain the worker module body; got:\n{worker_code}"
+    );
+    assert!(
+        worker_code.contains("function heavy"),
+        "worker chunk should inline the nested static dependency; got:\n{worker_code}"
+    );
+
+    // Main bundle: rewritten URL + no worker body.
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+    assert!(
+        main_code.contains(&format!("'./{worker_filename}'")),
+        "main chunk should reference the emitted worker filename; got:\n{main_code}"
+    );
+    assert!(
+        !main_code.contains("./compute.worker"),
+        "main chunk should no longer reference the raw worker source path"
+    );
+    assert!(
+        !main_code.contains("onmessage"),
+        "main chunk must not inline the worker body"
+    );
+    assert!(
+        !main_code.contains("function heavy"),
+        "main chunk must not inline the worker's nested dependency"
+    );
+    // The `new Worker(new URL(..., import.meta.url), ...)` shell stays intact.
+    assert!(main_code.contains("new Worker(new URL("));
+    assert!(main_code.contains("import.meta.url"));
+}

--- a/crates/project-resolver/src/import_scanner.rs
+++ b/crates/project-resolver/src/import_scanner.rs
@@ -18,13 +18,28 @@ static DYNAMIC_IMPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"import\(\s*['"]([^'"]+)['"]\s*\)"#).expect("DYNAMIC_IMPORT_RE is a valid regex")
 });
 
-/// Distinguishes static `import`/`export` declarations from dynamic `import()` expressions.
+/// Matches `new Worker(new URL('./foo.worker', import.meta.url), ...)` and
+/// `new SharedWorker(...)`. The captured group is the specifier that points
+/// to the worker entry file. Matches are treated as a new entrypoint into
+/// the dependency graph, producing a separate chunk.
+static WORKER_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"new\s+(?:Worker|SharedWorker)\s*\(\s*new\s+URL\s*\(\s*['"]([^'"]+)['"]\s*,\s*import\.meta\.url"#,
+    )
+    .expect("WORKER_URL_RE is a valid regex")
+});
+
+/// Distinguishes static `import`/`export` declarations from dynamic `import()`
+/// expressions and web-worker URL constructions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ImportKind {
     /// A static `import ... from '...'`, `export ... from '...'`, or side-effect `import '...'`.
     Static,
     /// A dynamic `import('...')` expression (triggers code splitting).
     Dynamic,
+    /// A `new Worker(new URL('...', import.meta.url), ...)` or `new SharedWorker(...)`
+    /// call — the URL argument is a worker entrypoint that becomes its own chunk.
+    Worker,
 }
 
 /// An import specifier with its kind (static or dynamic).
@@ -50,6 +65,7 @@ pub fn scan_imports_with_kind(source: &str) -> Vec<ScannedImport> {
     let mut imports = Vec::new();
     let mut seen_static = std::collections::HashSet::new();
     let mut seen_dynamic = std::collections::HashSet::new();
+    let mut seen_worker = std::collections::HashSet::new();
 
     for cap in FROM_CLAUSE_RE.captures_iter(source) {
         if let Some(m) = cap.get(1) {
@@ -82,6 +98,18 @@ pub fn scan_imports_with_kind(source: &str) -> Vec<ScannedImport> {
                 imports.push(ScannedImport {
                     specifier: s,
                     kind: ImportKind::Dynamic,
+                });
+            }
+        }
+    }
+
+    for cap in WORKER_URL_RE.captures_iter(source) {
+        if let Some(m) = cap.get(1) {
+            let s = m.as_str().to_string();
+            if seen_worker.insert(s.clone()) {
+                imports.push(ScannedImport {
+                    specifier: s,
+                    kind: ImportKind::Worker,
                 });
             }
         }
@@ -255,6 +283,42 @@ const routes = [
         assert_eq!(imports[0].kind, ImportKind::Static);
         assert_eq!(imports[1].specifier, "./admin/admin.component");
         assert_eq!(imports[1].kind, ImportKind::Dynamic);
+    }
+
+    #[test]
+    fn test_scan_with_kind_worker_module() {
+        let source = r#"const w = new Worker(new URL('./compute.worker', import.meta.url), { type: 'module' });"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].specifier, "./compute.worker");
+        assert_eq!(imports[0].kind, ImportKind::Worker);
+    }
+
+    #[test]
+    fn test_scan_with_kind_shared_worker() {
+        let source = r#"const w = new SharedWorker(new URL("./shared.worker", import.meta.url));"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].specifier, "./shared.worker");
+        assert_eq!(imports[0].kind, ImportKind::Worker);
+    }
+
+    #[test]
+    fn test_scan_with_kind_worker_whitespace_variants() {
+        let source = r#"new   Worker ( new   URL (   './w',  import.meta.url ), {type:'module'})"#;
+        let imports = scan_imports_with_kind(source);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].specifier, "./w");
+        assert_eq!(imports[0].kind, ImportKind::Worker);
+    }
+
+    #[test]
+    fn test_scan_with_kind_worker_ignores_non_import_meta() {
+        // A new Worker with a URL that's not rooted on import.meta.url isn't
+        // a bundled worker entry — we leave those alone for the runtime.
+        let source = r#"new Worker(new URL('./compute.worker', location.href));"#;
+        let imports = scan_imports_with_kind(source);
+        assert!(imports.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #66.

## Summary
- New `ImportKind::Worker` plus a regex in `project-resolver` that picks up `new Worker(new URL('<specifier>', import.meta.url), { type: 'module' })` and `new SharedWorker(...)` calls while scanning project sources, so the worker target becomes an edge in the file graph.
- The chunk graph treats Worker edges as split points alongside dynamic `import()`, and emits them with a `worker-<name>.js` filename prefix (stripping a trailing `.worker` segment so `foo.worker.ts` → `worker-foo.js`). Each worker keeps its own chunk graph, so statically-imported dependencies of the worker travel into its chunk rather than the main bundle.
- At the call site, the bundler walks `Expression::NewExpression` looking for the `Worker`/`SharedWorker` + `new URL(<literal>, import.meta.url)` shape, and rewrites the inner string literal to the emitted chunk filename (the `new URL(..., import.meta.url)` shell stays intact so the browser still resolves the URL relative to the module).
- Workspace version bumped to 0.7.24.

## Test plan
- [x] `cargo test --workspace` (348 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] New scanner unit tests cover module-type workers, shared workers, whitespace variants, and the `import.meta.url` guard.
- [x] New chunker test covers Worker-edge split points + `worker-*.js` filename derivation.
- [x] New rewrite tests cover `new Worker(new URL(...))`, `new SharedWorker(new URL(...))`, and the non-`import.meta.url` negative case.
- [x] New bundler integration test (`worker_integration.rs`) drives the full `resolve_project` → `bundle` pipeline on a tempdir fixture and asserts the worker chunk contains both the worker module and its nested static dependency, while the main bundle rewrites the URL to `./worker-compute.js`.