### PR TITLE
feat(template-compiler): animation trigger template syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.25"
+version = "0.7.26"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -202,6 +202,11 @@ pub fn generate_ivy(
         let scoped = scope_component_styles(styles_src);
         dc.push_str(&format!(",\n    styles: {scoped}"));
     }
+    if let Some(ref animations_src) = component.animations_source {
+        // Angular's runtime reads `data.animation` when resolving `@`-prefixed
+        // property/listener bindings through the animation renderer.
+        dc.push_str(&format!(",\n    data: {{ animation: {animations_src} }}"));
+    }
     dc.push_str("\n  })");
 
     // Collect child template functions
@@ -2997,6 +3002,7 @@ mod tests {
             inline_styles: Vec::new(),
             style_urls: Vec::new(),
             input_properties: Vec::new(),
+            animations_source: None,
         }
     }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -3536,6 +3536,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_animation_property_binding_codegen() {
+        let output = compile_template("<div [@fade]=\"state\"></div>");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}property('@fade', ctx.state)"),
+            "expected ɵɵproperty('@fade', ctx.state): {dc}"
+        );
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}property"));
+    }
+
+    #[test]
+    fn test_animation_listener_done_codegen() {
+        let output = compile_template("<div (@fade.done)=\"onDone($event)\"></div>");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}listener('@fade.done'"),
+            "expected ɵɵlistener('@fade.done', ...): {dc}"
+        );
+        assert!(
+            dc.contains("ctx.onDone($event)"),
+            "listener body should call ctx.onDone($event): {dc}"
+        );
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}listener"));
+    }
+
+    #[test]
+    fn test_animation_listener_start_codegen() {
+        let output = compile_template("<div (@fade.start)=\"onStart()\"></div>");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}listener('@fade.start'"),
+            "expected ɵɵlistener('@fade.start', ...): {dc}"
+        );
+    }
+
     fn collect_pipe_slot_offsets(code: &str) -> Vec<u32> {
         let mut out = Vec::new();
         for marker in [

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -58,6 +58,10 @@ pub struct ExtractedComponent {
     pub style_urls: Vec<String>,
     /// Property names decorated with `@Input()`.
     pub input_properties: Vec<String>,
+    /// Raw source text of the `animations` array (e.g. `[trigger('fade', [...])]`).
+    /// Passed through to the `defineComponent({ data: { animation: [...] } })`
+    /// field so Angular's runtime can register triggers with the animation renderer.
+    pub animations_source: Option<String>,
 }
 
 impl ExtractedComponent {
@@ -196,6 +200,7 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             inline_styles: metadata.inline_styles,
             style_urls: metadata.style_urls,
             input_properties,
+            animations_source: metadata.animations_source,
         }));
     }
 
@@ -872,6 +877,7 @@ struct DecoratorMetadata {
     styles_source: Option<String>,
     inline_styles: Vec<String>,
     style_urls: Vec<String>,
+    animations_source: Option<String>,
 }
 
 /// Extract metadata from the `@Component({...})` decorator argument.
@@ -889,6 +895,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                 styles_source: None,
                 inline_styles: Vec::new(),
                 style_urls: Vec::new(),
+                animations_source: None,
             });
         }
     };
@@ -906,6 +913,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                 styles_source: None,
                 inline_styles: Vec::new(),
                 style_urls: Vec::new(),
+                animations_source: None,
             });
         }
     };
@@ -919,6 +927,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
     let mut styles_source = None;
     let mut inline_styles: Vec<String> = Vec::new();
     let mut style_urls: Vec<String> = Vec::new();
+    let mut animations_source = None;
 
     for prop in &arg.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
@@ -1029,6 +1038,13 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                         }
                     }
                 }
+                "animations" => {
+                    let start = prop.value.span().start as usize;
+                    let end = prop.value.span().end as usize;
+                    if start < source.len() && end <= source.len() {
+                        animations_source = Some(source[start..end].to_string());
+                    }
+                }
                 _ => {}
             }
         }
@@ -1044,6 +1060,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
         styles_source,
         inline_styles,
         style_urls,
+        animations_source,
     })
 }
 

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -33,13 +33,16 @@ close_tag = { "</" ~ tag_name ~ ">" }
 tag_name = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "-")* }
 
 // Attributes (ordered by specificity to avoid ambiguity)
-attribute = _{ class_binding | style_binding | attr_binding | two_way_binding | event_binding | property_binding | structural_directive | ref_variable | static_attribute }
+attribute = _{ class_binding | style_binding | attr_binding | two_way_binding | event_binding | animation_property_binding | property_binding | structural_directive | ref_variable | static_attribute }
 
 two_way_binding = { "[(" ~ prop_name ~ ")]" ~ "=" ~ quoted_value }
 structural_directive = { "*" ~ attr_name ~ "=" ~ quoted_value }
 ref_variable = { "#" ~ identifier ~ ("=" ~ quoted_value)? }
 
 event_binding = { "(" ~ event_name ~ ")" ~ "=" ~ quoted_value }
