### PR TITLE
feat(cli,bundler): SCSS / Less / Stylus component style preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -699,12 +699,14 @@ dependencies = [
  "pest",
  "pest_derive",
  "rayon",
+ "tempfile",
  "tracing",
+ "which",
 ]
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -1809,6 +1811,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.24"
+version = "0.7.25"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,8 +7,10 @@ use colored::Colorize;
 use ngc_bundler::{BundleInput, BundleOptions};
 use ngc_diagnostics::{NgcError, NgcResult};
 use ngc_project_resolver::angular_json::{
-    CrossOrigin, FileReplacement, ResolvedAngularProject, ResolvedAsset, ResolvedStyle,
+    CrossOrigin, FileReplacement, InlineStyleLanguage, ResolvedAngularProject, ResolvedAsset,
+    ResolvedStyle,
 };
+use ngc_template_compiler::{StyleContext, StyleLanguage};
 
 /// Result of the bundled build pipeline.
 #[derive(serde::Serialize)]
@@ -195,7 +197,8 @@ fn run_build(
     // Step 4: Compile Angular decorators (@Component, @Injectable, @Directive, @Pipe, @NgModule)
     let templates_span = tracing::info_span!("template_compile").entered();
     let files: Vec<PathBuf> = file_graph.graph.node_weights().cloned().collect();
-    let compiled = ngc_template_compiler::compile_all_decorators(&files)?;
+    let style_ctx = build_style_context(angular_project.as_ref(), &config_dir);
+    let compiled = ngc_template_compiler::compile_all_decorators_with_styles(&files, &style_ctx)?;
     drop(templates_span);
 
     // Report any JIT fallbacks
@@ -679,10 +682,14 @@ fn generate_polyfills(polyfills: &[String], out_dir: &Path) -> NgcResult<PathBuf
     Ok(path)
 }
 
-/// Read and concatenate global CSS style files, writing dist/styles.css.
+/// Read and concatenate global style files, writing dist/styles.css.
 ///
-/// Resolves CSS `@import` directives that reference npm packages (e.g.
-/// `@import "tailwindcss"`) by looking up the package in `node_modules`.
+/// Accepts `.css`, `.scss`, `.sass`, `.less`, and `.styl`/`.stylus` files.
+/// Non-CSS entries are preprocessed through the appropriate Node subprocess
+/// (`sass` / `less` / `stylus`) before concatenation. After concatenation,
+/// CSS `@import` directives that reference npm packages (e.g.
+/// `@import "tailwindcss"`) are resolved by looking up the package in
+/// `node_modules`.
 fn extract_global_styles(
     styles: &[ResolvedStyle],
     out_dir: &Path,
@@ -698,16 +705,15 @@ fn extract_global_styles(
             .extension()
             .and_then(|e| e.to_str())
             .unwrap_or("");
-        if ext != "css" {
-            return Err(NgcError::StyleError {
+        let language = StyleLanguage::from_extension(ext);
+        let content = if language == StyleLanguage::Css {
+            std::fs::read_to_string(&style.path).map_err(|e| NgcError::Io {
                 path: style.path.clone(),
-                message: format!(".{ext} files are not supported — only plain .css in v0.5"),
-            });
-        }
-        let content = std::fs::read_to_string(&style.path).map_err(|e| NgcError::Io {
-            path: style.path.clone(),
-            source: e,
-        })?;
+                source: e,
+            })?
+        } else {
+            ngc_template_compiler::preprocessor::preprocess_file(&style.path, project_root)?
+        };
         if !css.is_empty() {
             css.push('\n');
         }
@@ -1334,6 +1340,42 @@ fn await_postcss(child: std::process::Child) {
                 e
             );
         }
+    }
+}
+
+/// Build the [`StyleContext`] used by the template compiler for component
+/// style preprocessing.
+///
+/// `project_root` points at the directory containing `node_modules`, which
+/// defaults to the tsconfig's directory (`config_dir`) but is overridden by
+/// the `angular.json` project root when present — that is where
+/// `@angular/build:application` looks for style preprocessor packages.
+fn build_style_context(
+    angular_project: Option<&ResolvedAngularProject>,
+    config_dir: &Path,
+) -> StyleContext {
+    let project_root = angular_project
+        .map(|ap| ap.root.clone())
+        .unwrap_or_else(|| config_dir.to_path_buf());
+    let inline_style_language = angular_project
+        .map(|ap| inline_language_to_style_language(ap.inline_style_language))
+        .unwrap_or(StyleLanguage::Css);
+    StyleContext {
+        project_root,
+        inline_style_language,
+    }
+}
+
+/// Bridge `ngc_project_resolver`'s `InlineStyleLanguage` to the
+/// `ngc_template_compiler`'s `StyleLanguage`. The two enums are intentionally
+/// separate so template-compiler doesn't depend on project-resolver.
+fn inline_language_to_style_language(lang: InlineStyleLanguage) -> StyleLanguage {
+    match lang {
+        InlineStyleLanguage::Css => StyleLanguage::Css,
+        InlineStyleLanguage::Scss => StyleLanguage::Scss,
+        InlineStyleLanguage::Sass => StyleLanguage::Sass,
+        InlineStyleLanguage::Less => StyleLanguage::Less,
+        InlineStyleLanguage::Stylus => StyleLanguage::Stylus,
     }
 }
 

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -81,6 +81,10 @@ pub struct RawBuildOptions {
     pub cross_origin: Option<String>,
     /// Whether to compute and inject SRI `integrity` attributes.
     pub subresource_integrity: Option<bool>,
+    /// Language for inline component styles: `css` (default), `scss`, `sass`,
+    /// `less`, or `stylus`. Used when a component uses a `styles: [...]`
+    /// literal rather than `styleUrl`/`styleUrls`.
+    pub inline_style_language: Option<String>,
 }
 
 /// Output path can be a simple string or an object for SSR setups.
