### PR TITLE
fix(template-compiler): scope multi-element `styles` arrays per literal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.28"
+version = "0.7.29"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -24,7 +24,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
-use ngc_diagnostics::{NgcError, NgcResult};
+use ngc_diagnostics::NgcResult;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     ArrayExpression, ArrayExpressionElement, CallExpression, Declaration,
@@ -119,11 +119,23 @@ fn flatten_one(
 ) -> NgcResult<Option<String>> {
     let alloc = Allocator::default();
     let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
-    if !parsed.errors.is_empty() {
-        return Err(NgcError::LinkerError {
-            path: path.to_path_buf(),
-            message: format!("parse error: {}", parsed.errors[0]),
-        });
+    if parsed.panicked || !parsed.errors.is_empty() {
+        // Dependency flattening is a best-effort post-pass. If the source is
+        // unparseable (e.g. a file that already took the transform-fallback
+        // path in the CLI after an upstream bug), surface a diagnostic and
+        // leave the source untouched rather than aborting the whole build.
+        // The earlier warning from the transform step already tells the user
+        // what broke.
+        let msg = if parsed.panicked {
+            "parser panicked".to_string()
+        } else {
+            format!("{}", parsed.errors[0])
+        };
+        tracing::warn!(
+            path = %path.display(),
+            "skipping dependency flatten: {msg}"
+        );
+        return Ok(None);
     }
 
     let mut imports = collect_named_imports(&parsed.program);
@@ -1157,5 +1169,32 @@ D.\u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: D, dependencies: [Dialog
             .expect("portal import injected");
         assert!(portal_line.contains("CdkPortal"));
         assert!(portal_line.contains("CdkPortalOutlet"));
+    }
+
+    #[test]
+    fn test_flatten_one_skips_unparseable_source() {
+        // Regression guard for GH #81. When the CLI's transform-fallback
+        // path forwards a file that oxc could not parse, this pass must not
+        // surface a second `parse error: Expected \`,\` or \`)\` but found \`:\``
+        // — it should log a warning and leave the source untouched.
+        let broken = r#"export class Broken {
+  static \u{0275}cmp = \u{0275}\u{0275}defineComponent({
+    styles: [`.a[_ngcontent-%COMP%]{ color: red; }`[_ngcontent-%COMP%], `.b`]
+  });
+}"#;
+        let registry = ModuleRegistry::new();
+        registry.register("AnyModule", vec!["X".into()]);
+        let public_exports = PublicExports::new();
+        let result = flatten_one(
+            broken,
+            Path::new("/project/src/broken.component.ts"),
+            &registry,
+            &public_exports,
+        );
+        let none = result.expect("unparseable source must not error");
+        assert!(
+            none.is_none(),
+            "unparseable source should be skipped, not rewritten"
+        );
     }
 }

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -3003,24 +3003,69 @@ fn build_conditional_expr(
 /// - `:host { ... }` → `[_nghost-%COMP%] { ... }`
 /// - `:host-context(X) .class { ... }` → `X[_nghost-%COMP%] .class[_ngcontent-%COMP%], X [_nghost-%COMP%] .class[_ngcontent-%COMP%] { ... }`
 fn scope_component_styles(styles_src: &str) -> String {
-    // The styles_src is a JavaScript array like [`...css...`]
-    // We need to transform the CSS content inside the backticks.
-    // Extract the CSS content between the first ` and last `
-    let css_start = styles_src.find('`').unwrap_or(0) + 1;
-    let css_end = styles_src.rfind('`').unwrap_or(styles_src.len());
-    if css_start >= css_end {
-        return styles_src.to_string();
+    // `styles_src` is a JavaScript array expression of string / template
+    // literals — `[\`css\`]`, `['css']`, or multi-element forms like
+    // `[\`a\`, \`b\`]`. Walk the source and scope each literal's *content*
+    // independently, preserving everything outside the literals (brackets,
+    // commas, whitespace) verbatim. The prior implementation used
+    // `find('`')..rfind('`')` and treated every character in between as CSS,
+    // which swept intermediate `\`,\`` boundaries into the selector walker
+    // and emitted the trailing `[_ngcontent-%COMP%]` outside the template
+    // literal — producing invalid TypeScript that panics oxc (GH #81).
+    let mut result = String::with_capacity(styles_src.len());
+    let mut iter = styles_src.char_indices().peekable();
+    while let Some((i, ch)) = iter.next() {
+        if matches!(ch, '`' | '"' | '\'') {
+            let delim = ch;
+            let content_start = i + ch.len_utf8();
+            let mut content_end: Option<usize> = None;
+            while let Some((j, c)) = iter.next() {
+                if c == '\\' {
+                    // Preserve the escape — skip whatever follows the backslash.
+                    let _ = iter.next();
+                    continue;
+                }
+                if c == delim {
+                    content_end = Some(j);
+                    break;
+                }
+            }
+            match content_end {
+                Some(end) => {
+                    let content = &styles_src[content_start..end];
+                    result.push(delim);
+                    // Skip scoping if a template literal has an interpolation
+                    // — `${...}` spans JS, not CSS, and a naive brace walk
+                    // would mangle it.
+                    if delim == '`' && content.contains("${") {
+                        result.push_str(content);
+                    } else {
+                        result.push_str(&scope_single_css(content));
+                    }
+                    result.push(delim);
+                }
+                None => {
+                    // Unterminated literal (malformed input). Bail out —
+                    // emit the remainder verbatim so we do no further harm.
+                    result.push_str(&styles_src[i..]);
+                    return result;
+                }
+            }
+        } else {
+            result.push(ch);
+        }
     }
+    result
+}
 
-    let css = &styles_src[css_start..css_end];
+/// Scope a single CSS string with `%COMP%` placeholders. Extracted from
+/// [`scope_component_styles`] so we can apply the transform per array
+/// element instead of across the entire array source.
+fn scope_single_css(css: &str) -> String {
     let content_attr = "[_ngcontent-%COMP%]";
     let host_attr = "[_nghost-%COMP%]";
 
     let mut result = String::new();
-
-    // Simple CSS rule parser: split on { and }
-    // Simple string-based matching instead of regex
-
     let mut selector = String::new();
     let mut in_block = false;
     let mut brace_depth = 0;
@@ -3038,7 +3083,6 @@ fn scope_component_styles(styles_src: &str) -> String {
                 }
             }
         } else if ch == '{' {
-            // Process the selector
             let sel = selector.trim().to_string();
             if sel.is_empty() {
                 result.push('{');
@@ -3048,14 +3092,11 @@ fn scope_component_styles(styles_src: &str) -> String {
                 continue;
             }
 
-            // Transform selector
             if sel.contains(":host-context(") {
-                // :host-context(X) .rest → X[_nghost-%COMP%] .rest[_ngcontent-%COMP%], X [_nghost-%COMP%] .rest[_ngcontent-%COMP%]
                 let after_hc = sel
                     .find(":host-context(")
                     .map(|i| &sel[i + ":host-context(".len()..])
                     .unwrap_or("");
-                // Find matching )
                 let close = after_hc.find(')').unwrap_or(after_hc.len());
                 let context = after_hc[..close].trim();
                 let rest = after_hc[close + 1..].trim();
@@ -3078,7 +3119,6 @@ fn scope_component_styles(styles_src: &str) -> String {
                     result.push_str(&format!("{host_attr} {rest}"));
                 }
             } else {
-                // Regular selector — append content attr to each part
                 let parts: Vec<&str> = sel.split(',').collect();
                 let scoped: Vec<String> = parts
                     .iter()
@@ -3096,10 +3136,13 @@ fn scope_component_styles(styles_src: &str) -> String {
         }
     }
 
-    // Reconstruct the styles array with scoped CSS
-    let prefix = &styles_src[..css_start];
-    let suffix = &styles_src[css_end..];
-    format!("{prefix}{result}{suffix}")
+    // Preserve any trailing whitespace / comments that never made it into a
+    // block so round-tripping of a pure-whitespace CSS string is a no-op.
+    if !selector.is_empty() && selector.trim().is_empty() {
+        result.push_str(&selector);
+    }
+
+    result
 }
 
 /// Append `[_ngcontent-%COMP%]` to the last element in a simple CSS selector.
@@ -4390,5 +4433,46 @@ mod tests {
             dc.contains("=0 {none}") && dc.contains("other {many}"),
             "ICU case bodies should be preserved: {dc}"
         );
+    }
+
+    #[test]
+    fn test_scope_component_styles_single_element_array() {
+        let scoped = scope_component_styles("[`.a { color: red; }`]");
+        assert_eq!(scoped, "[`.a[_ngcontent-%COMP%]{ color: red; }`]");
+    }
+
+    #[test]
+    fn test_scope_component_styles_multi_element_array_preserves_boundaries() {
+        // Regression guard for GH #81. With two template literals in the
+        // array, the old `find('`')..rfind('`')` logic treated the whole
+        // middle as CSS and emitted `[_ngcontent-%COMP%]` OUTSIDE a template
+        // literal, producing invalid TypeScript. Each literal must be
+        // scoped independently.
+        let scoped = scope_component_styles("[`.a { color: red; }`, `.b { color: blue; }`]");
+        assert_eq!(
+            scoped,
+            "[`.a[_ngcontent-%COMP%]{ color: red; }`, `.b[_ngcontent-%COMP%]{ color: blue; }`]"
+        );
+    }
+
+    #[test]
+    fn test_scope_component_styles_skips_interpolation() {
+        // Template literal with `${expr}` spans JS, not CSS; the scoper
+        // must leave it alone.
+        let src = r#"[`.a { width: ${n}px; }`]"#;
+        let scoped = scope_component_styles(src);
+        assert_eq!(scoped, src);
+    }
+
+    #[test]
+    fn test_scope_component_styles_handles_string_literals() {
+        let scoped = scope_component_styles("['.a { color: red; }']");
+        assert_eq!(scoped, "['.a[_ngcontent-%COMP%]{ color: red; }']");
+    }
+
+    #[test]
+    fn test_scope_component_styles_host_selector() {
+        let scoped = scope_component_styles("[`:host { display: block; }`]");
+        assert_eq!(scoped, "[`[_nghost-%COMP%]{ display: block; }`]");
     }
 }