+// `[@trigger]` with no value is valid Angular shorthand for `[@trigger]="undefined"`.
+animation_property_binding = { "[" ~ animation_prop_name ~ "]" ~ ("=" ~ quoted_value)? }
+animation_prop_name = @{ "@" ~ (ASCII_ALPHANUMERIC | "-" | "_")+ }
 property_binding = { "[" ~ prop_name ~ "]" ~ "=" ~ quoted_value }
 class_binding = { "[class." ~ class_name ~ "]" ~ "=" ~ quoted_value }
 style_binding = { "[style." ~ style_prop ~ "]" ~ "=" ~ quoted_value }
@@ -47,7 +50,7 @@ attr_binding = { "[attr." ~ attr_name ~ "]" ~ "=" ~ quoted_value }
 static_attribute = { attr_name ~ ("=" ~ quoted_value)? }
 
 event_name = @{ (ASCII_ALPHANUMERIC | "." | "-" | "@")+ }
-prop_name = @{ (ASCII_ALPHANUMERIC | "-" | "@")+ }
+prop_name = @{ (ASCII_ALPHANUMERIC | "-")+ }
 class_name = @{ (ASCII_ALPHANUMERIC | "-" | ":" | "_" | "." | "/")+ }
 style_prop = @{ (ASCII_ALPHANUMERIC | "-" | "." | "%")+ }
 attr_name = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -46,8 +46,8 @@ style_binding = { "[style." ~ style_prop ~ "]" ~ "=" ~ quoted_value }
 attr_binding = { "[attr." ~ attr_name ~ "]" ~ "=" ~ quoted_value }
 static_attribute = { attr_name ~ ("=" ~ quoted_value)? }
 
-event_name = @{ (ASCII_ALPHANUMERIC | "." | "-")+ }
-prop_name = @{ (ASCII_ALPHANUMERIC | "-")+ }
+event_name = @{ (ASCII_ALPHANUMERIC | "." | "-" | "@")+ }
+prop_name = @{ (ASCII_ALPHANUMERIC | "-" | "@")+ }
 class_name = @{ (ASCII_ALPHANUMERIC | "-" | ":" | "_" | "." | "/")+ }
 style_prop = @{ (ASCII_ALPHANUMERIC | "-" | "." | "%")+ }
 attr_name = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -118,6 +118,7 @@ pub fn generate_template_fn(
         inline_styles: Vec::new(),
         style_urls: Vec::new(),
         input_properties: Vec::new(),
+        animations_source: None,
     };
 
     let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -165,6 +165,20 @@ fn parse_attributes(
                     .unwrap_or_default();
                 attrs.push(crate::ast::TemplateAttribute::Property { name, expression });
             }
+            Rule::animation_property_binding => {
+                let mut inner = pair.into_inner();
+                let name = inner
+                    .next()
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_default();
+                // `[@trigger]` without `="..."` is shorthand for `[@trigger]="undefined"`.
+                let expression = inner
+                    .next()
+                    .and_then(|p| p.into_inner().next())
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_else(|| "undefined".to_string());
+                attrs.push(crate::ast::TemplateAttribute::Property { name, expression });
+            }
             Rule::class_binding => {
                 let mut inner = pair.into_inner();
                 let class_name = inner
@@ -697,6 +711,21 @@ mod tests {
                     assert_eq!(expression, "state");
                 }
                 _ => panic!("expected property binding for [@fade]"),
+            },
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_animation_property_binding_no_value() {
+        let nodes = parse("<div [@slide]></div>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => match &e.attributes[0] {
+                TemplateAttribute::Property { name, expression } => {
+                    assert_eq!(name, "@slide");
+                    assert_eq!(expression, "undefined");
+                }
+                _ => panic!("expected property binding for [@slide]"),
             },
             _ => panic!("expected element"),
         }

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -688,6 +688,51 @@ mod tests {
     }
 
     #[test]