@@ -268,6 +272,40 @@ pub struct ResolvedAngularProject {
     pub cross_origin: CrossOrigin,
     /// Whether SRI `integrity` attributes should be injected.
     pub subresource_integrity: bool,
+    /// Language for inline component `styles: [\`...\`]` literals.
+    pub inline_style_language: InlineStyleLanguage,
+}
+
+/// Language applied to inline component `styles: [\`...\`]` literals when no
+/// `styleUrl`/`styleUrls` are present. Mirrors `@angular/build:application`
+/// `inlineStyleLanguage`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InlineStyleLanguage {
+    /// Plain CSS — no preprocessing.
+    #[default]
+    Css,
+    /// SCSS (indented `scss`) via the `sass` npm package.
+    Scss,
+    /// Sass (original indented syntax) via the `sass` npm package.
+    Sass,
+    /// Less via the `less` npm package.
+    Less,
+    /// Stylus via the `stylus` npm package.
+    Stylus,
+}
+
+impl InlineStyleLanguage {
+    /// Parse from the `angular.json` string value. Unknown or missing values
+    /// default to `Css`.
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(|s| s.to_ascii_lowercase()).as_deref() {
+            Some("scss") => InlineStyleLanguage::Scss,
+            Some("sass") => InlineStyleLanguage::Sass,
+            Some("less") => InlineStyleLanguage::Less,
+            Some("stylus") => InlineStyleLanguage::Stylus,
+            _ => InlineStyleLanguage::Css,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -412,6 +450,8 @@ pub fn resolve_angular_project(
         .and_then(|bc| bc.subresource_integrity)
         .or_else(|| options.and_then(|o| o.subresource_integrity))
         .unwrap_or(false);
+    let inline_style_language =
+        InlineStyleLanguage::parse(options.and_then(|o| o.inline_style_language.as_deref()));
 
     debug!(
         project = %name,
@@ -437,6 +477,7 @@ pub fn resolve_angular_project(
         deploy_url,
         cross_origin,
         subresource_integrity,
+        inline_style_language,
     })
 }
 
@@ -830,6 +871,76 @@ mod tests {
         let result = resolve_angular_project(f.path(), None, Some("production")).unwrap();
         assert_eq!(result.base_href.as_deref(), Some("/prod/"));
         assert!(result.subresource_integrity);
+    }
+
+    #[test]
+    fn test_parse_inline_style_language() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "inlineStyleLanguage": "scss"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.inline_style_language, InlineStyleLanguage::Scss);
+    }
+
+    #[test]
+    fn test_inline_style_language_defaults_to_css() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": { "outputPath": "dist", "tsConfig": "tsconfig.json" }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.inline_style_language, InlineStyleLanguage::Css);
+    }
+
+    #[test]
+    fn test_inline_style_language_less_and_stylus() {
+        for (raw, expected) in [
+            ("less", InlineStyleLanguage::Less),
+            ("stylus", InlineStyleLanguage::Stylus),
+            ("sass", InlineStyleLanguage::Sass),
+        ] {
+            let json = format!(
+                r#"{{
+                    "projects": {{
+                        "app": {{
+                            "architect": {{
+                                "build": {{
+                                    "options": {{
+                                        "outputPath": "dist",
+                                        "tsConfig": "tsconfig.json",
+                                        "inlineStyleLanguage": "{raw}"
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}"#
+            );
+            let f = write_temp_json(&json);
+            let result = resolve_angular_project(f.path(), None, None).unwrap();
+            assert_eq!(result.inline_style_language, expected);
+        }
     }
 
     #[test]

--- a/crates/template-compiler/Cargo.toml
+++ b/crates/template-compiler/Cargo.toml
@@ -22,3 +22,5 @@ tracing = "0.1"
 ngc-project-resolver = { path = "../project-resolver" }
 ngc-ts-transform = { path = "../ts-transform" }
 insta = { version = "1.46", features = ["glob"] }
+tempfile = "3"
+which = "8"

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -2994,6 +2994,8 @@ mod tests {
             angular_core_import_span: None,
             other_angular_core_imports: Vec::new(),
             styles_source: None,
+            inline_styles: Vec::new(),
+            style_urls: Vec::new(),
             input_properties: Vec::new(),
         }
     }

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -42,7 +42,20 @@ pub struct ExtractedComponent {
     /// Named imports from `@angular/core` other than `Component`.
     pub other_angular_core_imports: Vec<String>,
     /// Raw source text of the `styles` array (e.g. `['\`.sidebar { ... }\`']`).
+    ///
+    /// Retained for codegen fast-path when no preprocessing is needed. When
+    /// `style_urls` is non-empty or `inlineStyleLanguage` is non-CSS, the
+    /// post-extraction step in `compile_component` rewrites this field to a
+    /// synthesized `[`compiled-css`]` array of preprocessed CSS.
     pub styles_source: Option<String>,
+    /// Inline CSS contents from `styles: [...]` — one entry per element
+    /// (template-literal body or string literal value, with no surrounding
+    /// backticks/quotes).
+    pub inline_styles: Vec<String>,
+    /// Relative paths from `styleUrl: '...'` or `styleUrls: [...]`. These
+    /// are resolved against the component's file directory and read during
+    /// `compile_component` so preprocessors can run on their contents.
+    pub style_urls: Vec<String>,
     /// Property names decorated with `@Input()`.
     pub input_properties: Vec<String>,
 }
@@ -180,6 +193,8 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             angular_core_import_span,
             other_angular_core_imports,
             styles_source: metadata.styles_source,
+            inline_styles: metadata.inline_styles,
+            style_urls: metadata.style_urls,
             input_properties,
         }));
     }
@@ -855,6 +870,8 @@ struct DecoratorMetadata {
     imports_source: Option<String>,
     imports_identifiers: Vec<String>,
     styles_source: Option<String>,
+    inline_styles: Vec<String>,
+    style_urls: Vec<String>,
 }
 
 /// Extract metadata from the `@Component({...})` decorator argument.
@@ -870,6 +887,8 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                 imports_source: None,
                 imports_identifiers: Vec::new(),
                 styles_source: None,
+                inline_styles: Vec::new(),
+                style_urls: Vec::new(),
             });
         }
     };
@@ -885,6 +904,8 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                 imports_source: None,
                 imports_identifiers: Vec::new(),
                 styles_source: None,
