### PR TITLE
feat(npm-resolver): `package.json` `imports` field (subpath imports `#foo`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.29"
+version = "0.7.30"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.29"
+version = "0.7.30"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -758,6 +758,41 @@ fn classify_lazy_externals(
 
     let mut out: Vec<ExternalImport> = Vec::with_capacity(externals.len());
     for ext in externals {
+        // Subpath imports (`#foo`) point at a file under the importing
+        // package's `imports` map — typically a project file, occasionally
+        // a bare specifier. Resolve to the actual target so chunk-membership
+        // is checked against the real path, not the alias string. Without
+        // this, every `#`-aliased project file would be misclassified as an
+        // npm cross-chunk import (since the alias is in `bundled_specifiers`)
+        // and emit a stale `import { X } from './main.js'` even when X is
+        // already declared in the lazy chunk itself.
+        if ext.source.starts_with('#') {
+            let resolved = ngc_npm_resolver::resolve::resolve_subpath_import(
+                &ext.source,
+                Some(module_path),
+                p.root_dir,
+                p.export_conditions,
+            )
+            .ok()
+            .and_then(|target| cached_canonicalize(p.canon_cache, &target));
+            match resolved {
+                Some(ref resolved_path) => {
+                    if p.chunk_module_set.contains(resolved_path) {
+                        continue; // same chunk — discard
+                    }
+                    if p.main_chunk_module_set.contains(resolved_path) {
+                        out.push(ext); // verified in main
+                    }
+                    // else: another lazy/shared chunk — discard
+                    continue;
+                }
+                None => {
+                    // Couldn't resolve — fall through to the bundled-specifier
+                    // path so we still emit a cross-chunk import rather than
+                    // dropping the reference.
+                }
+            }
+        }
         if p.bundled_specifiers.contains(&ext.source) {
             // npm bare specifier → cross-chunk from main
             out.push(ext);

--- a/crates/bundler/tests/subpath_imports_integration.rs
+++ b/crates/bundler/tests/subpath_imports_integration.rs
@@ -1,0 +1,154 @@
+//! End-to-end integration for `package.json` `imports` subpath aliases
+//! (`#`-prefixed specifiers).
+//!
+//! A project file imports `#internal/helper`. The project's `package.json`
+//! declares an `imports` map that rewrites the alias to a file under
+//! `src/internal/`. After the full `resolve_project` → `resolve_npm_dependencies`
+//! → `bundle` pipeline runs, the helper's code must be inlined into the main
+//! chunk — proving both that the alias resolves and that the bundler treats
+//! `#internal/helper` as a local (bundled) import.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use ngc_bundler::{bundle, BundleInput, BundleOptions};
+use ngc_npm_resolver::package_json::DEVELOPMENT_BROWSER_CONDITIONS;
+use ngc_npm_resolver::resolve_npm_dependencies;
+use ngc_project_resolver::resolve_project;
+use tempfile::tempdir;
+
+#[test]
+fn subpath_import_helper_is_inlined_into_main_chunk() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.ts"], "exclude": [] }"#,
+    )
+    .expect("write tsconfig");
+
+    fs::write(
+        root.join("package.json"),
+        r##"{
+          "name": "subpath-fixture",
+          "imports": {
+            "#internal/*": "./src/internal/*.js"
+          }
+        }"##,
+    )
+    .expect("write package.json");
+
+    let src = root.join("src");
+    fs::create_dir_all(src.join("internal")).expect("create src/internal");
+
+    fs::write(
+        src.join("main.ts"),
+        "import { helper } from '#internal/helper';\nconsole.log(helper());\n",
+    )
+    .expect("write main.ts");
+
+    // Target of the `#internal/*` alias. The file is authored as `.js` to
+    // match the mapping in package.json — the bundler picks it up as a
+    // project file via the npm-resolver path, not the ts-transform path.
+    fs::write(
+        src.join("internal/helper.js"),
+        "export const helper = () => 42;\n",
+    )
+    .expect("write helper.js");
+
+    // Empty node_modules so the crawler doesn't early-return.
+    fs::create_dir_all(root.join("node_modules")).expect("create node_modules");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    // Collect specifiers the project emits (including `#internal/helper`).
+    let bare_specs: Vec<String> = file_graph.npm_import_sites.keys().cloned().collect();
+    assert!(
+        bare_specs.iter().any(|s| s == "#internal/helper"),
+        "project scan should surface the `#internal/helper` specifier, got {bare_specs:?}"
+    );
+
+    let npm = resolve_npm_dependencies(&bare_specs, root, DEVELOPMENT_BROWSER_CONDITIONS)
+        .expect("npm resolution");
+    assert!(
+        npm.resolved_specifiers.contains("#internal/helper"),
+        "#internal/helper should resolve, got {:?}",
+        npm.resolved_specifiers
+    );
+
+    // Merge project modules + npm-resolver-discovered helper into the graph.
+    let mut graph = file_graph.graph;
+    let mut path_index = file_graph.path_index;
+    for path in npm.modules.keys() {
+        if !path_index.contains_key(path) {
+            let idx = graph.add_node(path.clone());
+            path_index.insert(path.clone(), idx);
+        }
+    }
+
+    // Add the edge: main.ts → internal/helper.js, keyed off the alias.
+    let helper_path = npm
+        .modules
+        .keys()
+        .find(|p| p.ends_with("src/internal/helper.js"))
+        .cloned()
+        .expect("helper.js should be in the npm resolution");
+    for (spec, sites) in &file_graph.npm_import_sites {
+        if spec == "#internal/helper" {
+            let to_idx = path_index[&helper_path];
+            for (from_file, kind) in sites {
+                if let Some(&from_idx) = path_index.get(from_file) {
+                    graph.add_edge(from_idx, to_idx, *kind);
+                }
+            }
+        }
+    }
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in graph.node_indices() {
+        let path = &graph[idx];
+        let source = npm
+            .modules
+            .get(path)
+            .cloned()
+            .or_else(|| fs::read_to_string(path).ok())
+            .unwrap_or_else(|| panic!("source missing for {}", path.display()));
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions::default(),
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: npm.resolved_specifiers.clone(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+    assert!(
+        main_code.contains("helper"),
+        "main chunk should inline the helper target: {main_code}"
+    );
+    assert!(
+        !main_code.contains("'#internal/helper'") && !main_code.contains("\"#internal/helper\""),
+        "main chunk must not leave the `#internal/helper` specifier in output: {main_code}"
+    );
+}

--- a/crates/bundler/tests/subpath_imports_integration.rs
+++ b/crates/bundler/tests/subpath_imports_integration.rs
@@ -152,3 +152,152 @@ fn subpath_import_helper_is_inlined_into_main_chunk() {
         "main chunk must not leave the `#internal/helper` specifier in output: {main_code}"
     );
 }
+
+/// Regression for the case where a lazy chunk pulls in a `#`-aliased project
+/// file as a static dep. Before the fix in `classify_lazy_externals`, the
+/// alias matched `bundled_specifiers` and was emitted as a cross-chunk import
+/// (`import { X } from './main.js'`) — even though the target file was already
+/// declared inside the lazy chunk itself. The browser then failed at module
+/// link time with "Importing binding name 'X' is not found".
+///
+/// We assert that the lazy chunk does NOT pull the aliased symbol in from
+/// `./main.js`, and instead carries the declaration locally.
+#[test]
+fn subpath_import_in_lazy_chunk_does_not_leak_to_main_import() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.ts"], "exclude": [] }"#,
+    )
+    .expect("write tsconfig");
+
+    fs::write(
+        root.join("package.json"),
+        r##"{
+          "name": "subpath-lazy-fixture",
+          "imports": { "#env/*": "./src/env/*.js" }
+        }"##,
+    )
+    .expect("write package.json");
+
+    let src = root.join("src");
+    fs::create_dir_all(src.join("env")).expect("create src/env");
+
+    // Entry point dynamically imports the lazy module — this is what splits
+    // the bundle into a separate chunk.
+    fs::write(
+        src.join("main.ts"),
+        "const lazy = import('./lazy');\nconsole.log(lazy);\n",
+    )
+    .expect("write main.ts");
+
+    // Lazy module statically imports the `#env/config` alias. The alias
+    // target is a project file that, post-resolution, ends up in the same
+    // chunk as `lazy.ts` because it's a static dep.
+    fs::write(
+        src.join("lazy.ts"),
+        "import { APP_ENV } from '#env/config';\nexport const v = APP_ENV;\n",
+    )
+    .expect("write lazy.ts");
+
+    fs::write(
+        src.join("env/config.js"),
+        "export const APP_ENV = { name: 'env-fixture' };\n",
+    )
+    .expect("write config.js");
+
+    fs::create_dir_all(root.join("node_modules")).expect("create node_modules");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let bare_specs: Vec<String> = file_graph.npm_import_sites.keys().cloned().collect();
+    let npm = resolve_npm_dependencies(&bare_specs, root, DEVELOPMENT_BROWSER_CONDITIONS)
+        .expect("npm resolution");
+
+    let mut graph = file_graph.graph;
+    let mut path_index = file_graph.path_index;
+    for path in npm.modules.keys() {
+        if !path_index.contains_key(path) {
+            let idx = graph.add_node(path.clone());
+            path_index.insert(path.clone(), idx);
+        }
+    }
+
+    let config_path = npm
+        .modules
+        .keys()
+        .find(|p| p.ends_with("src/env/config.js"))
+        .cloned()
+        .expect("config.js should be in npm resolution");
+    for (spec, sites) in &file_graph.npm_import_sites {
+        if spec == "#env/config" {
+            let to_idx = path_index[&config_path];
+            for (from_file, kind) in sites {
+                if let Some(&from_idx) = path_index.get(from_file) {
+                    graph.add_edge(from_idx, to_idx, *kind);
+                }
+            }
+        }
+    }
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in graph.node_indices() {
+        let path = &graph[idx];
+        let source = npm
+            .modules
+            .get(path)
+            .cloned()
+            .or_else(|| fs::read_to_string(path).ok())
+            .unwrap_or_else(|| panic!("source missing for {}", path.display()));
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions::default(),
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: npm.resolved_specifiers.clone(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    // Find the lazy chunk (anything that's not main).
+    let (_lazy_name, lazy_code) = output
+        .chunks
+        .iter()
+        .find(|(k, _)| k.as_str() != output.main_filename)
+        .expect("lazy chunk for ./lazy should exist");
+
+    assert!(
+        lazy_code.contains("APP_ENV"),
+        "lazy chunk should carry the const declaration: {lazy_code}"
+    );
+    // The bug under repair: `APP_ENV` was added to the cross-chunk import
+    // group from `./main.js`. After the fix, the lazy chunk owns the symbol
+    // locally and must not re-import it.
+    assert!(
+        !lazy_code.contains("APP_ENV") || !lazy_code.contains("from './main.js'") || {
+            // If both substrings exist, ensure the main.js import line itself
+            // doesn't list APP_ENV — this is the precise failure mode.
+            !lazy_code
+                .lines()
+                .filter(|l| l.contains("from './main.js'"))
+                .any(|l| l.contains("APP_ENV"))
+        },
+        "lazy chunk must not pull APP_ENV from ./main.js: {lazy_code}"
+    );
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -423,17 +423,29 @@ fn run_build(
 
     // Add edges from project files to npm entry files
     for (specifier, import_sites) in &file_graph.npm_import_sites {
-        if let Some(entry_path) = npm_resolution
-            .resolved_specifiers
-            .contains(specifier)
-            .then(|| {
+        let resolve_entry = || -> Option<PathBuf> {
+            if specifier.starts_with('#') {
+                let from_file = import_sites.first().map(|(p, _)| p.as_path());
+                ngc_npm_resolver::resolve::resolve_subpath_import(
+                    specifier,
+                    from_file,
+                    &config_dir,
+                    export_conditions,
+                )
+                .ok()
+            } else {
                 ngc_npm_resolver::resolve::resolve_bare_specifier(
                     specifier,
                     &config_dir,
                     export_conditions,
                 )
                 .ok()
-            })
+            }
+        };
+        if let Some(entry_path) = npm_resolution
+            .resolved_specifiers
+            .contains(specifier)
+            .then(resolve_entry)
             .flatten()
         {
             if let Some(&to_idx) = path_index.get(&entry_path) {

--- a/crates/npm-resolver/src/lib.rs
+++ b/crates/npm-resolver/src/lib.rs
@@ -342,6 +342,90 @@ mod tests {
         assert!(result.modules.is_empty());
     }
 
+    /// A project file imports `#internal/helper`, which the root package.json
+    /// maps via a wildcard to a project-relative file. The crawler must pull
+    /// in both the importing file and the target.
+    #[test]
+    fn test_crawl_resolves_subpath_import() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Project root with an imports map and the target file.
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{ "imports": { "#internal/*": "./src/internal/*.js" } }"##,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src/internal")).unwrap();
+        fs::write(
+            dir.path().join("src/internal/helper.js"),
+            "export const helper = 42;\n",
+        )
+        .unwrap();
+
+        // A no-op node_modules so the crawler doesn't early-return.
+        fs::create_dir_all(dir.path().join("node_modules")).unwrap();
+
+        let result = resolve_npm_dependencies(&["#internal/helper".to_string()], dir.path(), DEV)
+            .expect("should resolve");
+
+        assert!(
+            result.resolved_specifiers.contains("#internal/helper"),
+            "specifier should be recorded"
+        );
+        assert!(
+            result
+                .modules
+                .keys()
+                .any(|p| p.ends_with("src/internal/helper.js")),
+            "helper.js should be crawled, got {:?}",
+            result.modules.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// A file inside an npm dep uses `#`-prefixed imports scoped to that dep's
+    /// own package.json, not the project's. Verifies the crawler follows
+    /// transitive subpath imports and picks the right ancestor.
+    #[test]
+    fn test_crawl_subpath_import_scoped_to_dep_package_json() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("node_modules")).unwrap();
+
+        let dep = dir.path().join("node_modules/dep-a");
+        fs::create_dir_all(dep.join("src/internal")).unwrap();
+        fs::create_dir_all(dep.join("dist")).unwrap();
+        fs::write(
+            dep.join("package.json"),
+            r##"{ "module": "./dist/index.mjs", "imports": { "#priv/*": "./src/internal/*.mjs" } }"##,
+        )
+        .unwrap();
+        fs::write(
+            dep.join("dist/index.mjs"),
+            "import { secret } from '#priv/secret';\nexport const v = secret;\n",
+        )
+        .unwrap();
+        fs::write(
+            dep.join("src/internal/secret.mjs"),
+            "export const secret = 99;\n",
+        )
+        .unwrap();
+
+        let result = resolve_npm_dependencies(&["dep-a".to_string()], dir.path(), DEV)
+            .expect("should resolve");
+
+        assert!(
+            result
+                .modules
+                .keys()
+                .any(|p| p.ends_with("src/internal/secret.mjs")),
+            "dep's `#priv/secret` target should be pulled in, got {:?}",
+            result.modules.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            result.resolved_specifiers.contains("#priv/secret"),
+            "transitive subpath specifier should be recorded"
+        );
+    }
+
     /// Integration test covering the end-to-end dev vs prod split: a package
     /// exposes different entry files for the `development` and `production`
     /// conditions, and each build mode pulls in its own transitive graph.

--- a/crates/npm-resolver/src/lib.rs
+++ b/crates/npm-resolver/src/lib.rs
@@ -80,8 +80,13 @@ pub fn resolve_npm_dependencies(
     // probes — fully independent per specifier.
     let initial_entries: Vec<(String, PathBuf)> = specifiers
         .par_iter()
-        .filter_map(
-            |spec| match resolve::resolve_bare_specifier(spec, project_root, conditions) {
+        .filter_map(|spec| {
+            let outcome = if spec.starts_with('#') {
+                resolve::resolve_subpath_import(spec, None, project_root, conditions)
+            } else {
+                resolve::resolve_bare_specifier(spec, project_root, conditions)
+            };
+            match outcome {
                 Ok(entry_path) => {
                     let canonical = canonicalize_cached(entry_path);
                     Some((spec.clone(), canonical))
@@ -90,8 +95,8 @@ pub fn resolve_npm_dependencies(
                     debug!(specifier = spec, error = %e, "skipping unresolvable npm package");
                     None
                 }
-            },
-        )
+            }
+        })
         .collect();
 
     let mut frontier: Vec<PathBuf> = Vec::new();
@@ -140,6 +145,23 @@ pub fn resolve_npm_dependencies(
                             resolve::resolve_relative_import(&import.specifier, file_path).ok(),
                             None,
                         )
+                    } else if import.specifier.starts_with('#') {
+                        match resolve::resolve_subpath_import(
+                            &import.specifier,
+                            Some(file_path),
+                            project_root,
+                            conditions,
+                        ) {
+                            Ok(p) => (Some(p), Some(import.specifier.clone())),
+                            Err(_) => {
+                                debug!(
+                                    specifier = import.specifier,
+                                    from = %file_path.display(),
+                                    "skipping unresolvable subpath import"
+                                );
+                                (None, None)
+                            }
+                        }
                     } else {
                         match resolve::resolve_bare_specifier(
                             &import.specifier,

--- a/crates/npm-resolver/src/package_json.rs
+++ b/crates/npm-resolver/src/package_json.rs
@@ -228,8 +228,53 @@ fn resolve_target(
     }
 }
 
+/// Resolve a `#`-prefixed subpath import against a package.json `imports` object.
+///
+/// Semantics mirror `exports` subpath resolution, minus the sugar forms:
+/// - Direct key match wins first (`"#alias": "./target.js"`).
+/// - Otherwise, pattern trailers (`"#foo/*"`) compete on longest-prefix.
+/// - Values can be strings, condition objects, arrays, or `null` (blocked).
+/// - Wildcard `*` in the target substitutes the matched suffix.
+///
+/// The returned string is the raw target — it may be a relative path
+/// (`"./src/x.js"`) or a bare specifier (`"lodash/cloneDeep"`). The caller
+/// decides how to resolve each form.
+pub fn match_imports_field(
+    imports: &serde_json::Value,
+    specifier: &str,
+    conditions: &[&str],
+) -> Option<String> {
+    let serde_json::Value::Object(map) = imports else {
+        return None;
+    };
+
+    if let Some(entry) = map.get(specifier) {
+        return resolve_target(entry, None, conditions);
+    }
+
+    let mut best: Option<(&str, &serde_json::Value)> = None;
+    for (pattern, value) in map {
+        let Some(prefix) = pattern.strip_suffix('*') else {
+            continue;
+        };
+        if !specifier.starts_with(prefix) {
+            continue;
+        }
+        match best {
+            Some((cur, _)) if cur.len() >= prefix.len() => {}
+            _ => best = Some((prefix, value)),
+        }
+    }
+    if let Some((prefix, value)) = best {
+        let rest = &specifier[prefix.len()..];
+        return resolve_target(value, Some(rest), conditions);
+    }
+
+    None
+}
+
 /// Try common ESM/JS extensions for a path.
-fn try_extensions(base: &Path) -> Option<PathBuf> {
+pub(crate) fn try_extensions(base: &Path) -> Option<PathBuf> {
     for ext in &["mjs", "js", "cjs"] {
         let candidate = base.with_extension(ext);
         if candidate.is_file() {
@@ -702,6 +747,67 @@ mod tests {
         let dev = resolve_package_entry(&pkg_dir, ".", DEV).unwrap();
         assert!(prod.ends_with("reactish.production.mjs"));
         assert!(dev.ends_with("reactish.development.mjs"));
+    }
+
+    // --- subpath imports (`#`-prefixed) ---
+
+    #[test]
+    fn test_imports_literal_match() {
+        let imports: serde_json::Value =
+            serde_json::from_str(r##"{ "#internal": "./src/internal/index.js" }"##).unwrap();
+        let target = match_imports_field(&imports, "#internal", DEV);
+        assert_eq!(target.as_deref(), Some("./src/internal/index.js"));
+    }
+
+    #[test]
+    fn test_imports_wildcard_substitution() {
+        let imports: serde_json::Value =
+            serde_json::from_str(r##"{ "#internal/*": "./src/internal/*.js" }"##).unwrap();
+        let target = match_imports_field(&imports, "#internal/helper", DEV);
+        assert_eq!(target.as_deref(), Some("./src/internal/helper.js"));
+    }
+
+    #[test]
+    fn test_imports_conditional_picks_import_branch() {
+        let imports: serde_json::Value = serde_json::from_str(
+            r##"{ "#dep": { "node": "./node-dep.js", "import": "./esm-dep.mjs", "default": "./dep.js" } }"##,
+        )
+        .unwrap();
+        let target = match_imports_field(&imports, "#dep", DEV);
+        assert_eq!(target.as_deref(), Some("./esm-dep.mjs"));
+    }
+
+    #[test]
+    fn test_imports_longest_prefix_wins() {
+        let imports: serde_json::Value =
+            serde_json::from_str(r##"{ "#x/*": "./short/*.js", "#x/deep/*": "./deep/*.js" }"##)
+                .unwrap();
+        let target = match_imports_field(&imports, "#x/deep/foo", DEV);
+        assert_eq!(target.as_deref(), Some("./deep/foo.js"));
+    }
+
+    #[test]
+    fn test_imports_null_target_blocked() {
+        let imports: serde_json::Value =
+            serde_json::from_str(r##"{ "#a": { "browser": null, "default": "./a.js" } }"##)
+                .unwrap();
+        let target = match_imports_field(&imports, "#a", DEV);
+        assert_eq!(target.as_deref(), Some("./a.js"));
+    }
+
+    #[test]
+    fn test_imports_bare_specifier_target() {
+        let imports: serde_json::Value =
+            serde_json::from_str(r##"{ "#clone": "lodash/cloneDeep" }"##).unwrap();
+        let target = match_imports_field(&imports, "#clone", DEV);
+        assert_eq!(target.as_deref(), Some("lodash/cloneDeep"));
+    }
+
+    #[test]
+    fn test_imports_no_match_returns_none() {
+        let imports: serde_json::Value =
+            serde_json::from_str(r##"{ "#foo": "./foo.js" }"##).unwrap();
+        assert!(match_imports_field(&imports, "#bar", DEV).is_none());
     }
 
     #[test]

--- a/crates/npm-resolver/src/resolve.rs
+++ b/crates/npm-resolver/src/resolve.rs
@@ -282,4 +282,139 @@ mod tests {
         let result = resolve_relative_import("../shared.mjs", &from).unwrap();
         assert!(result.ends_with("shared.mjs"));
     }
+
+    // --- subpath imports (`#`-prefixed) ---
+
+    #[test]
+    fn test_subpath_import_literal_from_project_root() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{ "imports": { "#internal/helper": "./src/internal/helper.js" } }"##,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src/internal")).unwrap();
+        fs::write(
+            dir.path().join("src/internal/helper.js"),
+            "export const helper = 1;",
+        )
+        .unwrap();
+
+        let result = resolve_subpath_import("#internal/helper", None, dir.path(), DEV).unwrap();
+        assert!(result.ends_with("src/internal/helper.js"));
+    }
+
+    #[test]
+    fn test_subpath_import_wildcard_substitution() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{ "imports": { "#internal/*": "./src/internal/*.js" } }"##,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("src/internal")).unwrap();
+        fs::write(
+            dir.path().join("src/internal/foo.js"),
+            "export const f = 1;",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("src/internal/bar.js"),
+            "export const b = 2;",
+        )
+        .unwrap();
+
+        let foo = resolve_subpath_import("#internal/foo", None, dir.path(), DEV).unwrap();
+        let bar = resolve_subpath_import("#internal/bar", None, dir.path(), DEV).unwrap();
+        assert!(foo.ends_with("src/internal/foo.js"));
+        assert!(bar.ends_with("src/internal/bar.js"));
+    }
+
+    #[test]
+    fn test_subpath_import_conditional_picks_browser() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{
+              "imports": {
+                "#dep": {
+                  "node": "./node/dep.js",
+                  "browser": "./browser/dep.mjs",
+                  "default": "./default/dep.js"
+                }
+              }
+            }"##,
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("browser")).unwrap();
+        fs::write(dir.path().join("browser/dep.mjs"), "export const d = 'b';").unwrap();
+
+        let result = resolve_subpath_import("#dep", None, dir.path(), DEV).unwrap();
+        assert!(result.ends_with("browser/dep.mjs"));
+    }
+
+    #[test]
+    fn test_subpath_import_scopes_to_nearest_ancestor() {
+        // Nested package.json at node_modules/dep owns any `#` specifier used
+        // inside dep/dist/file.js — not the project-root package.json.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{ "imports": { "#alias": "./project/alias.js" } }"##,
+        )
+        .unwrap();
+
+        let dep_dir = dir.path().join("node_modules/dep");
+        fs::create_dir_all(dep_dir.join("dist")).unwrap();
+        fs::write(
+            dep_dir.join("package.json"),
+            r##"{ "imports": { "#alias": "./lib/alias.js" } }"##,
+        )
+        .unwrap();
+        fs::create_dir_all(dep_dir.join("lib")).unwrap();
+        fs::write(dep_dir.join("lib/alias.js"), "export const a = 'dep';").unwrap();
+
+        let from = dep_dir.join("dist/main.js");
+        let result = resolve_subpath_import("#alias", Some(&from), dir.path(), DEV).unwrap();
+        assert!(
+            result.ends_with("node_modules/dep/lib/alias.js"),
+            "{}",
+            result.display()
+        );
+    }
+
+    #[test]
+    fn test_subpath_import_bare_specifier_target() {
+        // A `#` alias can point at a bare specifier, which must round-trip
+        // through the node_modules resolver.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{ "imports": { "#clone": "clone-pkg" } }"##,
+        )
+        .unwrap();
+        let clone_dir = dir.path().join("node_modules/clone-pkg");
+        fs::create_dir_all(&clone_dir).unwrap();
+        fs::write(
+            clone_dir.join("package.json"),
+            r#"{ "module": "./index.mjs" }"#,
+        )
+        .unwrap();
+        fs::write(clone_dir.join("index.mjs"), "export default 1;").unwrap();
+
+        let result = resolve_subpath_import("#clone", None, dir.path(), DEV).unwrap();
+        assert!(result.ends_with("node_modules/clone-pkg/index.mjs"));
+    }
+
+    #[test]
+    fn test_subpath_import_no_match_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r##"{ "imports": { "#a": "./a.js" } }"##,
+        )
+        .unwrap();
+        let err = resolve_subpath_import("#missing", None, dir.path(), DEV);
+        assert!(err.is_err());
+    }
 }

--- a/crates/npm-resolver/src/resolve.rs
+++ b/crates/npm-resolver/src/resolve.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::{NgcError, NgcResult};
 
-use crate::package_json::{parse_specifier, resolve_package_entry};
+use crate::package_json::{match_imports_field, parse_specifier, resolve_package_entry};
 
 /// Resolve a bare module specifier to an absolute file path.
 ///
@@ -32,6 +32,85 @@ pub fn resolve_bare_specifier(
     }
 
     resolve_package_entry(&pkg_dir, &subpath, conditions)
+}
+
+/// Resolve a `#`-prefixed subpath import against the nearest ancestor
+/// `package.json` that owns the importing file.
+///
+/// Node's resolver scopes `imports` to the importing package, not the package
+/// being imported *from*. So we walk up from `from_file` (or from
+/// `project_root` when a top-level specifier has no anchoring file) until we
+/// hit a `package.json`, then consult its `imports` field.
+///
+/// Targets that start with `./` / `../` / `/` are resolved relative to the
+/// owning package directory. Anything else is treated as a bare specifier and
+/// routed through the regular node_modules resolver.
+pub fn resolve_subpath_import(
+    specifier: &str,
+    from_file: Option<&Path>,
+    project_root: &Path,
+    conditions: &[&str],
+) -> NgcResult<PathBuf> {
+    let start: &Path = from_file.and_then(|f| f.parent()).unwrap_or(project_root);
+    let pkg_dir = find_ancestor_pkg_dir(start).ok_or_else(|| NgcError::NpmResolutionError {
+        specifier: specifier.to_string(),
+        message: format!("no ancestor package.json from {}", start.display()),
+    })?;
+
+    let pkg_json_path = pkg_dir.join("package.json");
+    let content = std::fs::read_to_string(&pkg_json_path).map_err(|e| NgcError::Io {
+        path: pkg_json_path.clone(),
+        source: e,
+    })?;
+    let pkg: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| NgcError::NpmResolutionError {
+            specifier: specifier.to_string(),
+            message: format!("invalid package.json at {}: {e}", pkg_json_path.display()),
+        })?;
+
+    let imports = pkg
+        .get("imports")
+        .ok_or_else(|| NgcError::NpmResolutionError {
+            specifier: specifier.to_string(),
+            message: format!("no \"imports\" field in {}", pkg_json_path.display()),
+        })?;
+
+    let target = match_imports_field(imports, specifier, conditions).ok_or_else(|| {
+        NgcError::NpmResolutionError {
+            specifier: specifier.to_string(),
+            message: format!("no matching entry in {}", pkg_json_path.display()),
+        }
+    })?;
+
+    if target.starts_with("./") || target.starts_with("../") || target.starts_with('/') {
+        let rel = target.trim_start_matches('/');
+        let resolved = pkg_dir.join(rel);
+        if resolved.is_file() {
+            return Ok(resolved);
+        }
+        if let Some(with_ext) = crate::package_json::try_extensions(&resolved) {
+            return Ok(with_ext);
+        }
+        return Err(NgcError::NpmResolutionError {
+            specifier: specifier.to_string(),
+            message: format!("imports target does not exist: {}", resolved.display()),
+        });
+    }
+
+    resolve_bare_specifier(&target, project_root, conditions)
+}
+
+/// Walk upwards from `start` looking for a directory that contains
+/// `package.json`. Returns the directory path if found.
+fn find_ancestor_pkg_dir(start: &Path) -> Option<PathBuf> {
+    let mut cur: Option<&Path> = Some(start);
+    while let Some(d) = cur {
+        if d.join("package.json").is_file() {
+            return Some(d.to_path_buf());
+        }
+        cur = d.parent();
+    }
+    None
 }
 
 /// Resolve a relative import specifier from within an npm package file.


### PR DESCRIPTION
Closes #63

## Summary
- Parse `imports` in `package.json` with the same semantics as `exports`: literal match, pattern trailer (longest prefix), conditional resolution, null-blocking.
- Route `#`-prefixed specifiers through `resolve_subpath_import`, which scopes to the nearest ancestor `package.json` of the importing file (project root for app code, dep's own package.json inside `node_modules/<pkg>`).
- Targets that start with `./`/`../`/`/` resolve against the owning package directory; bare-specifier targets re-enter the node_modules resolver.
- Bundler `classify_lazy_externals` resolves `#`-aliased externals to the actual canonical file before deciding cross-chunk membership — without this, an aliased project file inlined into a lazy chunk would also emit a stale `import { X } from './main.js'`, breaking the browser module linker.

## Tests
- Unit: literal alias, wildcard substitution, conditional branch selection, longest-prefix, null-blocked, bare target, no-match.
- Crawl-level: project-root `#internal/*` alias pulls in the target; a transitive `#priv/*` inside a dep scopes to that dep's own package.json.
- Bundler integration: `#internal/helper` in project code is inlined into the main chunk and the `#`-prefixed specifier is stripped from the output.
- Bundler regression: a `#`-aliased static dep inside a lazy chunk does not leak into the chunk's `./main.js` import.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`