--- a/crates/template-compiler/tests/preprocessor_integration.rs
+++ b/crates/template-compiler/tests/preprocessor_integration.rs
@@ -405,3 +405,46 @@ fn compile_all_decorators_processes_scss_component_in_parallel_path() {
         cf.source
     );
 }
+
+// ---------------------------------------------------------------------------
+// GH #81: inline SCSS `styles: [\`...\`]` alongside a `styleUrl` must emit a
+// valid multi-element array that survives ts-transform without fallback.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inline_scss_alongside_style_url_emits_valid_multi_element_array() {
+    let Some((_guard, project_root)) = make_project_with_node_modules() else {
+        return;
+    };
+    let component_path = project_root.join("scss_styles.component.ts");
+    std::fs::write(
+        project_root.join("scss_styles.component.scss"),
+        "$c: #112233;\n.external { color: $c; }\n",
+    )
+    .unwrap();
+    let body = "styleUrl: './scss_styles.component.scss',\n\
+            styles: [`\n\
+                @use 'sass:color';\n\
+                $inline-color: #2e7d32;\n\
+                .scss-inline { background: color.adjust($inline-color, $lightness: 60%); }\n\
+            `]";
+    std::fs::write(&component_path, component_source("", body)).unwrap();
+
+    let ctx = StyleContext {
+        project_root: project_root.clone(),
+        inline_style_language: StyleLanguage::Scss,
+    };
+    let result = compile_component_with_styles(
+        &std::fs::read_to_string(&component_path).unwrap(),
+        &component_path,
+        &ctx,
+    )
+    .expect("compile inline SCSS + styleUrl");
+    assert!(result.compiled);
+    let out = &result.source;
+
+    // Round-trip through ts-transform: the compiled source must be valid
+    // TypeScript, so oxc parses it cleanly and no fallback is taken.
+    ngc_ts_transform::transform_source(out, "scss_styles.component.ts")
+        .expect("ts-transform must accept the compiled source");
+}