+    fn test_animation_property_binding() {
+        let nodes = parse("<div [@fade]=\"state\"></div>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => match &e.attributes[0] {
+                TemplateAttribute::Property { name, expression } => {
+                    assert_eq!(name, "@fade");
+                    assert_eq!(expression, "state");
+                }
+                _ => panic!("expected property binding for [@fade]"),
+            },
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_animation_listener_done() {
+        let nodes = parse("<div (@fade.done)=\"onDone($event)\"></div>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => match &e.attributes[0] {
+                TemplateAttribute::Event { name, handler } => {
+                    assert_eq!(name, "@fade.done");
+                    assert_eq!(handler, "onDone($event)");
+                }
+                _ => panic!("expected event binding for (@fade.done)"),
+            },
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
+    fn test_animation_listener_start() {
+        let nodes = parse("<div (@fade.start)=\"onStart()\"></div>");
+        match &nodes[0] {
+            TemplateNode::Element(e) => match &e.attributes[0] {
+                TemplateAttribute::Event { name, handler } => {
+                    assert_eq!(name, "@fade.start");
+                    assert_eq!(handler, "onStart()");
+                }
+                _ => panic!("expected event binding for (@fade.start)"),
+            },
+            _ => panic!("expected element"),
+        }
+    }
+
+    #[test]
     fn test_let_with_if() {
         let nodes = parse("@let x = value(); @if (x) { <p>yes</p> }");
         assert_eq!(nodes.len(), 2);

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -154,6 +154,7 @@ mod tests {
             inline_styles: Vec::new(),
             style_urls: Vec::new(),
             input_properties: Vec::new(),
+            animations_source: None,
         }
     }
 

--- a/crates/template-compiler/tests/animation_triggers_integration.rs
+++ b/crates/template-compiler/tests/animation_triggers_integration.rs
@@ -1,0 +1,90 @@
+//! End-to-end integration test for Angular animation trigger template syntax.
+//!
+//! Compiles an `@Component` decorator that uses `@angular/animations`
+//! `trigger('fade', [...])` in the `animations` array and references the
+//! trigger in the template via `[@fade]="state"` and
+//! `(@fade.done)="onDone($event)"`. Verifies that the rewritten source
+//! contains the expected Ivy instructions:
+//!
+//!   - `ɵɵproperty('@fade', ctx.state)` in the update block
+//!   - `ɵɵlistener('@fade.done', ...)` in the creation block
+//!   - `ɵɵlistener('@fade.start', ...)` for the `.start` phase
+//!
+//! Angular's runtime routes `@`-prefixed property names to the animation
+//! renderer and dispatches the listener when the matching state transition
+//! reaches the given phase, so emitting these instructions is what makes
+//! `trigger(...)` work against the real `@angular/animations` package.
+
+use std::path::PathBuf;
+
+use ngc_template_compiler::compile_component;
+
+const FIXTURE_SOURCE: &str = r#"
+import { Component } from '@angular/core';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+
+@Component({
+  selector: 'app-fade',
+  standalone: true,
+  template: `
+    <div
+      [@fade]="state"
+      (@fade.done)="onDone($event)"
+      (@fade.start)="onStart($event)">
+      fade me
+    </div>
+  `,
+  animations: [
+    trigger('fade', [
+      state('visible', style({ opacity: 1 })),
+      state('hidden', style({ opacity: 0 })),
+      transition('visible <=> hidden', animate('200ms ease-in-out')),
+    ]),
+  ],
+})
+export class FadeComponent {
+  state: 'visible' | 'hidden' = 'visible';
+  onDone(_event: unknown) {}
+  onStart(_event: unknown) {}
+}
+"#;
+
+#[test]
+fn animation_trigger_template_compiles_to_ivy_instructions() {
+    let compiled = compile_component(FIXTURE_SOURCE, &PathBuf::from("fade.component.ts"))
+        .expect("component should compile");
+
+    assert!(compiled.compiled, "compile_component should rewrite source");
+    assert!(
+        !compiled.jit_fallback,
+        "animation trigger syntax must not trigger JIT fallback"
+    );
+
+    let rewritten = &compiled.source;
+
+    assert!(
+        rewritten.contains("\u{0275}\u{0275}property('@fade', ctx.state)"),
+        "expected ɵɵproperty('@fade', ctx.state) in rewritten source:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("\u{0275}\u{0275}listener('@fade.done'"),
+        "expected ɵɵlistener('@fade.done', ...) in rewritten source:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("\u{0275}\u{0275}listener('@fade.start'"),
+        "expected ɵɵlistener('@fade.start', ...) in rewritten source:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("ctx.onDone($event)"),
+        "listener body should forward $event to ctx.onDone:\n{rewritten}"
+    );
+    assert!(
+        rewritten.contains("ctx.onStart($event)"),
+        "listener body should forward $event to ctx.onStart:\n{rewritten}"
+    );
+
+    assert!(
+        rewritten.contains("trigger('fade'"),
+        "original animations array should be preserved for Angular's runtime:\n{rewritten}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #59.

Teaches the template compiler the Angular animation binding syntax so that components using `@angular/animations` `trigger(...)` compile natively instead of falling through to JIT.

- Parser accepts `[@name]="expr"`, `[@name]` (shorthand for `undefined`), and `(@name.start|done)="handler"`.
- Codegen emits `ɵɵproperty('@name', expr)` and `ɵɵlistener('@name.phase', fn)` so Angular's runtime routes the binding through the animation renderer.
- The `animations: [...]` array from `@Component` is preserved in the generated `defineComponent` call as `data: { animation: [...] }` — Angular's runtime reads that field when registering triggers.

## Test plan

- [x] `cargo test --workspace` (unit + integration)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Parser unit tests cover `[@fade]="state"`, bare `[@slide]`, and both `.start` / `.done` listener phases
- [x] Codegen unit tests confirm `ɵɵproperty('@fade', ctx.state)` / `ɵɵlistener('@fade.done', ...)` emit as expected
- [x] Integration test compiles a full `@Component` that uses `trigger('fade', [state, transition, animate])` and verifies the rewritten source contains the expected Ivy instructions and a preserved `trigger('fade', ...)` in `data.animation`