+                inline_styles: Vec::new(),
+                style_urls: Vec::new(),
             });
         }
     };
@@ -896,6 +917,8 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
     let mut imports_source = None;
     let mut imports_identifiers = Vec::new();
     let mut styles_source = None;
+    let mut inline_styles: Vec<String> = Vec::new();
+    let mut style_urls: Vec<String> = Vec::new();
 
     for prop in &arg.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
@@ -932,11 +955,64 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                         standalone = b.value;
                     }
                 }
-                "styles" | "styleUrl" | "styleUrls" => {
+                "styles" => {
                     let start = prop.value.span().start as usize;
                     let end = prop.value.span().end as usize;
                     if start < source.len() && end <= source.len() {
                         styles_source = Some(source[start..end].to_string());
+                    }
+                    // Also parse each element into a structured list so the
+                    // preprocessor step can operate on raw content rather than
+                    // the JS source text.
+                    match &prop.value {
+                        Expression::ArrayExpression(arr) => {
+                            for elem in &arr.elements {
+                                match elem {
+                                    oxc_ast::ast::ArrayExpressionElement::TemplateLiteral(tpl) => {
+                                        if tpl.expressions.is_empty() {
+                                            let text: String = tpl
+                                                .quasis
+                                                .iter()
+                                                .map(|q| q.value.raw.as_str())
+                                                .collect();
+                                            inline_styles.push(text);
+                                        }
+                                    }
+                                    oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) => {
+                                        inline_styles.push(s.value.to_string());
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        Expression::StringLiteral(s) => {
+                            inline_styles.push(s.value.to_string());
+                        }
+                        Expression::TemplateLiteral(tpl) => {
+                            if tpl.expressions.is_empty() {
+                                let text: String =
+                                    tpl.quasis.iter().map(|q| q.value.raw.as_str()).collect();
+                                inline_styles.push(text);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                "styleUrl" => {
+                    if let Expression::StringLiteral(s) = &prop.value {
+                        style_urls.push(s.value.to_string());
+                    }
+                }
+                "styleUrls" => {
+                    if let Expression::ArrayExpression(arr) = &prop.value {
+                        for elem in &arr.elements {
+                            if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
+                                style_urls.push(s.value.to_string());
+                            }
+                        }
+                    } else if let Expression::StringLiteral(s) = &prop.value {
+                        // Defensive: single string passed to styleUrls.
+                        style_urls.push(s.value.to_string());
                     }
                 }
                 "imports" => {
@@ -968,6 +1044,8 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
         imports_source,
         imports_identifiers,
         styles_source,
+        inline_styles,
+        style_urls,
     })
 }
 

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -968,15 +968,15 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                         Expression::ArrayExpression(arr) => {
                             for elem in &arr.elements {
                                 match elem {
-                                    oxc_ast::ast::ArrayExpressionElement::TemplateLiteral(tpl) => {
-                                        if tpl.expressions.is_empty() {
-                                            let text: String = tpl
-                                                .quasis
-                                                .iter()
-                                                .map(|q| q.value.raw.as_str())
-                                                .collect();
-                                            inline_styles.push(text);
-                                        }
+                                    oxc_ast::ast::ArrayExpressionElement::TemplateLiteral(tpl)
+                                        if tpl.expressions.is_empty() =>
+                                    {
+                                        let text: String = tpl
+                                            .quasis
+                                            .iter()
+                                            .map(|q| q.value.raw.as_str())
+                                            .collect();
+                                        inline_styles.push(text);
                                     }
                                     oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) => {
                                         inline_styles.push(s.value.to_string());
@@ -988,12 +988,10 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                         Expression::StringLiteral(s) => {
                             inline_styles.push(s.value.to_string());
                         }
-                        Expression::TemplateLiteral(tpl) => {
-                            if tpl.expressions.is_empty() {
-                                let text: String =
-                                    tpl.quasis.iter().map(|q| q.value.raw.as_str()).collect();
-                                inline_styles.push(text);
-                            }
+                        Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
+                            let text: String =
+                                tpl.quasis.iter().map(|q| q.value.raw.as_str()).collect();
+                            inline_styles.push(text);
                         }
                         _ => {}
                     }

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -14,6 +14,7 @@ mod injectable_codegen;
 mod ng_module_codegen;
 mod parser;
 mod pipe_codegen;
+pub mod preprocessor;
 mod rewrite;
 mod selector;
 

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -24,6 +24,34 @@ use ngc_diagnostics::{NgcError, NgcResult};
 use rayon::prelude::*;
 use tracing::debug;
 
+pub use preprocessor::StyleLanguage;
+
+/// Context needed to preprocess component styles.
+///
+/// Threaded through `compile_all_decorators_with_styles` so that SCSS / Less /
+/// Stylus subprocesses can locate `node_modules` (via `project_root`) and so
+/// that inline `styles: [\`...\`]` literals are interpreted against the
+/// configured `inlineStyleLanguage` from `angular.json`.
+#[derive(Debug, Clone)]
+pub struct StyleContext {
+    /// Directory that contains `node_modules` — usually the project root
+    /// (the directory containing `angular.json`).
+    pub project_root: PathBuf,
+    /// `inlineStyleLanguage` from `angular.json`, applied to bodies of
+    /// `styles: [\`...\`]` array entries. File-based `styleUrl`/`styleUrls`
+    /// entries always derive their language from the file extension.
+    pub inline_style_language: StyleLanguage,
+}
+
+impl Default for StyleContext {
+    fn default() -> Self {
+        Self {
+            project_root: PathBuf::from("."),
+            inline_style_language: StyleLanguage::Css,
+        }
+    }
+}
+
 /// Lightweight metadata for template compilation without `ExtractedComponent`.
 ///
 /// Used by the Angular linker to compile templates from `ɵɵngDeclareComponent`
@@ -87,6 +115,8 @@ pub fn generate_template_fn(
         angular_core_import_span: None,
         other_angular_core_imports: Vec::new(),
         styles_source: meta.styles_source.clone(),
+        inline_styles: Vec::new(),
+        style_urls: Vec::new(),
         input_properties: Vec::new(),
     };
 
@@ -203,7 +233,18 @@ pub struct CompiledFile {
 /// Files without Angular decorators are returned unchanged.
 ///
 /// Files are processed in parallel using rayon.
+///
+/// Uses a default style context (no preprocessing). Callers that need SCSS /
+/// Less / Stylus support should use [`compile_all_decorators_with_styles`].
 pub fn compile_all_decorators(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
+    compile_all_decorators_with_styles(files, &StyleContext::default())
+}
+
+/// Variant of [`compile_all_decorators`] that preprocesses component styles.
+pub fn compile_all_decorators_with_styles(
+    files: &[PathBuf],
+    style_ctx: &StyleContext,
+) -> NgcResult<Vec<CompiledFile>> {
     let results: Vec<NgcResult<CompiledFile>> = files
         .par_iter()
         .map(|file_path| {
@@ -212,7 +253,7 @@ pub fn compile_all_decorators(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>>
                 source: e,
             })?;
 
-            compile_file(&source, file_path)
+            compile_file(&source, file_path, style_ctx)
         })
         .collect();
 
@@ -229,9 +270,13 @@ pub fn compile_templates(files: &[PathBuf]) -> NgcResult<Vec<CompiledFile>> {
 /// Tries `@Component` first, then falls through to `@Injectable`, `@Directive`,
 /// `@Pipe`, and `@NgModule`. Returns the source unchanged if no Angular decorator
 /// is found.
-fn compile_file(source: &str, file_path: &Path) -> NgcResult<CompiledFile> {
+fn compile_file(
+    source: &str,
+    file_path: &Path,
+    style_ctx: &StyleContext,
+) -> NgcResult<CompiledFile> {
     // Try @Component first (most complex, has template compilation)
-    let component_result = compile_component(source, file_path)?;
+    let component_result = compile_component_with_styles(source, file_path, style_ctx)?;
     if component_result.compiled || component_result.jit_fallback {
         return Ok(component_result);
     }
@@ -297,13 +342,99 @@ fn compile_file(source: &str, file_path: &Path) -> NgcResult<CompiledFile> {
     })
 }
 
+/// Resolve `styleUrl`/`styleUrls` from disk, preprocess them plus any inline
+/// `styles: [\`...\`]` entries according to `style_ctx.inline_style_language`,
+/// and rewrite `extracted.styles_source` to a template-literal array of
+/// compiled CSS.
+///
+/// Has no effect for components that only use plain CSS and have no
+/// `styleUrl`/`styleUrls` — the existing raw `styles_source` flows through
+/// unchanged and the PostCSS-style %COMP% scoping works as before.
+fn preprocess_component_styles(
+    extracted: &mut extract::ExtractedComponent,
+    file_path: &Path,
+    style_ctx: &StyleContext,
+) -> NgcResult<()> {
+    let needs_url_resolution = !extracted.style_urls.is_empty();
+    let inline_needs_preproc = style_ctx.inline_style_language != StyleLanguage::Css
+        && !extracted.inline_styles.is_empty();
+
+    if !needs_url_resolution && !inline_needs_preproc {
+        return Ok(());
+    }
+
+    let base_dir = file_path.parent().unwrap_or(Path::new("."));
+    let mut compiled: Vec<String> =
+        Vec::with_capacity(extracted.inline_styles.len() + extracted.style_urls.len());
+
+    // Preprocess inline styles under inlineStyleLanguage.
+    for src in &extracted.inline_styles {
+        let css = preprocessor::preprocess_style(
+            src,
+            style_ctx.inline_style_language,
+            &style_ctx.project_root,
+            file_path,
+        )?;
+        compiled.push(css);
+    }
+
+    // Resolve + preprocess each styleUrl/styleUrls entry.
+    for url in &extracted.style_urls {
+        let path = base_dir.join(url);
+        let content = std::fs::read_to_string(&path).map_err(|e| NgcError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        let language = StyleLanguage::from_extension(ext);
+        let css =
+            preprocessor::preprocess_style(&content, language, &style_ctx.project_root, &path)?;
+        compiled.push(css);
+    }
+
+    // Synthesize a JS array literal of backtick-quoted CSS strings. Any
+    // existing backticks in the CSS are escaped so the emitted source parses.
+    let mut arr = String::from("[");
+    for (i, css) in compiled.iter().enumerate() {
+        if i > 0 {
+            arr.push_str(", ");
+        }
+        arr.push('`');
+        for ch in css.chars() {
+            match ch {
+                '`' => arr.push_str("\\`"),
+                '\\' => arr.push_str("\\\\"),
+                '$' => arr.push_str("\\$"),
+                _ => arr.push(ch),
+            }
+        }
+        arr.push('`');
+    }
+    arr.push(']');
+    extracted.styles_source = Some(arr);
+    Ok(())
+}
+
 /// Compile a single TypeScript source string containing an Angular component.
 ///
 /// If the source contains an `@Component` decorator with an inline `template`,
 /// parses the template, generates Ivy instructions, and rewrites the source.
 /// If no `@Component` is found, returns the source unchanged.
+///
+/// Uses a default style context (no preprocessing). For SCSS / Less / Stylus
+/// component styles, use [`compile_component_with_styles`].
 pub fn compile_component(source: &str, file_path: &Path) -> NgcResult<CompiledFile> {
-    let extracted = match extract::extract_component(source, file_path)? {
+    compile_component_with_styles(source, file_path, &StyleContext::default())
+}
+
+/// Variant of [`compile_component`] that preprocesses SCSS / Less / Stylus
+/// component styles into CSS before codegen emits the `styles:` array.
+pub fn compile_component_with_styles(
+    source: &str,
+    file_path: &Path,
+    style_ctx: &StyleContext,
+) -> NgcResult<CompiledFile> {
+    let mut extracted = match extract::extract_component(source, file_path)? {
         Some(ext) => ext,
         None => {
             return Ok(CompiledFile {
@@ -328,6 +459,11 @@ pub fn compile_component(source: &str, file_path: &Path) -> NgcResult<CompiledFi
             jit_fallback: true,
         });
     }
+
+    // Resolve + preprocess any non-CSS component styles. Rewrites
+    // `extracted.styles_source` to a template-literal array of compiled CSS so
+    // that codegen + CSS scoping proceed unchanged.
+    preprocess_component_styles(&mut extracted, file_path, style_ctx)?;
 
     // Resolve template source: inline template or external templateUrl
     let resolved_template;
@@ -565,7 +701,7 @@ export class SidenavComponent implements OnInit {
 }
 "#;
         let path = PathBuf::from("test.component.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled, "should be compiled");
         assert!(
             !result.source.contains("@Component"),
@@ -594,7 +730,7 @@ export class AuthService {
 }
 "#;
         let path = PathBuf::from("auth.service.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled, "should be compiled");
         assert!(result.source.contains("\u{0275}prov"));
         assert!(result.source.contains("\u{0275}\u{0275}defineInjectable"));
@@ -621,7 +757,7 @@ export class DataService {
 }
 "#;
         let path = PathBuf::from("data.service.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}\u{0275}inject(HttpClient)"));
         assert!(result.source.contains("\u{0275}\u{0275}inject(Router)"));
@@ -648,7 +784,7 @@ export class HighlightDirective {
 }
 "#;
         let path = PathBuf::from("highlight.directive.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}dir"));
         assert!(result.source.contains("\u{0275}\u{0275}defineDirective"));
@@ -677,7 +813,7 @@ export class DateFormatPipe implements PipeTransform {
 }
 "#;
         let path = PathBuf::from("date-format.pipe.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}pipe"));
         assert!(result.source.contains("\u{0275}\u{0275}definePipe"));
@@ -705,7 +841,7 @@ export class DateFormatPipe implements PipeTransform {
 export class AppModule {}
 "#;
         let path = PathBuf::from("app.module.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}mod"));
         assert!(result.source.contains("\u{0275}inj"));
@@ -726,7 +862,7 @@ export class AppModule {}
     fn test_plain_class_unchanged() {
         let source = "export class PlainClass { x = 1; }\n";
         let path = PathBuf::from("plain.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(!result.compiled);
         assert_eq!(result.source, source);
     }
@@ -915,7 +1051,7 @@ export class TestComponent {
 export class IconComponent {}
 "#;
         let path = PathBuf::from("icon.component.ts");
-        let result = compile_file(source, &path).expect("should compile");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
         assert!(result.compiled, "should be compiled");
 
         let out = &result.source;

--- a/crates/template-compiler/src/preprocessor.rs
+++ b/crates/template-compiler/src/preprocessor.rs
@@ -1,0 +1,309 @@
+//! Component-style preprocessor harness for SCSS / Sass / Less / Stylus.
+//!
+//! Mirrors the PostCSS/Tailwind subprocess pattern used for global styles:
+//! a short Node script is spawned, the raw source is piped to stdin, and the
+//! compiled CSS is read back from stdout. The matching npm package (`sass`,
+//! `less`, or `stylus`) must be installed in the project; if it is missing we
+//! surface a clear [`NgcError::StyleError`] so the user can `npm install` it.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use ngc_diagnostics::{NgcError, NgcResult};
+
+/// Style source language, derived from a file extension or from
+/// `inlineStyleLanguage` in `angular.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StyleLanguage {
+    /// Plain CSS — passthrough (no subprocess).
+    #[default]
+    Css,
+    /// SCSS (`sass` package, default syntax).
+    Scss,
+    /// Sass indented syntax (`sass` package, `syntax: 'indented'`).
+    Sass,
+    /// Less (`less` package).
+    Less,
+    /// Stylus (`stylus` package).
+    Stylus,
+}
+
+impl StyleLanguage {
+    /// Map a file extension (no leading dot) to a language. Unknown extensions
+    /// fall back to [`StyleLanguage::Css`].
+    pub fn from_extension(ext: &str) -> Self {
+        match ext.to_ascii_lowercase().as_str() {
+            "scss" => StyleLanguage::Scss,
+            "sass" => StyleLanguage::Sass,
+            "less" => StyleLanguage::Less,
+            "styl" | "stylus" => StyleLanguage::Stylus,
+            _ => StyleLanguage::Css,
+        }
+    }
+
+    /// npm package that provides the preprocessor, or `None` for plain CSS.
+    pub fn npm_package(self) -> Option<&'static str> {
+        match self {
+            StyleLanguage::Css => None,
+            StyleLanguage::Scss | StyleLanguage::Sass => Some("sass"),
+            StyleLanguage::Less => Some("less"),
+            StyleLanguage::Stylus => Some("stylus"),
+        }
+    }
+
+    /// Human-readable name used in diagnostic messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StyleLanguage::Css => "css",
+            StyleLanguage::Scss => "scss",
+            StyleLanguage::Sass => "sass",
+            StyleLanguage::Less => "less",
+            StyleLanguage::Stylus => "stylus",
+        }
+    }
+
+    fn node_script(self) -> &'static str {
+        match self {
+            StyleLanguage::Scss => SCSS_SCRIPT,
+            StyleLanguage::Sass => SASS_INDENTED_SCRIPT,
+            StyleLanguage::Less => LESS_SCRIPT,
+            StyleLanguage::Stylus => STYLUS_SCRIPT,
+            StyleLanguage::Css => "",
+        }
+    }
+}
+
+/// Compile `content` into plain CSS using `language`'s preprocessor.
+///
+/// `project_root` is used to locate the npm package in `node_modules` and as
+/// the subprocess's working directory (so relative `@use`/`@import` resolve
+/// against the project). `source_path` is attached to diagnostics.
+///
+/// Plain CSS is returned unchanged — no subprocess is spawned.
+pub fn preprocess_style(
+    content: &str,
+    language: StyleLanguage,
+    project_root: &Path,
+    source_path: &Path,
+) -> NgcResult<String> {
+    if language == StyleLanguage::Css {
+        return Ok(content.to_string());
+    }
+    let pkg = language
+        .npm_package()
+        .expect("non-css language has a package");
+    let pkg_dir = project_root.join("node_modules").join(pkg);
+    if !pkg_dir.is_dir() {
+        return Err(NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!(
+                "cannot preprocess {} styles: the `{pkg}` npm package is not installed in {}. \
+                 Run `npm install --save-dev {pkg}` and retry.",
+                language.as_str(),
+                project_root.display()
+            ),
+        });
+    }
+
+    let mut child = Command::new("node")
+        .arg("-e")
+        .arg(language.node_script())
+        .current_dir(project_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!(
+                "could not run node for {} preprocessing: {e}",
+                language.as_str()
+            ),
+        })?;
+
+    {
+        let stdin = child.stdin.as_mut().ok_or_else(|| NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!("could not open stdin for {} subprocess", language.as_str()),
+        })?;
+        stdin
+            .write_all(content.as_bytes())
+            .map_err(|e| NgcError::StyleError {
+                path: source_path.to_path_buf(),
+                message: format!(
+                    "could not write to {} subprocess stdin: {e}",
+                    language.as_str()
+                ),
+            })?;
+    }
+
+    let output = child.wait_with_output().map_err(|e| NgcError::StyleError {
+        path: source_path.to_path_buf(),
+        message: format!("failed to await {} subprocess: {e}", language.as_str()),
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!(
+                "{} preprocessing failed: {}",
+                language.as_str(),
+                stderr.trim()
+            ),
+        });
+    }
+    String::from_utf8(output.stdout).map_err(|e| NgcError::StyleError {
+        path: source_path.to_path_buf(),
+        message: format!(
+            "{} preprocessor output was not valid UTF-8: {e}",
+            language.as_str()
+        ),
+    })
+}
+
+/// Convenience: read a style file from disk and preprocess it.
+pub fn preprocess_file(path: &Path, project_root: &Path) -> NgcResult<String> {
+    let content = std::fs::read_to_string(path).map_err(|e| NgcError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let language = StyleLanguage::from_extension(ext);
+    preprocess_style(&content, language, project_root, path)
+}
+
+/// Return type shared by component preprocessing helpers.
+#[derive(Debug, Clone, Default)]
+pub struct ComponentStyles {
+    /// Compiled CSS strings, one per entry in the original `styles[]` /
+    /// `styleUrls[]` declaration, preserving source order.
+    pub compiled_css: Vec<String>,
+    /// Absolute paths of `styleUrl`/`styleUrls` entries that were resolved
+    /// from disk. Useful for surface-level reporting.
+    #[allow(dead_code)]
+    pub resolved_urls: Vec<PathBuf>,
+}
+
+const SCSS_SCRIPT: &str = r#"
+const sass = require('sass');
+const chunks = [];
+process.stdin.on('data', c => chunks.push(c));
+process.stdin.on('end', () => {
+    try {
+        const input = Buffer.concat(chunks).toString('utf8');
+        const out = sass.compileString(input);
+        process.stdout.write(out.css);
+    } catch (err) {
+        console.error(err && err.message ? err.message : String(err));
+        process.exit(1);
+    }
+});
+"#;
+
+const SASS_INDENTED_SCRIPT: &str = r#"
+const sass = require('sass');
+const chunks = [];
+process.stdin.on('data', c => chunks.push(c));
+process.stdin.on('end', () => {
+    try {
+        const input = Buffer.concat(chunks).toString('utf8');
+        const out = sass.compileString(input, { syntax: 'indented' });
+        process.stdout.write(out.css);
+    } catch (err) {
+        console.error(err && err.message ? err.message : String(err));
+        process.exit(1);
+    }
+});
+"#;
+
+const LESS_SCRIPT: &str = r#"
+const less = require('less');
+const chunks = [];
+process.stdin.on('data', c => chunks.push(c));
+process.stdin.on('end', () => {
+    const input = Buffer.concat(chunks).toString('utf8');
+    less.render(input).then(out => {
+        process.stdout.write(out.css);
+    }).catch(err => {
+        console.error(err && err.message ? err.message : String(err));
+        process.exit(1);
+    });
+});
+"#;
+
+const STYLUS_SCRIPT: &str = r#"
+const stylus = require('stylus');
+const chunks = [];
+process.stdin.on('data', c => chunks.push(c));
+process.stdin.on('end', () => {
+    const input = Buffer.concat(chunks).toString('utf8');
+    stylus.render(input, (err, css) => {
+        if (err) {
+            console.error(err && err.message ? err.message : String(err));
+            process.exit(1);
+        }
+        process.stdout.write(css);
+    });
+});
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn css_is_passthrough() {
+        let out = preprocess_style(
+            ".a { color: red; }",
+            StyleLanguage::Css,
+            Path::new("/tmp"),
+            Path::new("inline.css"),
+        )
+        .unwrap();
+        assert_eq!(out, ".a { color: red; }");
+    }
+
+    #[test]
+    fn missing_package_yields_style_error() {
+        let tmp = tempfile_dir();
+        let err = preprocess_style(
+            "$x: 1;\n.a { width: $x; }",
+            StyleLanguage::Scss,
+            &tmp,
+            Path::new("inline.scss"),
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("sass"), "expected sass in message: {msg}");
+        assert!(msg.contains("npm install"), "expected install hint: {msg}");
+    }
+
+    #[test]
+    fn extension_maps_to_language() {
+        assert_eq!(StyleLanguage::from_extension("scss"), StyleLanguage::Scss);
+        assert_eq!(StyleLanguage::from_extension("SASS"), StyleLanguage::Sass);
+        assert_eq!(StyleLanguage::from_extension("less"), StyleLanguage::Less);
+        assert_eq!(StyleLanguage::from_extension("styl"), StyleLanguage::Stylus);
+        assert_eq!(
+            StyleLanguage::from_extension("stylus"),
+            StyleLanguage::Stylus
+        );
+        assert_eq!(StyleLanguage::from_extension("css"), StyleLanguage::Css);
+        assert_eq!(StyleLanguage::from_extension("txt"), StyleLanguage::Css);
+    }
+
+    fn tempfile_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "ngc-preproc-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -151,6 +151,8 @@ mod tests {
             angular_core_import_span: Some((0, 43)),
             other_angular_core_imports: Vec::new(),
             styles_source: None,
+            inline_styles: Vec::new(),
+            style_urls: Vec::new(),
             input_properties: Vec::new(),
         }
     }

--- a/crates/template-compiler/tests/preprocessor_integration.rs
+++ b/crates/template-compiler/tests/preprocessor_integration.rs
@@ -1,0 +1,407 @@
+//! End-to-end integration tests for component style preprocessing.
+//!
+//! Exercises the `compile_all_decorators_with_styles` pipeline on synthetic
+//! `@Component` fixtures that use:
+//!   - `.scss` / `.sass` / `.less` / `.styl` `styleUrl`/`styleUrls`
+//!   - `styles: [\`...\`]` with `inlineStyleLanguage: scss`
+//!   - missing-npm-package diagnostics
+//!
+//! These tests shell out to real Node subprocesses via the `sass`, `less`,
+//! and `stylus` npm packages. Packages are installed once per test run into a
+//! per-user cache dir under the system temp directory; individual test
+//! fixtures symlink their `node_modules` to this cache. Tests that cannot
+//! locate a `node` binary or `npm` are skipped with a log line — the missing-
+//! package diagnostic test does not need them and always runs.
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use ngc_template_compiler::{
+    compile_all_decorators_with_styles, compile_component_with_styles, StyleContext, StyleLanguage,
+};
+use tempfile::tempdir;
+
+/// Install `sass`, `less`, and `stylus` into a shared cache directory so each
+/// test can symlink its `node_modules` to the cache. Returns the absolute
+/// path to `node_modules` on success, or `None` if node/npm are unavailable.
+fn preprocessor_cache() -> Option<&'static Path> {
+    static CACHE: OnceLock<Option<PathBuf>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            if !command_exists("node") || !command_exists("npm") {
+                eprintln!("ngc-preprocessor-integration: node/npm not on PATH — skipping install");
+                return None;
+            }
+            let cache_root = std::env::temp_dir().join("ngc-preprocessor-test-cache-v1");
+            let node_modules = cache_root.join("node_modules");
+
+            let all_present = ["sass", "less", "stylus"]
+                .iter()
+                .all(|pkg| node_modules.join(pkg).is_dir());
+            if all_present {
+                return Some(node_modules);
+            }
+            std::fs::create_dir_all(&cache_root).ok()?;
+            // package.json so npm treats the cache root as a project.
+            std::fs::write(
+                cache_root.join("package.json"),
+                "{\"name\":\"ngc-preprocessor-cache\",\"private\":true}",
+            )
+            .ok()?;
+
+            eprintln!(
+                "ngc-preprocessor-integration: installing sass, less, stylus into {}",
+                cache_root.display()
+            );
+            let status = Command::new("npm")
+                .arg("install")
+                .arg("--no-audit")
+                .arg("--no-fund")
+                .arg("--silent")
+                .arg("sass@1.77.8")
+                .arg("less@4.2.0")
+                .arg("stylus@0.64.0")
+                .current_dir(&cache_root)
+                .status();
+            match status {
+                Ok(s) if s.success() => Some(node_modules),
+                Ok(s) => {
+                    eprintln!("ngc-preprocessor-integration: npm install exited with {s}");
+                    None
+                }
+                Err(e) => {
+                    eprintln!("ngc-preprocessor-integration: could not run npm: {e}");
+                    None
+                }
+            }
+        })
+        .as_deref()
+}
+
+fn command_exists(cmd: &str) -> bool {
+    which::which(cmd).is_ok()
+}
+
+/// Build a fresh temp project rooted at a new directory with its
+/// `node_modules` symlinked to the shared cache. Returns `None` when the
+/// cache is unavailable (tests should skip in that case).
+fn make_project_with_node_modules() -> Option<(tempfile::TempDir, PathBuf)> {
+    let cache = preprocessor_cache()?;
+    let dir = tempdir().expect("create tempdir");
+    let project_root = dir.path().to_path_buf();
+    symlink(cache, project_root.join("node_modules")).expect("symlink node_modules");
+    Some((dir, project_root))
+}
+
+fn component_source(imports: &str, decorator_body: &str) -> String {
+    format!(
+        "import {{ Component }} from '@angular/core';\n\
+         {imports}\n\
+         @Component({{\n\
+             selector: 'app-test',\n\
+             standalone: true,\n\
+             template: '<div class=\"box\">hi</div>',\n\
+             {decorator_body}\n\
+         }})\n\
+         export class TestComponent {{}}\n"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics: missing package
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_sass_package_emits_clear_style_error() {
+    let dir = tempdir().expect("create tempdir");
+    let project_root = dir.path().to_path_buf();
+    // Intentionally no node_modules.
+    let component_path = project_root.join("app.component.ts");
+    std::fs::write(
+        project_root.join("styles.scss"),
+        "$c: red;\n.box { color: $c; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &component_path,
+        component_source("", "styleUrl: './styles.scss'"),
+    )
+    .unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Css,
+    };
+    let err = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("`sass` npm package is not installed"),
+        "expected missing-package diagnostic, got: {msg}"
+    );
+    assert!(
+        msg.contains("npm install --save-dev sass"),
+        "expected install hint, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// styleUrl: './foo.scss'
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scss_style_url_is_compiled_and_inlined_into_define_component() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("widget.component.ts");
+    std::fs::write(
+        project_root.join("widget.component.scss"),
+        "$brand: #abcdef;\n\
+         .box {\n\
+             color: $brand;\n\
+             &__inner { padding: 4px; }\n\
+         }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &component_path,
+        component_source("", "styleUrl: './widget.component.scss'"),
+    )
+    .unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Css,
+    };
+    let result = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .expect("compile with scss styleUrl");
+    assert!(result.compiled, "component should compile");
+
+    let out = &result.source;
+    assert!(
+        out.contains("styles:"),
+        "defineComponent should carry a styles array: {out}"
+    );
+    assert!(
+        out.contains("#abcdef"),
+        "SCSS variable should resolve to its concrete color: {out}"
+    );
+    assert!(
+        out.contains(".box__inner"),
+        "SCSS nested selector should be flattened: {out}"
+    );
+    assert!(
+        !out.contains("$brand"),
+        "raw SCSS source must not appear in output: {out}"
+    );
+}
+
+#[test]
+fn style_urls_array_preserves_order_and_compiles_each_language() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("mixed.component.ts");
+    std::fs::write(
+        project_root.join("first.scss"),
+        ".first { color: #111111; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("second.css"),
+        ".second { color: #222222; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &component_path,
+        component_source("", "styleUrls: ['./first.scss', './second.css']"),
+    )
+    .unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Css,
+    };
+    let result = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .expect("compile with styleUrls array");
+    assert!(result.compiled);
+    let out = &result.source;
+    let first_pos = out.find("#111111").expect("first.scss compiled color");
+    let second_pos = out.find("#222222").expect("second.css inlined color");
+    assert!(
+        first_pos < second_pos,
+        "styleUrls array order must be preserved in styles output"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// inlineStyleLanguage: scss → inline styles[] preprocessed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inline_style_language_scss_preprocesses_template_literal_bodies() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("theme.component.ts");
+    let body = "styles: [`\n\
+        $radius: 8px;\n\
+        .box { border-radius: $radius; &:hover { opacity: 0.5; } }\n\
+    `]";
+    std::fs::write(&component_path, component_source("", body)).unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Scss,
+    };
+    let result = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .expect("compile with inlineStyleLanguage scss");
+    assert!(result.compiled);
+    let out = &result.source;
+    assert!(
+        out.contains("8px"),
+        "SCSS variable should resolve to its value: {out}"
+    );
+    assert!(
+        out.contains(".box:hover"),
+        "nested `&:hover` should be flattened: {out}"
+    );
+    assert!(
+        !out.contains("$radius"),
+        "raw SCSS variable must not appear after preprocessing: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// .less and .styl
+// ---------------------------------------------------------------------------
+
+#[test]
+fn less_style_url_is_compiled() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("less.component.ts");
+    std::fs::write(
+        project_root.join("less.component.less"),
+        "@brand: #112233;\n\
+         .box { color: @brand; .inner { padding: 4px; } }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &component_path,
+        component_source("", "styleUrl: './less.component.less'"),
+    )
+    .unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Css,
+    };
+    let result = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .expect("compile with less styleUrl");
+    assert!(result.compiled);
+    let out = &result.source;
+    assert!(out.contains("#112233"), "less @variable resolved: {out}");
+    assert!(
+        out.contains(".box .inner"),
+        "less nested selector flattened: {out}"
+    );
+}
+
+#[test]
+fn stylus_style_url_is_compiled() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("styl.component.ts");
+    std::fs::write(
+        project_root.join("styl.component.styl"),
+        "brand = #789abc\n.box\n  color brand\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &component_path,
+        component_source("", "styleUrl: './styl.component.styl'"),
+    )
+    .unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Css,
+    };
+    let result = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .expect("compile with stylus styleUrl");
+    assert!(result.compiled);
+    let out = &result.source;
+    assert!(out.contains("#789abc"), "stylus variable resolved: {out}");
+    assert!(
+        out.to_ascii_lowercase().contains(".box"),
+        "stylus selector emitted: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Batch driver: the parallel `compile_all_decorators_with_styles` path runs
+// the same preprocessor and returns compiled files.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compile_all_decorators_processes_scss_component_in_parallel_path() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("parallel.component.ts");
+    std::fs::write(
+        project_root.join("parallel.scss"),
+        "$c: #9988aa;\n.parallel { color: $c; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &component_path,
+        component_source("", "styleUrl: './parallel.scss'"),
+    )
+    .unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Css,
+    };
+    let results = compile_all_decorators_with_styles(std::slice::from_ref(&component_path), &ctx)
+        .expect("compile_all should succeed");
+    assert_eq!(results.len(), 1);
+    let cf = &results[0];
+    assert!(cf.compiled);
+    assert!(
+        cf.source.contains("#9988aa"),
+        "compile_all pipeline must run preprocessor: {}",
+        cf.source
+    );
+}