--- a/crates/ts-transform/src/transform.rs
+++ b/crates/ts-transform/src/transform.rs
@@ -446,4 +446,41 @@ export class AppComponent {
     fn test_map_extension_js_passthrough() {
         assert_eq!(map_extension(Path::new("foo.js")), PathBuf::from("foo.js"));
     }
+
+    #[test]
+    fn test_inline_scss_styles_template_literal_passes_through() {
+        // Regression guard for GH #81. A component file whose `styles` array
+        // contains a backtick template literal with SCSS `@use 'sass:color';`
+        // pragmas and keyword-argument function calls (`$lightness: 60%`)
+        // must parse cleanly as TypeScript — the SCSS text is opaque string
+        // content, not JS syntax. Transform must not panic and must not
+        // surface a parse error back to the caller.
+        let source = "import { Component } from '@angular/core';\n\
+\n\
+@Component({\n\
+  selector: 'app-scss-styles',\n\
+  styleUrl: './scss-styles.component.scss',\n\
+  styles: [`\n\
+    @use 'sass:color';\n\
+\n\
+    $inline-color: #2e7d32;\n\
+\n\
+    .scss-inline {\n\
+      background: color.adjust($inline-color, $lightness: 60%);\n\
+    }\n\
+  `],\n\
+  template: `<p>hi</p>`,\n\
+})\n\
+export class ScssStylesComponent {}\n";
+        let result = transform_source(source, "scss-styles.component.ts")
+            .expect("inline SCSS styles should survive TS transform");
+        assert!(
+            result.contains("class ScssStylesComponent"),
+            "class should be preserved: {result}"
+        );
+        assert!(
+            !result.contains("@Component("),
+            "decorator should be stripped: {result}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #81.

## Summary
- Rewrite `scope_component_styles` to iterate over each string/template literal in the `styles: [...]` array and scope each element's CSS content independently. Previously it used `find('`')..rfind('`')` and swept the intermediate `` `, ` `` boundary into the CSS selector walker, which emitted `[_ngcontent-%COMP%]` OUTSIDE the template literal and produced invalid TypeScript that panicked oxc.
- Skip template literals that contain `${…}` interpolation — those span JS, not CSS.
- Make the linker's `flatten_one` a best-effort pass: log a warning and leave the source untouched when parsing fails, instead of bubbling a second `parse error` after the transform pass has already warned.

## Tests
- `ts-transform`: raw user source with `@use 'sass:color'` and `color.adjust(..., $lightness: 60%)` inside a backtick `styles` template literal parses without panic and does not hit the transform-fallback path.
- `template-compiler` unit tests: multi-element arrays, string-literal elements, `${…}` interpolation skip, and `:host` selector all scope correctly.
- `template-compiler` integration test (requires `sass` npm package): compile a component with both `styleUrl` and inline SCSS `styles: [...]`, then round-trip through `ts-transform` — the compiled output must parse cleanly.
- `linker`: unparseable project source is skipped with a warning (returns `Ok(None)`), does not surface `Expected ',' or ')' but found ':'`.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Full Docker build of `test/test-ng-project` (deferred — `/test/` directory is gitignored / not present in this worktree; the integration test in `preprocessor_integration.rs` composes the same pipeline ngc-cli uses).