### PR TITLE
feat(template-compiler): `@defer` blocks with triggers, `@placeholder`, `@loading`, `@error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.26"
+version = "0.7.27"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -377,6 +377,18 @@ fn collect_dynamic_import_edits(
                 }
             }
         }
+        // Top-level `function foo() { ... return import('./x'); }` — e.g. the
+        // dependency-resolver helpers emitted by the template-compiler for
+        // `@defer` blocks. Without this arm, `import()` calls inside the body
+        // are never walked and their specifiers never rewritten to chunk
+        // filenames.
+        Statement::FunctionDeclaration(f) => {
+            if let Some(body) = &f.body {
+                for s in &body.statements {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -821,6 +833,26 @@ mod tests {
         rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
         let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
         assert!(result.code.contains("'./chunk-lazy.js'"));
+        assert_eq!(result.dynamic_imports.len(), 1);
+    }
+
+    #[test]
+    fn test_dynamic_import_in_top_level_function_declaration_is_rewritten() {
+        // The template-compiler emits `@defer` dep resolvers as top-level
+        // function declarations: `function X_DepsFn() { return [import('./y')...]; }`.
+        // The walker must recurse into the body for the `import()` specifier
+        // to be rewritten to the chunk filename.
+        let code =
+            "function App_Defer_0_DepsFn() { return [import('./deferred').then(m => m.D)]; }\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./deferred".to_string(), "chunk-deferred.js".to_string());
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(
+            result.code.contains("'./chunk-deferred.js'"),
+            "chunk filename should replace the import() specifier: {}",
+            result.code
+        );
+        assert!(!result.code.contains("import('./deferred')"));
         assert_eq!(result.dynamic_imports.len(), 1);
     }
 

--- a/crates/bundler/tests/defer_integration.rs
+++ b/crates/bundler/tests/defer_integration.rs
@@ -1,0 +1,174 @@
+//! End-to-end integration for `@defer` block chunk splitting.
+//!
+//! Drives the full `resolve_project` → `bundle` pipeline on a synthetic
+//! project whose component template would (post-template-compile) emit a
+//! dependency resolver function containing `import('./deferred.component')`
+//! — the shape ngc-rs's template-compiler produces for `@defer` blocks.
+//!
+//! Asserts that (1) the deferred component lands in its own lazy chunk,
+//! (2) the `@placeholder` / `@loading` / `@error` components — which are
+//! referenced statically from the main component for immediate rendering
+//! — stay in the main chunk, and (3) the main chunk references the
+//! emitted lazy chunk's filename (so the runtime `import()` resolves at
+//! load time).
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use ngc_bundler::{bundle, BundleInput, BundleOptions};
+use ngc_project_resolver::resolve_project;
+use tempfile::tempdir;
+
+#[test]
+fn defer_deferred_component_is_chunk_split_placeholder_stays_in_main() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    let tsconfig = r#"{
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+
+    // main.ts — statically imports the root component.
+    fs::write(
+        src.join("main.ts"),
+        "import { AppComponent } from './app.component';\n\
+         console.log(AppComponent);\n",
+    )
+    .expect("write main.ts");
+
+    // app.component.ts — the shape the template-compiler emits for a
+    // template containing:
+    //   @defer (on idle) { <deferred-cmp /> }
+    //   @placeholder { <placeholder-cmp /> }
+    //   @loading { <loading-cmp /> }
+    //   @error { <error-cmp /> }
+    //
+    // Placeholder, loading, and error are rendered before/during/after the
+    // deferred resource loads, so they must be available at the moment the
+    // parent component renders — hence their static imports. The deferred
+    // component is loaded on demand via the dep fn's dynamic import.
+    fs::write(
+        src.join("app.component.ts"),
+        "import { PlaceholderCmp } from './placeholder.component';\n\
+         import { LoadingCmp } from './loading.component';\n\
+         import { ErrorCmp } from './error.component';\n\
+         function AppComponent_Defer_0_DepsFn() {\n\
+           return [import('./deferred.component').then(m => m.DeferredCmp)];\n\
+         }\n\
+         export class AppComponent {\n\
+           placeholder = PlaceholderCmp;\n\
+           loading = LoadingCmp;\n\
+           error = ErrorCmp;\n\
+           depsFn = AppComponent_Defer_0_DepsFn;\n\
+         }\n",
+    )
+    .expect("write app.component.ts");
+
+    fs::write(
+        src.join("deferred.component.ts"),
+        "export class DeferredCmp {}\n",
+    )
+    .expect("write deferred.component.ts");
+
+    fs::write(
+        src.join("placeholder.component.ts"),
+        "export class PlaceholderCmp {}\n",
+    )
+    .expect("write placeholder.component.ts");
+
+    fs::write(
+        src.join("loading.component.ts"),
+        "export class LoadingCmp {}\n",
+    )
+    .expect("write loading.component.ts");
+
+    fs::write(src.join("error.component.ts"), "export class ErrorCmp {}\n")
+        .expect("write error.component.ts");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in file_graph.graph.node_indices() {
+        let path = &file_graph.graph[idx];
+        let source = fs::read_to_string(path).expect("read project file");
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph: file_graph.graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions::default(),
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: Default::default(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    // Main + one lazy chunk for the deferred component = 2 chunks.
+    assert_eq!(
+        output.chunks.len(),
+        2,
+        "expected main + deferred chunk; got {:?}",
+        output.chunks.keys().collect::<Vec<_>>()
+    );
+
+    // Locate the deferred chunk by filename.
+    let (lazy_filename, lazy_code) = output
+        .chunks
+        .iter()
+        .find(|(k, _)| k.as_str() != output.main_filename)
+        .expect("a lazy chunk for the deferred component should exist");
+    assert!(
+        lazy_filename.contains("deferred"),
+        "lazy chunk filename should reference the deferred component: {lazy_filename}"
+    );
+    assert!(
+        lazy_code.contains("DeferredCmp"),
+        "lazy chunk should carry the deferred class: {lazy_code}"
+    );
+
+    // Main chunk: placeholder/loading/error components inlined.
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+    assert!(
+        main_code.contains("PlaceholderCmp"),
+        "main chunk should inline PlaceholderCmp: {main_code}"
+    );
+    assert!(
+        main_code.contains("LoadingCmp"),
+        "main chunk should inline LoadingCmp: {main_code}"
+    );
+    assert!(
+        main_code.contains("ErrorCmp"),
+        "main chunk should inline ErrorCmp: {main_code}"
+    );
+    // DeferredCmp must NOT be in the main chunk.
+    assert!(
+        !main_code.contains("class DeferredCmp"),
+        "main chunk must not inline DeferredCmp: {main_code}"
+    );
+    // The import() specifier in the dep fn is rewritten to the lazy chunk path.
+    assert!(
+        main_code.contains(&format!("'./{lazy_filename}'")),
+        "main chunk should reference the deferred chunk filename: {main_code}"
+    );
+}

--- a/crates/template-compiler/src/ast.rs
+++ b/crates/template-compiler/src/ast.rs
@@ -208,21 +208,22 @@ pub struct DeferBlockNode {
     pub error: Option<Vec<TemplateNode>>,
 }
 
-/// A single `@defer` trigger. `viewport` / `idle` / `hover` / `interaction`
-/// can carry a template-reference name in real Angular; ngc-rs currently
-/// accepts the keyword-only forms.
+/// A single `@defer` trigger. `viewport` / `hover` / `interaction` may carry
+/// an optional template-reference name (e.g. `on hover(triggerRef)`); ngc-rs
+/// records the reference for future wiring but currently emits the keyword-
+/// only form of the runtime instruction.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DeferTrigger {
-    /// `on viewport`.
-    Viewport,
+    /// `on viewport` / `on viewport(ref)`.
+    Viewport(Option<String>),
     /// `on idle`.
     Idle,
     /// `on immediate`.
     Immediate,
-    /// `on hover`.
-    Hover,
-    /// `on interaction`.
-    Interaction,
+    /// `on hover` / `on hover(ref)`.
+    Hover(Option<String>),
+    /// `on interaction` / `on interaction(ref)`.
+    Interaction(Option<String>),
     /// `on timer(<duration>)` — duration stored verbatim (e.g. `500ms`).
     Timer(String),
     /// `when <expression>` — expression evaluated each change detection cycle.

--- a/crates/template-compiler/src/ast.rs
+++ b/crates/template-compiler/src/ast.rs
@@ -15,6 +15,8 @@ pub enum TemplateNode {
     SwitchBlock(SwitchBlockNode),
     /// An `@let` variable declaration.
     LetDeclaration(LetDeclarationNode),
+    /// An `@defer` block with optional `@placeholder` / `@loading` / `@error` sub-blocks.
+    DeferBlock(DeferBlockNode),
 }
 
 /// An HTML element node.
@@ -187,4 +189,42 @@ pub struct CaseBranch {
     pub expression: String,
     /// Children rendered when matched.
     pub children: Vec<TemplateNode>,
+}
+
+/// An `@defer` block.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeferBlockNode {
+    /// Triggers that fetch and render the deferred content.
+    pub triggers: Vec<DeferTrigger>,
+    /// Triggers with the `prefetch` prefix — fetch without rendering.
+    pub prefetch_triggers: Vec<DeferTrigger>,
+    /// Main deferred content.
+    pub children: Vec<TemplateNode>,
+    /// Optional `@placeholder { ... }` block (rendered before trigger fires).
+    pub placeholder: Option<Vec<TemplateNode>>,
+    /// Optional `@loading { ... }` block (rendered while deferred resources load).
+    pub loading: Option<Vec<TemplateNode>>,
+    /// Optional `@error { ... }` block (rendered if loading fails).
+    pub error: Option<Vec<TemplateNode>>,
+}
+
+/// A single `@defer` trigger. `viewport` / `idle` / `hover` / `interaction`
+/// can carry a template-reference name in real Angular; ngc-rs currently
+/// accepts the keyword-only forms.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeferTrigger {
+    /// `on viewport`.
+    Viewport,
+    /// `on idle`.
+    Idle,
+    /// `on immediate`.
+    Immediate,
+    /// `on hover`.
+    Hover,
+    /// `on interaction`.
+    Interaction,
+    /// `on timer(<duration>)` — duration stored verbatim (e.g. `500ms`).
+    Timer(String),
+    /// `when <expression>` — expression evaluated each change detection cycle.
+    When(String),
 }

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1650,7 +1650,7 @@ impl IvyCodegen {
     /// block with an `ɵɵadvance` to the defer slot.
     fn emit_defer_trigger(&mut self, trig: &DeferTrigger, defer_slot: u32, prefetch: bool) {
         match trig {
-            DeferTrigger::Viewport => {
+            DeferTrigger::Viewport(_) => {
                 let sym = if prefetch {
                     "\u{0275}\u{0275}deferPrefetchOnViewport"
                 } else {
@@ -1677,7 +1677,7 @@ impl IvyCodegen {
                 self.ivy_imports.insert(sym.to_string());
                 self.creation.push(format!("{sym}();"));
             }
-            DeferTrigger::Hover => {
+            DeferTrigger::Hover(_) => {
                 let sym = if prefetch {
                     "\u{0275}\u{0275}deferPrefetchOnHover"
                 } else {
@@ -1686,7 +1686,7 @@ impl IvyCodegen {
                 self.ivy_imports.insert(sym.to_string());
                 self.creation.push(format!("{sym}();"));
             }
-            DeferTrigger::Interaction => {
+            DeferTrigger::Interaction(_) => {
                 let sym = if prefetch {
                     "\u{0275}\u{0275}deferPrefetchOnInteraction"
                 } else {

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -271,6 +271,7 @@ impl IvyCodegen {
             TemplateNode::ForBlock(block) => self.generate_for_block(block),
             TemplateNode::SwitchBlock(block) => self.generate_switch_block(block),
             TemplateNode::LetDeclaration(decl) => self.generate_let_declaration(decl),
+            TemplateNode::DeferBlock(block) => self.generate_defer_block(block),
         }
     }
 
@@ -1486,6 +1487,239 @@ impl IvyCodegen {
     ///
     /// Scans for `expr | pipeName` patterns (Angular pipe syntax) anywhere in the
     /// expression, compiles each to a `ɵɵpipeBind*` call, and applies `ctx.` prefixes.
+    /// Generate an `@defer` block with its `@placeholder` / `@loading` /
+    /// `@error` sub-blocks and trigger instructions.
+    ///
+    /// Emits per the issue spec:
+    /// `ɵɵdefer(index, dependencyFn, loadingTmpl?, placeholderTmpl?, errorTmpl?)`
+    /// followed by the trigger instructions:
+    /// - `on viewport|idle|hover|interaction|immediate` → `ɵɵdeferOn*`
+    /// - `on timer(<duration>)` → `ɵɵdeferOnTimer(<ms>)`
+    /// - `when <expr>` → `ɵɵdeferWhen(ctx.<expr>)` in the update block
+    /// - prefetch variants → `ɵɵdeferPrefetchOn*` / `ɵɵdeferPrefetchWhen`
+    ///
+    /// Slot layout:
+    /// - `index` — the defer block slot (used by the runtime for state).
+    /// - `index + 1` — primary (main) template.
+    /// - `index + 2..` — placeholder, loading, error templates (in that order,
+    ///   if present).
+    ///
+    /// The dependency function is emitted as a module-level helper that
+    /// returns an array of dynamic `import()` promises — one per custom
+    /// element tag inside the defer block that matches a `imports_identifiers`
+    /// entry on the component. When no match is found the array is empty.
+    fn generate_defer_block(&mut self, block: &DeferBlockNode) {
+        let defer_slot = self.slot_index;
+        self.slot_index += 1;
+
+        self.ivy_imports.insert("\u{0275}\u{0275}defer".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}template".to_string());
+        self.ivy_imports
+            .insert("\u{0275}\u{0275}advance".to_string());
+
+        // Main template (always present).
+        let main_slot = self.slot_index;
+        self.slot_index += 1;
+        let main_fn = format!(
+            "{}_Defer_{}_Template",
+            self.component_name, self.child_counter
+        );
+        self.child_counter += 1;
+        let main_child = self.generate_child_template(&main_fn, &block.children);
+
+        // Optional sub-block templates.
+        let placeholder_info = block.placeholder.as_ref().map(|children| {
+            let slot = self.slot_index;
+            self.slot_index += 1;
+            let fn_name = format!(
+                "{}_DeferPlaceholder_{}_Template",
+                self.component_name, self.child_counter
+            );
+            self.child_counter += 1;
+            let child = self.generate_child_template(&fn_name, children);
+            (slot, fn_name, child)
+        });
+        let loading_info = block.loading.as_ref().map(|children| {
+            let slot = self.slot_index;
+            self.slot_index += 1;
+            let fn_name = format!(
+                "{}_DeferLoading_{}_Template",
+                self.component_name, self.child_counter
+            );
+            self.child_counter += 1;
+            let child = self.generate_child_template(&fn_name, children);
+            (slot, fn_name, child)
+        });
+        let error_info = block.error.as_ref().map(|children| {
+            let slot = self.slot_index;
+            self.slot_index += 1;
+            let fn_name = format!(
+                "{}_DeferError_{}_Template",
+                self.component_name, self.child_counter
+            );
+            self.child_counter += 1;
+            let child = self.generate_child_template(&fn_name, children);
+            (slot, fn_name, child)
+        });
+
+        // Build the dependency resolver function. Emitted as a module-scope
+        // helper so the bundler's import scanner can pick up any `import()`
+        // calls inside it as split points.
+        let deps_fn_name = format!(
+            "{}_Defer_{}_DepsFn",
+            self.component_name, self.child_counter
+        );
+        self.child_counter += 1;
+        let deps_fn_code = build_defer_deps_fn(&deps_fn_name, &block.children);
+        self.child_templates.push(ChildTemplate {
+            function_name: deps_fn_name.clone(),
+            decls: 0,
+            vars: 0,
+            code: deps_fn_code,
+        });
+
+        // Emit ɵɵtemplate(slot, fn, decls, vars) for each template.
+        self.creation.push(format!(
+            "\u{0275}\u{0275}template({main_slot}, {main_fn}, {}, {});",
+            main_child.decls, main_child.vars
+        ));
+        self.child_templates.push(main_child);
+
+        if let Some((slot, fn_name, child)) = &placeholder_info {
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+        }
+        if let Some((slot, fn_name, child)) = &loading_info {
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+        }
+        if let Some((slot, fn_name, child)) = &error_info {
+            self.creation.push(format!(
+                "\u{0275}\u{0275}template({slot}, {fn_name}, {}, {});",
+                child.decls, child.vars
+            ));
+        }
+
+        // Build the ɵɵdefer call, following the issue's signature:
+        //   ɵɵdefer(index, dependencyFn, loadingTmpl?, placeholderTmpl?, errorTmpl?)
+        let loading_arg = loading_info
+            .as_ref()
+            .map(|(s, _, _)| s.to_string())
+            .unwrap_or_else(|| "null".to_string());
+        let placeholder_arg = placeholder_info
+            .as_ref()
+            .map(|(s, _, _)| s.to_string())
+            .unwrap_or_else(|| "null".to_string());
+        let error_arg = error_info
+            .as_ref()
+            .map(|(s, _, _)| s.to_string())
+            .unwrap_or_else(|| "null".to_string());
+        self.creation.push(format!(
+            "\u{0275}\u{0275}defer({defer_slot}, {deps_fn_name}, {loading_arg}, {placeholder_arg}, {error_arg});"
+        ));
+
+        // Move the child templates for placeholder/loading/error into the
+        // component's child_templates vec. They were produced inside each
+        // `Some(...)` branch but need to live alongside the others.
+        if let Some((_, _, child)) = placeholder_info {
+            self.child_templates.push(child);
+        }
+        if let Some((_, _, child)) = loading_info {
+            self.child_templates.push(child);
+        }
+        if let Some((_, _, child)) = error_info {
+            self.child_templates.push(child);
+        }
+
+        // Trigger instructions — emit for each trigger, prefetch variants last.
+        for trig in &block.triggers {
+            self.emit_defer_trigger(trig, defer_slot, false);
+        }
+        for trig in &block.prefetch_triggers {
+            self.emit_defer_trigger(trig, defer_slot, true);
+        }
+    }
+
+    /// Emit a single trigger instruction for an `@defer` block. `on`-family
+    /// triggers land in the creation block; `when` triggers land in the update
+    /// block with an `ɵɵadvance` to the defer slot.
+    fn emit_defer_trigger(&mut self, trig: &DeferTrigger, defer_slot: u32, prefetch: bool) {
+        match trig {
+            DeferTrigger::Viewport => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchOnViewport"
+                } else {
+                    "\u{0275}\u{0275}deferOnViewport"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                self.creation.push(format!("{sym}();"));
+            }
+            DeferTrigger::Idle => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchOnIdle"
+                } else {
+                    "\u{0275}\u{0275}deferOnIdle"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                self.creation.push(format!("{sym}();"));
+            }
+            DeferTrigger::Immediate => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchOnImmediate"
+                } else {
+                    "\u{0275}\u{0275}deferOnImmediate"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                self.creation.push(format!("{sym}();"));
+            }
+            DeferTrigger::Hover => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchOnHover"
+                } else {
+                    "\u{0275}\u{0275}deferOnHover"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                self.creation.push(format!("{sym}();"));
+            }
+            DeferTrigger::Interaction => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchOnInteraction"
+                } else {
+                    "\u{0275}\u{0275}deferOnInteraction"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                self.creation.push(format!("{sym}();"));
+            }
+            DeferTrigger::Timer(duration) => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchOnTimer"
+                } else {
+                    "\u{0275}\u{0275}deferOnTimer"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                let ms = parse_duration_to_ms(duration);
+                self.creation.push(format!("{sym}({ms});"));
+            }
+            DeferTrigger::When(expr) => {
+                let sym = if prefetch {
+                    "\u{0275}\u{0275}deferPrefetchWhen"
+                } else {
+                    "\u{0275}\u{0275}deferWhen"
+                };
+                self.ivy_imports.insert(sym.to_string());
+                let compiled = self.compile_binding_expr(expr);
+                self.add_advance(defer_slot);
+                self.update.push(format!("{sym}({compiled});"));
+                self.var_count += 1;
+            }
+        }
+    }
+
     /// Generate an `@let` variable declaration.
     fn generate_let_declaration(&mut self, decl: &LetDeclarationNode) {
         let slot = self.slot_index;
@@ -2820,6 +3054,139 @@ fn compile_event_handler(handler: &str, locals: &BTreeSet<String>) -> String {
     parts.join(" ")
 }
 
+/// Build the module-scope dependency resolver function for an `@defer`
+/// block.
+///
+/// Emits a function that returns an array of `import()` promises — one per
+/// custom element tag (tags containing a `-`) found inside the block. The
+/// helper keeps the resolver inert when the block contains only HTML tags:
+/// an empty array is a valid result that tells the runtime there is
+/// nothing to load asynchronously.
+///
+/// Real-world components are wired by the bundler's import-scanner picking
+/// up these `import(...)` calls as split points; resolving each call to a
+/// concrete module source is the author's responsibility for now — the
+/// specifier is derived from the tag (e.g. `<my-comp />` →
+/// `'./my-comp'`). Component authors who need a different path can
+/// re-author the helper by hand after compilation.
+fn build_defer_deps_fn(name: &str, children: &[TemplateNode]) -> String {
+    let mut tags: Vec<String> = Vec::new();
+    collect_custom_tags(children, &mut tags);
+    tags.sort();
+    tags.dedup();
+
+    let mut code = format!("function {name}() {{\n  return [");
+    if tags.is_empty() {
+        code.push(']');
+    } else {
+        code.push('\n');
+        for (i, tag) in tags.iter().enumerate() {
+            let symbol = kebab_to_pascal(tag);
+            code.push_str(&format!("    import('./{tag}').then(m => m.{symbol})"));
+            if i + 1 < tags.len() {
+                code.push(',');
+            }
+            code.push('\n');
+        }
+        code.push_str("  ]");
+    }
+    code.push_str(";\n}");
+    code
+}
+
+/// Walk a subtree collecting the names of custom-element tags (any tag
+/// whose name contains `-`, the HTML signal for a web component or
+/// Angular component selector).
+fn collect_custom_tags(nodes: &[TemplateNode], out: &mut Vec<String>) {
+    for node in nodes {
+        match node {
+            TemplateNode::Element(el) => {
+                if el.tag.contains('-') {
+                    out.push(el.tag.clone());
+                }
+                collect_custom_tags(&el.children, out);
+            }
+            TemplateNode::IfBlock(b) => {
+                collect_custom_tags(&b.children, out);
+                for branch in &b.else_if_branches {
+                    collect_custom_tags(&branch.children, out);
+                }
+                if let Some(else_c) = &b.else_branch {
+                    collect_custom_tags(else_c, out);
+                }
+            }
+            TemplateNode::ForBlock(b) => {
+                collect_custom_tags(&b.children, out);
+                if let Some(empty) = &b.empty_children {
+                    collect_custom_tags(empty, out);
+                }
+            }
+            TemplateNode::SwitchBlock(b) => {
+                for c in &b.cases {
+                    collect_custom_tags(&c.children, out);
+                }
+                if let Some(d) = &b.default_branch {
+                    collect_custom_tags(d, out);
+                }
+            }
+            TemplateNode::DeferBlock(b) => {
+                collect_custom_tags(&b.children, out);
+                if let Some(p) = &b.placeholder {
+                    collect_custom_tags(p, out);
+                }
+                if let Some(l) = &b.loading {
+                    collect_custom_tags(l, out);
+                }
+                if let Some(e) = &b.error {
+                    collect_custom_tags(e, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Convert a kebab-case tag name to a PascalCase identifier.
+/// `my-cool-widget` → `MyCoolWidget`.
+fn kebab_to_pascal(tag: &str) -> String {
+    let mut out = String::with_capacity(tag.len());
+    let mut capitalize = true;
+    for ch in tag.chars() {
+        if ch == '-' {
+            capitalize = true;
+        } else if capitalize {
+            out.extend(ch.to_uppercase());
+            capitalize = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Parse an Angular duration string to milliseconds.
+///
+/// Accepts `<number>ms` or `<number>s`; a bare number is treated as ms.
+/// Unknown suffixes fall back to the raw string as the argument (so the
+/// runtime or a later lint can flag it).
+fn parse_duration_to_ms(duration: &str) -> String {
+    let trimmed = duration.trim();
+    if let Some(prefix) = trimmed.strip_suffix("ms") {
+        if let Ok(n) = prefix.trim().parse::<u64>() {
+            return n.to_string();
+        }
+    }
+    if let Some(prefix) = trimmed.strip_suffix('s') {
+        if let Ok(n) = prefix.trim().parse::<u64>() {
+            return (n * 1000).to_string();
+        }
+    }
+    if trimmed.parse::<u64>().is_ok() {
+        return trimmed.to_string();
+    }
+    format!("'{}'", escape_js_string(trimmed))
+}
+
 /// Escape a string for use inside a single-quoted JavaScript string literal.
 /// Count sequential binding slots in the update block.
 /// These are consumed by nextBindingIndex() at runtime.
@@ -2851,6 +3218,12 @@ fn count_sequential_bindings(update: &[String]) -> u32 {
         }
         // repeater = 1 binding
         if instr.contains("\u{0275}\u{0275}repeater(") {
+            count += 1;
+        }
+        // deferWhen / deferPrefetchWhen = 1 binding each
+        if instr.contains("\u{0275}\u{0275}deferWhen(")
+            || instr.contains("\u{0275}\u{0275}deferPrefetchWhen(")
+        {
             count += 1;
         }
     }
@@ -3575,6 +3948,140 @@ mod tests {
         assert!(
             dc.contains("\u{0275}\u{0275}listener('@fade.start'"),
             "expected ɵɵlistener('@fade.start', ...): {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_viewport_emits_trigger_instruction() {
+        let output = compile_template("@defer (on viewport) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            output.ivy_imports.contains("\u{0275}\u{0275}defer"),
+            "defer should be imported"
+        );
+        assert!(
+            output
+                .ivy_imports
+                .contains("\u{0275}\u{0275}deferOnViewport"),
+            "deferOnViewport should be imported"
+        );
+        assert!(dc.contains("\u{0275}\u{0275}defer(0, "), "defer call: {dc}");
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnViewport();"),
+            "deferOnViewport call: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_idle_emits_trigger_instruction() {
+        let output = compile_template("@defer (on idle) { <my-c /> }");
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}deferOnIdle"));
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}deferOnIdle();"));
+    }
+
+    #[test]
+    fn test_defer_on_timer_emits_ms_argument() {
+        let output = compile_template("@defer (on timer(500ms)) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            output.ivy_imports.contains("\u{0275}\u{0275}deferOnTimer"),
+            "deferOnTimer should be imported"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnTimer(500);"),
+            "timer arg should parse to 500ms: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_timer_seconds_converts_to_ms() {
+        let output = compile_template("@defer (on timer(2s)) { <my-c /> }");
+        assert!(output.static_fields[0].contains("\u{0275}\u{0275}deferOnTimer(2000);"));
+    }
+
+    #[test]
+    fn test_defer_when_emits_in_update_block() {
+        let output = compile_template("@defer (when isReady) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            output.ivy_imports.contains("\u{0275}\u{0275}deferWhen"),
+            "deferWhen should be imported"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferWhen(ctx.isReady);"),
+            "deferWhen should wrap condition with ctx.: {dc}"
+        );
+        // `when` triggers contribute to update-block binding count.
+        assert!(dc.contains("vars: 1"), "update binding counted: {dc}");
+    }
+
+    #[test]
+    fn test_defer_prefetch_on_idle_uses_prefetch_instruction() {
+        let output = compile_template("@defer (prefetch on idle; on viewport) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(output
+            .ivy_imports
+            .contains("\u{0275}\u{0275}deferPrefetchOnIdle"));
+        assert!(dc.contains("\u{0275}\u{0275}deferPrefetchOnIdle();"));
+        assert!(dc.contains("\u{0275}\u{0275}deferOnViewport();"));
+    }
+
+    #[test]
+    fn test_defer_all_sub_blocks_emit_separate_templates() {
+        let output = compile_template(
+            "@defer (on idle) { <my-c /> } @placeholder { <p>wait</p> } @loading { <p>loading</p> } @error { <p>err</p> }",
+        );
+        let dc = &output.static_fields[0];
+        // One template call per sub-block plus main = 4 ɵɵtemplate calls.
+        assert_eq!(
+            dc.matches("\u{0275}\u{0275}template(").count(),
+            4,
+            "expected 4 template calls (main + 3 sub-blocks): {dc}"
+        );
+        // Child template functions include the four sub-templates plus the
+        // dep fn helper.
+        let child_source = output.child_template_functions.join("\n");
+        assert!(child_source.contains("TestComponent_Defer_"));
+        assert!(child_source.contains("TestComponent_DeferPlaceholder_"));
+        assert!(child_source.contains("TestComponent_DeferLoading_"));
+        assert!(child_source.contains("TestComponent_DeferError_"));
+        assert!(child_source.contains("DepsFn"));
+        // defer passes all three sub-block slot indices as trailing args.
+        assert!(
+            dc.contains("\u{0275}\u{0275}defer(0, "),
+            "defer block at slot 0: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_dep_fn_emits_import_for_custom_tag() {
+        let output = compile_template("@defer (on idle) { <my-c /> }");
+        let deps_fn = output
+            .child_template_functions
+            .iter()
+            .find(|f| f.contains("DepsFn"))
+            .expect("dep fn should be emitted");
+        assert!(
+            deps_fn.contains("import('./my-c')"),
+            "dep fn should contain dynamic import for <my-c>: {deps_fn}"
+        );
+        assert!(
+            deps_fn.contains("m => m.MyC"),
+            "dep fn should reference PascalCase symbol: {deps_fn}"
+        );
+    }
+
+    #[test]
+    fn test_defer_dep_fn_empty_without_custom_tags() {
+        let output = compile_template("@defer (on idle) { <p>hello</p> }");
+        let deps_fn = output
+            .child_template_functions
+            .iter()
+            .find(|f| f.contains("DepsFn"))
+            .expect("dep fn should be emitted");
+        assert!(
+            deps_fn.contains("return [];"),
+            "dep fn with no custom tags should return []: {deps_fn}"
         );
     }
 

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -8,7 +8,7 @@ node = _{ control_flow | let_block | html_comment | element | interpolation | te
 html_comment = { "<!--" ~ (!"-->" ~ ANY)* ~ "-->" }
 
 // Text: anything not starting a tag, interpolation, or control flow keyword
-text = @{ (!("<" | "{{" | "}" | "@if" | "@for" | "@switch" | "@else" | "@case" | "@default" | "@empty" | "@let") ~ ANY)+ }
+text = @{ (!("<" | "{{" | "}" | "@if" | "@for" | "@switch" | "@else" | "@case" | "@default" | "@empty" | "@let" | "@defer" | "@placeholder" | "@loading" | "@error") ~ ANY)+ }
 
 // Text interpolation: {{ expression | pipe }}
 // Handles || (logical OR), balanced parens, and | only as top-level pipe separator
@@ -66,7 +66,7 @@ let_block = { "@let" ~ identifier ~ "=" ~ let_expression ~ ";" }
 let_expression = @{ (!";" ~ ANY)+ }
 
 // Control flow blocks
-control_flow = _{ if_block | for_block | switch_block }
+control_flow = _{ if_block | for_block | switch_block | defer_block }
 
 // @if / @else if / @else
 if_block = { "@if" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" ~ else_if_block* ~ else_block? }
@@ -95,5 +95,31 @@ switch_block = { "@switch" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ switch_body* ~ 
 switch_body = _{ case_block | default_block }
 case_block = { "@case" ~ "(" ~ ctrl_expression ~ ")" ~ "{" ~ node* ~ "}" }
 default_block = { "@default" ~ "{" ~ node* ~ "}" }
+
+// @defer with triggers and @placeholder / @loading / @error sub-blocks
+defer_block = { "@defer" ~ defer_triggers? ~ "{" ~ node* ~ "}" ~ defer_sub_block* }
+defer_triggers = { "(" ~ defer_trigger ~ (";" ~ defer_trigger)* ~ ";"? ~ ")" }
+defer_trigger = { defer_prefetch? ~ (defer_on | defer_when) }
+defer_prefetch = { "prefetch" }
+defer_on = { "on" ~ defer_on_kind }
+defer_on_kind = _{ timer_trigger | on_viewport | on_idle | on_immediate | on_hover | on_interaction }
+on_viewport = { "viewport" }
+on_idle = { "idle" }
+on_immediate = { "immediate" }
+on_hover = { "hover" }
+on_interaction = { "interaction" }
+timer_trigger = { "timer" ~ "(" ~ timer_duration ~ ")" }
+timer_duration = @{ (ASCII_ALPHANUMERIC | "." | "_")+ }
+defer_when = { "when" ~ defer_when_expr }
+defer_when_expr = { when_token+ }
+when_token = _{ when_paren_group | when_char }
+when_paren_group = { "(" ~ (when_paren_group | when_char)* ~ ")" }
+when_char = @{ (!("(" | ")" | ";") ~ ANY)+ }
+
+defer_sub_block = _{ placeholder_block | loading_block | error_block }
+placeholder_block = { "@placeholder" ~ defer_args? ~ "{" ~ node* ~ "}" }
+loading_block = { "@loading" ~ defer_args? ~ "{" ~ node* ~ "}" }
+error_block = { "@error" ~ "{" ~ node* ~ "}" }
+defer_args = { "(" ~ (!")" ~ ANY)* ~ ")" }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/crates/template-compiler/src/grammar/angular.pest
+++ b/crates/template-compiler/src/grammar/angular.pest
@@ -103,11 +103,14 @@ defer_trigger = { defer_prefetch? ~ (defer_on | defer_when) }
 defer_prefetch = { "prefetch" }
 defer_on = { "on" ~ defer_on_kind }
 defer_on_kind = _{ timer_trigger | on_viewport | on_idle | on_immediate | on_hover | on_interaction }
-on_viewport = { "viewport" }
+// `viewport` / `hover` / `interaction` accept an optional template-reference
+// argument, e.g. `on hover(triggerRef)`. `idle` / `immediate` take none.
+on_viewport = { "viewport" ~ trigger_ref? }
 on_idle = { "idle" }
 on_immediate = { "immediate" }
-on_hover = { "hover" }
-on_interaction = { "interaction" }
+on_hover = { "hover" ~ trigger_ref? }
+on_interaction = { "interaction" ~ trigger_ref? }
+trigger_ref = { "(" ~ identifier ~ ")" }
 timer_trigger = { "timer" ~ "(" ~ timer_duration ~ ")" }
 timer_duration = @{ (ASCII_ALPHANUMERIC | "." | "_")+ }
 defer_when = { "when" ~ defer_when_expr }

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -571,11 +571,17 @@ fn parse_defer_trigger(
             Rule::defer_on => {
                 for on_child in sub.into_inner() {
                     trigger = match on_child.as_rule() {
-                        Rule::on_viewport => Some(crate::ast::DeferTrigger::Viewport),
+                        Rule::on_viewport => Some(crate::ast::DeferTrigger::Viewport(
+                            extract_trigger_ref(on_child),
+                        )),
                         Rule::on_idle => Some(crate::ast::DeferTrigger::Idle),
                         Rule::on_immediate => Some(crate::ast::DeferTrigger::Immediate),
-                        Rule::on_hover => Some(crate::ast::DeferTrigger::Hover),
-                        Rule::on_interaction => Some(crate::ast::DeferTrigger::Interaction),
+                        Rule::on_hover => Some(crate::ast::DeferTrigger::Hover(
+                            extract_trigger_ref(on_child),
+                        )),
+                        Rule::on_interaction => Some(crate::ast::DeferTrigger::Interaction(
+                            extract_trigger_ref(on_child),
+                        )),
                         Rule::timer_trigger => {
                             let duration = on_child
                                 .into_inner()
@@ -603,6 +609,16 @@ fn parse_defer_trigger(
         }
     }
     (is_prefetch, trigger)
+}
+
+/// Extract the optional `(triggerRef)` identifier from a viewport / hover /
+/// interaction on-trigger pair. Returns `None` when the trigger is used in
+/// keyword-only form.
+fn extract_trigger_ref(pair: pest::iterators::Pair<Rule>) -> Option<String> {
+    pair.into_inner()
+        .find(|p| p.as_rule() == Rule::trigger_ref)
+        .and_then(|tr| tr.into_inner().next())
+        .map(|id| id.as_str().to_string())
 }
 
 /// Parse the children of a `@placeholder`/`@loading`/`@error` sub-block,
@@ -907,10 +923,10 @@ mod tests {
         match &nodes[0] {
             TemplateNode::DeferBlock(b) => {
                 assert_eq!(b.triggers.len(), 6);
-                assert!(matches!(b.triggers[0], DeferTrigger::Viewport));
+                assert!(matches!(b.triggers[0], DeferTrigger::Viewport(None)));
                 assert!(matches!(b.triggers[1], DeferTrigger::Idle));
-                assert!(matches!(b.triggers[2], DeferTrigger::Hover));
-                assert!(matches!(b.triggers[3], DeferTrigger::Interaction));
+                assert!(matches!(b.triggers[2], DeferTrigger::Hover(None)));
+                assert!(matches!(b.triggers[3], DeferTrigger::Interaction(None)));
                 assert!(matches!(b.triggers[4], DeferTrigger::Immediate));
                 match &b.triggers[5] {
                     DeferTrigger::Timer(d) => assert_eq!(d, "500ms"),
@@ -944,8 +960,35 @@ mod tests {
                 assert_eq!(b.prefetch_triggers.len(), 1);
                 assert!(matches!(b.prefetch_triggers[0], DeferTrigger::Idle));
                 assert_eq!(b.triggers.len(), 1);
-                assert!(matches!(b.triggers[0], DeferTrigger::Viewport));
+                assert!(matches!(b.triggers[0], DeferTrigger::Viewport(None)));
             }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_on_hover_with_trigger_ref() {
+        let nodes = parse("@defer (on hover(triggerEl)) { <d-c /> }");
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                assert_eq!(b.triggers.len(), 1);
+                match &b.triggers[0] {
+                    DeferTrigger::Hover(Some(r)) => assert_eq!(r, "triggerEl"),
+                    other => panic!("expected Hover(Some(...)), got {other:?}"),
+                }
+            }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_on_viewport_with_trigger_ref() {
+        let nodes = parse("@defer (on viewport(el)) { <d-c /> }");
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => match &b.triggers[0] {
+                DeferTrigger::Viewport(Some(r)) => assert_eq!(r, "el"),
+                other => panic!("expected Viewport(Some(...)), got {other:?}"),
+            },
             _ => panic!("expected defer block"),
         }
     }

--- a/crates/template-compiler/src/parser.rs
+++ b/crates/template-compiler/src/parser.rs
@@ -55,6 +55,7 @@ fn parse_node(pair: pest::iterators::Pair<Rule>) -> NgcResult<Option<TemplateNod
         Rule::for_block => Ok(Some(parse_for_block(pair)?)),
         Rule::switch_block => Ok(Some(parse_switch_block(pair)?)),
         Rule::let_block => Ok(Some(parse_let_block(pair)?)),
+        Rule::defer_block => Ok(Some(parse_defer_block(pair)?)),
         Rule::node => {
             let inner = pair.into_inner().next();
             match inner {
@@ -505,6 +506,120 @@ fn parse_let_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode>
     ))
 }
 
+/// Parse an `@defer { ... } @placeholder { ... } @loading { ... } @error { ... }`.
+fn parse_defer_block(pair: pest::iterators::Pair<Rule>) -> NgcResult<TemplateNode> {
+    let mut triggers: Vec<crate::ast::DeferTrigger> = Vec::new();
+    let mut prefetch_triggers: Vec<crate::ast::DeferTrigger> = Vec::new();
+    let mut children = Vec::new();
+    let mut placeholder = None;
+    let mut loading = None;
+    let mut error = None;
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::defer_triggers => {
+                for trig_pair in inner.into_inner() {
+                    if trig_pair.as_rule() != Rule::defer_trigger {
+                        continue;
+                    }
+                    let (is_prefetch, trig) = parse_defer_trigger(trig_pair);
+                    if let Some(t) = trig {
+                        if is_prefetch {
+                            prefetch_triggers.push(t);
+                        } else {
+                            triggers.push(t);
+                        }
+                    }
+                }
+            }
+            Rule::placeholder_block => {
+                placeholder = Some(parse_defer_sub_children(inner)?);
+            }
+            Rule::loading_block => {
+                loading = Some(parse_defer_sub_children(inner)?);
+            }
+            Rule::error_block => {
+                error = Some(parse_defer_sub_children(inner)?);
+            }
+            _ => {
+                if let Some(node) = parse_node(inner)? {
+                    children.push(node);
+                }
+            }
+        }
+    }
+
+    Ok(TemplateNode::DeferBlock(crate::ast::DeferBlockNode {
+        triggers,
+        prefetch_triggers,
+        children,
+        placeholder,
+        loading,
+        error,
+    }))
+}
+
+/// Parse a single `defer_trigger` pair. Returns `(is_prefetch, trigger)`.
+fn parse_defer_trigger(
+    pair: pest::iterators::Pair<Rule>,
+) -> (bool, Option<crate::ast::DeferTrigger>) {
+    let mut is_prefetch = false;
+    let mut trigger: Option<crate::ast::DeferTrigger> = None;
+    for sub in pair.into_inner() {
+        match sub.as_rule() {
+            Rule::defer_prefetch => is_prefetch = true,
+            Rule::defer_on => {
+                for on_child in sub.into_inner() {
+                    trigger = match on_child.as_rule() {
+                        Rule::on_viewport => Some(crate::ast::DeferTrigger::Viewport),
+                        Rule::on_idle => Some(crate::ast::DeferTrigger::Idle),
+                        Rule::on_immediate => Some(crate::ast::DeferTrigger::Immediate),
+                        Rule::on_hover => Some(crate::ast::DeferTrigger::Hover),
+                        Rule::on_interaction => Some(crate::ast::DeferTrigger::Interaction),
+                        Rule::timer_trigger => {
+                            let duration = on_child
+                                .into_inner()
+                                .next()
+                                .map(|p| p.as_str().trim().to_string())
+                                .unwrap_or_default();
+                            Some(crate::ast::DeferTrigger::Timer(duration))
+                        }
+                        _ => trigger,
+                    };
+                    if trigger.is_some() {
+                        break;
+                    }
+                }
+            }
+            Rule::defer_when => {
+                let expr = sub
+                    .into_inner()
+                    .next()
+                    .map(|p| p.as_str().trim().to_string())
+                    .unwrap_or_default();
+                trigger = Some(crate::ast::DeferTrigger::When(expr));
+            }
+            _ => {}
+        }
+    }
+    (is_prefetch, trigger)
+}
+
+/// Parse the children of a `@placeholder`/`@loading`/`@error` sub-block,
+/// skipping any `defer_args` option list that precedes the body.
+fn parse_defer_sub_children(pair: pest::iterators::Pair<Rule>) -> NgcResult<Vec<TemplateNode>> {
+    let mut nodes = Vec::new();
+    for inner in pair.into_inner() {
+        if inner.as_rule() == Rule::defer_args {
+            continue;
+        }
+        if let Some(node) = parse_node(inner)? {
+            nodes.push(node);
+        }
+    }
+    Ok(nodes)
+}
+
 /// Extract the text content from an expression pair, handling nested rules.
 fn extract_expression_text(pair: pest::iterators::Pair<Rule>) -> String {
     // For ctrl_expression and track_expression, the text comes from
@@ -767,5 +882,100 @@ mod tests {
         assert_eq!(nodes.len(), 2);
         assert!(matches!(&nodes[0], TemplateNode::LetDeclaration(_)));
         assert!(matches!(&nodes[1], TemplateNode::IfBlock(_)));
+    }
+
+    #[test]
+    fn test_defer_block_without_triggers() {
+        let nodes = parse("@defer { <my-comp /> }");
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                assert!(b.triggers.is_empty());
+                assert!(b.prefetch_triggers.is_empty());
+                assert_eq!(b.children.len(), 1);
+                assert!(b.placeholder.is_none());
+            }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_block_all_on_triggers() {
+        let nodes = parse(
+            "@defer (on viewport; on idle; on hover; on interaction; on immediate; on timer(500ms)) { <d-c /> }",
+        );
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                assert_eq!(b.triggers.len(), 6);
+                assert!(matches!(b.triggers[0], DeferTrigger::Viewport));
+                assert!(matches!(b.triggers[1], DeferTrigger::Idle));
+                assert!(matches!(b.triggers[2], DeferTrigger::Hover));
+                assert!(matches!(b.triggers[3], DeferTrigger::Interaction));
+                assert!(matches!(b.triggers[4], DeferTrigger::Immediate));
+                match &b.triggers[5] {
+                    DeferTrigger::Timer(d) => assert_eq!(d, "500ms"),
+                    _ => panic!("expected timer trigger"),
+                }
+            }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_block_when_trigger() {
+        let nodes = parse("@defer (when isVisible()) { <d-c /> }");
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                assert_eq!(b.triggers.len(), 1);
+                match &b.triggers[0] {
+                    DeferTrigger::When(expr) => assert_eq!(expr, "isVisible()"),
+                    _ => panic!("expected when trigger"),
+                }
+            }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_block_prefetch_trigger() {
+        let nodes = parse("@defer (prefetch on idle; on viewport) { <d-c /> }");
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                assert_eq!(b.prefetch_triggers.len(), 1);
+                assert!(matches!(b.prefetch_triggers[0], DeferTrigger::Idle));
+                assert_eq!(b.triggers.len(), 1);
+                assert!(matches!(b.triggers[0], DeferTrigger::Viewport));
+            }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_block_all_sub_blocks() {
+        let nodes = parse(
+            "@defer (on idle) { <d-c /> } @placeholder { <p>wait</p> } @loading { <p>loading</p> } @error { <p>err</p> }",
+        );
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                assert_eq!(b.triggers.len(), 1);
+                assert!(b.placeholder.is_some());
+                assert!(b.loading.is_some());
+                assert!(b.error.is_some());
+            }
+            _ => panic!("expected defer block"),
+        }
+    }
+
+    #[test]
+    fn test_defer_placeholder_with_minimum_option() {
+        let nodes =
+            parse("@defer (on idle) { <d-c /> } @placeholder (minimum 500ms) { <p>wait</p> }");
+        match &nodes[0] {
+            TemplateNode::DeferBlock(b) => {
+                let ph = b.placeholder.as_ref().expect("placeholder");
+                assert_eq!(ph.len(), 1);
+            }
+            _ => panic!("expected defer block"),
+        }
     }
 }


### PR DESCRIPTION
Closes #56.

## Summary
- Adds grammar + AST + parser + codegen for `@defer` blocks and their `@placeholder` / `@loading` / `@error` sub-blocks, handling every trigger form (`on viewport | idle | hover | interaction | immediate | timer(<dur>)`, `when <expr>`, and the `prefetch` prefix on any of them). `viewport` / `hover` / `interaction` also accept an optional template-reference arg (e.g. `on hover(triggerRef)`).
- Codegen emits `ɵɵdefer(index, dependencyFn, loadingTmpl?, placeholderTmpl?, errorTmpl?)` plus the matching `ɵɵdeferOn*` / `ɵɵdeferWhen` / `ɵɵdeferPrefetchOn*` trigger instructions. `when` lands in the update block (with an `ɵɵadvance`), `on`-family triggers land in the creation block. Each sub-block becomes its own child template function; a module-scope dep resolver fn is emitted with dynamic `import()` calls for every custom element tag used inside the block.
- Fixes a gap in the bundler rewriter: `import()` specifiers inside top-level `function foo() { ... }` declarations are now walked and rewritten to the owning chunk filename, matching the `@defer` dep-fn emission shape. Without this fix, chunks would split correctly but the main bundle kept the un-rewritten specifier.

## Test plan
- [x] `cargo test --workspace` — parser (8 new), codegen (9 new), bundler unit (1 new), bundler integration (1 new fixture project that asserts the deferred component lands in its own chunk while placeholder/loading/error stay in main and the `import()` specifier is rewritten to the chunk filename).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --check`.