### PR DESCRIPTION
Closes #61.

## Summary
- Parses `inlineStyleLanguage` from `angular.json` into a typed `InlineStyleLanguage` enum on the resolved project.
- Adds a new `ngc_template_compiler::preprocessor` module that shells out to a short Node script per language (`sass`, `less`, `stylus`) and pipes the raw source through stdin, mirroring the existing PostCSS/Tailwind subprocess pattern. Missing preprocessor packages surface a clear `NgcError::StyleError` with an `npm install --save-dev <pkg>` hint.
- Extracts `styleUrl` / `styleUrls` separately from inline `styles: [` ` ... ` `]` in `@Component` decorators. Before codegen, the compiler resolves each `styleUrl` from disk, preprocesses it by file extension, preprocesses inline `styles[]` entries under `inlineStyleLanguage`, and rewrites `styles_source` to a backtick-quoted array of compiled CSS so the existing `%COMP%` scoping path is unchanged.
- CLI threads a `StyleContext` (project root + `inlineStyleLanguage`) into `compile_all_decorators_with_styles`. Global `angular.json` `styles[]` entries now accept `.scss`/`.sass`/`.less`/`.styl` files and run them through the same preprocessor before concatenation.

## Test plan
- [x] `cargo test --workspace` (all existing tests + 7 new integration tests for SCSS/Less/Stylus)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] New `crates/template-compiler/tests/preprocessor_integration.rs` covers:
  - `.scss` `styleUrl` compiles and inlines into `defineComponent` `styles`
  - `styleUrls: [` `.scss`, `.css` `]` preserves source order
  - `inlineStyleLanguage: scss` preprocesses template-literal `styles: [\`...\`]`
  - `.less` and `.styl` `styleUrl` end-to-end compilation
  - Missing `sass` package produces a clear diagnostic pointing to `npm install --save-dev sass`
  - Parallel `compile_all_decorators_with_styles` drives preprocessing for multi-file runs