### PR TITLE
feat(template-compiler): `@HostListener` / `@HostBinding` decorator extraction in AOT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "base64",
  "clap",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "rayon",
+ "tempfile",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.30"
+version = "0.7.31"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/Cargo.toml
+++ b/crates/linker/Cargo.toml
@@ -19,3 +19,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 insta = { version = "1.46", features = ["glob"] }
+tempfile = "3"

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 use ngc_diagnostics::NgcResult;
+use ngc_template_compiler::host_codegen;
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
 use oxc_span::GetSpan;
 
@@ -321,56 +322,10 @@ pub fn build_host_bindings(
             if let ObjectPropertyKind::ObjectProperty(p) = prop {
                 let key = prop_key_text(&p.key, source);
                 if let Expression::StringLiteral(s) = &p.value {
-                    let expr = compile_host_expression(&s.value);
-                    if let Some(style_prop) = key.strip_prefix("style.") {
-                        // style.X → ɵɵstyleProp (2 vars per style binding)
-                        let fn_name = if ng_import.is_empty() {
-                            "\u{0275}\u{0275}styleProp".to_string()
-                        } else {
-                            format!("{ng_import}.\u{0275}\u{0275}styleProp")
-                        };
-                        binding_stmts.push(format!("{fn_name}(\"{style_prop}\", {expr})"));
-                        host_vars += 2;
-                    } else if let Some(class_name) = key.strip_prefix("class.") {
-                        // class.X → ɵɵclassProp (2 vars per class binding)
-                        let fn_name = if ng_import.is_empty() {
-                            "\u{0275}\u{0275}classProp".to_string()
-                        } else {
-                            format!("{ng_import}.\u{0275}\u{0275}classProp")
-                        };
-                        binding_stmts.push(format!("{fn_name}(\"{class_name}\", {expr})"));
-                        host_vars += 2;
-                    } else if key == "class" {
-                        // class → ɵɵclassMap
-                        let fn_name = if ng_import.is_empty() {
-                            "\u{0275}\u{0275}classMap".to_string()
-                        } else {
-                            format!("{ng_import}.\u{0275}\u{0275}classMap")
-                        };
-                        binding_stmts.push(format!("{fn_name}({expr})"));
-                        host_vars += 2;
-                    } else if let Some(attr_name) = key.strip_prefix("attr.") {
-                        // attr.X → ɵɵattribute (1 var). Without this branch,
-                        // RouterLink's `[attr.href]` falls through to
-                        // ɵɵproperty, which sets a JS property named
-                        // "attr.href" instead of the HTML attribute.
-                        let fn_name = if ng_import.is_empty() {
-                            "\u{0275}\u{0275}attribute".to_string()
-                        } else {
-                            format!("{ng_import}.\u{0275}\u{0275}attribute")
-                        };
-                        binding_stmts.push(format!("{fn_name}(\"{attr_name}\", {expr})"));
-                        host_vars += 1;
-                    } else {
-                        // Regular property → ɵɵproperty (1 var)
-                        let fn_name = if ng_import.is_empty() {
-                            "\u{0275}\u{0275}property".to_string()
-                        } else {
-                            format!("{ng_import}.\u{0275}\u{0275}property")
-                        };
-                        binding_stmts.push(format!("{fn_name}(\"{key}\", {expr})"));
-                        host_vars += 1;
-                    }
+                    let (stmt, vars) =
+                        host_codegen::dispatch_property_binding(&key, &s.value, ng_import);
+                    binding_stmts.push(stmt);
+                    host_vars += vars;
                 }
             }
         }
@@ -382,15 +337,7 @@ pub fn build_host_bindings(
             if let ObjectPropertyKind::ObjectProperty(p) = prop {
                 let key = prop_key_text(&p.key, source);
                 if let Expression::StringLiteral(s) = &p.value {
-                    let listener_fn = if ng_import.is_empty() {
-                        "\u{0275}\u{0275}listener".to_string()
-                    } else {
-                        format!("{ng_import}.\u{0275}\u{0275}listener")
-                    };
-                    let expr = compile_host_expression(&s.value);
-                    listener_stmts.push(format!(
-                        "{listener_fn}(\"{key}\", function($event) {{ return {expr}; }})"
-                    ));
+                    listener_stmts.push(host_codegen::dispatch_listener(&key, &s.value, ng_import));
                 }
             }
         }
@@ -402,28 +349,7 @@ pub fn build_host_bindings(
         Some(format!("[{}]", attrs.join(", ")))
     };
 
-    let host_bindings = if binding_stmts.is_empty() && listener_stmts.is_empty() {
-        None
-    } else {
-        let mut body = String::new();
-        if !listener_stmts.is_empty() {
-            body.push_str("if (rf & 1) { ");
-            for stmt in &listener_stmts {
-                body.push_str(stmt);
-                body.push_str("; ");
-            }
-            body.push_str("} ");
-        }
-        if !binding_stmts.is_empty() {
-            body.push_str("if (rf & 2) { ");
-            for stmt in &binding_stmts {
-                body.push_str(stmt);
-                body.push_str("; ");
-            }
-            body.push('}');
-        }
-        Some(format!("function(rf, ctx) {{ {body} }}"))
-    };
+    let host_bindings = host_codegen::build_host_bindings_function(&binding_stmts, &listener_stmts);
 
     (host_attrs, host_bindings, host_vars)
 }
@@ -436,234 +362,6 @@ fn prop_key_text(key: &PropertyKey<'_>, source: &str) -> String {
         _ => {
             let span = key.span();
             source[span.start as usize..span.end as usize].to_string()
-        }
-    }
-}
-
-/// Compile a host binding expression by prefixing component property references with `ctx.`
-/// and stripping TypeScript-specific syntax (like `!` non-null assertion).
-///
-/// Parses the expression as TypeScript, walks the AST to find standalone identifiers
-/// (not member expression properties or built-in values), and prefixes them with `ctx.`.
-///
-/// Examples:
-/// - `"checked"` → `ctx.checked`
-/// - `"!!checked"` → `!!ctx.checked`
-/// - `"disabled || null"` → `ctx.disabled || null`
-/// - `"_getMinDate() ? _dateAdapter.toIso8601(_getMinDate()!) : null"`
-///   → `ctx._getMinDate() ? ctx._dateAdapter.toIso8601(ctx._getMinDate()) : null`
-fn compile_host_expression(expr: &str) -> String {
-    let wrapper = format!("var __expr = {expr};");
-    let alloc = oxc_allocator::Allocator::default();
-    let parsed = oxc_parser::Parser::new(&alloc, &wrapper, oxc_span::SourceType::tsx()).parse();
-
-    if !parsed.errors.is_empty() {
-        // If parsing fails, return the expression as-is (better than crashing)
-        tracing::warn!("failed to parse host expression: {expr}");
-        return expr.to_string();
-    }
-
-    // Extract the expression from `var __expr = <expr>;`
-    let init_expr = match &parsed.program.body.first() {
-        Some(oxc_ast::ast::Statement::VariableDeclaration(decl)) => {
-            decl.declarations.first().and_then(|d| d.init.as_ref())
-        }
-        _ => None,
-    };
-
-    let init_expr = match init_expr {
-        Some(e) => e,
-        None => return expr.to_string(),
-    };
-
-    // Collect byte offsets of identifiers that need `ctx.` prefix
-    // and byte ranges of `!` non-null assertions to remove
-    let mut ctx_inserts: Vec<u32> = Vec::new();
-    let mut remove_ranges: Vec<(u32, u32)> = Vec::new();
-
-    collect_ctx_rewrites(init_expr, &mut ctx_inserts, &mut remove_ranges, false);
-
-    // Apply modifications to the original expression string
-    // First, map wrapper offsets back to expression offsets
-    let expr_offset = "var __expr = ".len() as u32;
-
-    let mut result = expr.to_string();
-
-    ctx_inserts.sort_unstable();
-    ctx_inserts.dedup();
-
-    // Merge inserts and removes into a single edit list, then apply from
-    // rightmost to leftmost so each edit only touches characters to the right
-    // of earlier (already-processed) edits — their positions in the mutated
-    // string still match the original offsets.
-    enum Edit {
-        Insert(u32),
-        Remove(u32, u32),
-    }
-    let mut edits: Vec<Edit> = Vec::with_capacity(ctx_inserts.len() + remove_ranges.len());
-    for off in &ctx_inserts {
-        edits.push(Edit::Insert(off - expr_offset));
-    }
-    for (s, e) in &remove_ranges {
-        edits.push(Edit::Remove(s - expr_offset, e - expr_offset));
-    }
-    edits.sort_by_key(|e| {
-        std::cmp::Reverse(match e {
-            Edit::Insert(p) => *p,
-            Edit::Remove(s, _) => *s,
-        })
-    });
-
-    for edit in edits {
-        match edit {
-            Edit::Insert(off) => {
-                let off = off as usize;
-                if off <= result.len() {
-                    result.insert_str(off, "ctx.");
-                }
-            }
-            Edit::Remove(s, e) => {
-                let (s, e) = (s as usize, e as usize);
-                if s <= result.len() && e <= result.len() {
-                    result.replace_range(s..e, "");
-                }
-            }
-        }
-    }
-
-    result
-}
-
-/// Recursively collect identifier positions that need `ctx.` prefix and
-/// TypeScript non-null assertion `!` positions to remove.
-fn collect_ctx_rewrites(
-    expr: &Expression<'_>,
-    ctx_inserts: &mut Vec<u32>,
-    remove_ranges: &mut Vec<(u32, u32)>,
-    is_member_property: bool,
-) {
-    use oxc_ast::ast::*;
-    use oxc_span::GetSpan;
-
-    /// Set of identifiers that should NOT get `ctx.` prefix.
-    fn is_builtin(name: &str) -> bool {
-        matches!(
-            name,
-            "null"
-                | "undefined"
-                | "true"
-                | "false"
-                | "NaN"
-                | "Infinity"
-                | "this"
-                | "Math"
-                | "Date"
-                | "JSON"
-                | "console"
-                | "window"
-                | "document"
-                | "Array"
-                | "Object"
-                | "String"
-                | "Number"
-                | "Boolean"
-                | "Error"
-                | "RegExp"
-                | "Symbol"
-                | "Promise"
-                | "Map"
-                | "Set"
-                | "$event"
-                | "ctx"
-        )
-    }
-
-    match expr {
-        Expression::Identifier(id) if !is_member_property && !is_builtin(&id.name) => {
-            ctx_inserts.push(id.span.start);
-        }
-        Expression::CallExpression(call) => {
-            // `$any(x)` is a template-DSL type assertion; compile it as identity
-            // (emit `x` unchanged) rather than a call to a nonexistent ctx.$any.
-            if let Expression::Identifier(id) = &call.callee {
-                if id.name == "$any" && call.arguments.len() == 1 {
-                    if let Some(arg) = call.arguments.first() {
-                        if !matches!(arg, Argument::SpreadElement(_)) {
-                            let inner = arg.to_expression();
-                            remove_ranges.push((call.span.start, inner.span().start));
-                            remove_ranges.push((inner.span().end, call.span.end));
-                            collect_ctx_rewrites(
-                                inner,
-                                ctx_inserts,
-                                remove_ranges,
-                                is_member_property,
-                            );
-                            return;
-                        }
-                    }
-                }
-            }
-            collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false);
-            for arg in &call.arguments {
-                if let Argument::SpreadElement(spread) = arg {
-                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
-                } else {
-                    collect_ctx_rewrites(arg.to_expression(), ctx_inserts, remove_ranges, false);
-                }
-            }
-        }
-        Expression::StaticMemberExpression(member) => {
-            // Object gets ctx. prefix, property does not
-            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
-            // property is just an IdentifierName, no rewrite needed
-        }
-        Expression::ComputedMemberExpression(member) => {
-            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&member.expression, ctx_inserts, remove_ranges, false);
-        }
-        Expression::UnaryExpression(unary) => {
-            collect_ctx_rewrites(&unary.argument, ctx_inserts, remove_ranges, false);
-        }
-        Expression::BinaryExpression(binary) => {
-            collect_ctx_rewrites(&binary.left, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&binary.right, ctx_inserts, remove_ranges, false);
-        }
-        Expression::LogicalExpression(logical) => {
-            collect_ctx_rewrites(&logical.left, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&logical.right, ctx_inserts, remove_ranges, false);
-        }
-        Expression::ConditionalExpression(cond) => {
-            collect_ctx_rewrites(&cond.test, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&cond.consequent, ctx_inserts, remove_ranges, false);
-            collect_ctx_rewrites(&cond.alternate, ctx_inserts, remove_ranges, false);
-        }
-        Expression::ParenthesizedExpression(paren) => {
-            collect_ctx_rewrites(&paren.expression, ctx_inserts, remove_ranges, false);
-        }
-        Expression::TSNonNullExpression(non_null) => {
-            // Process the inner expression, then mark the `!` for removal
-            collect_ctx_rewrites(
-                &non_null.expression,
-                ctx_inserts,
-                remove_ranges,
-                is_member_property,
-            );
-            // The `!` is at the end of the expression span, just before the closing
-            let inner_end = non_null.expression.span().end;
-            let outer_end = non_null.span.end;
-            if outer_end > inner_end {
-                remove_ranges.push((inner_end, outer_end));
-            }
-        }
-        Expression::TemplateLiteral(_)
-        | Expression::StringLiteral(_)
-        | Expression::NumericLiteral(_)
-        | Expression::BooleanLiteral(_)
-        | Expression::NullLiteral(_) => {
-            // Literals don't need rewriting
-        }
-        _ => {
-            // For other expression types, leave as-is
         }
     }
 }
@@ -977,81 +675,5 @@ mod tests {
             result.contains("hostVars: 4"),
             "expected hostVars: 4, got: {result}"
         );
-    }
-
-    #[test]
-    fn test_compile_host_expression_simple() {
-        assert_eq!(compile_host_expression("checked"), "ctx.checked");
-    }
-
-    #[test]
-    fn test_compile_host_expression_negation() {
-        assert_eq!(compile_host_expression("!!checked"), "!!ctx.checked");
-    }
-
-    #[test]
-    fn test_compile_host_expression_logical() {
-        assert_eq!(
-            compile_host_expression("disabled || null"),
-            "ctx.disabled || null"
-        );
-    }
-
-    #[test]
-    fn test_compile_host_expression_method_call() {
-        assert_eq!(
-            compile_host_expression("toastClasses()"),
-            "ctx.toastClasses()"
-        );
-    }
-
-    #[test]
-    fn test_compile_host_expression_member_chain() {
-        assert_eq!(
-            compile_host_expression("_rangeInput.rangePicker ? \"dialog\" : null"),
-            "ctx._rangeInput.rangePicker ? \"dialog\" : null"
-        );
-    }
-
-    #[test]
-    fn test_compile_host_expression_ts_non_null() {
-        assert_eq!(
-            compile_host_expression("_getMinDate()!"),
-            "ctx._getMinDate()"
-        );
-    }
-
-    #[test]
-    fn test_compile_host_expression_any_in_listener() {
-        // `$any($event.target).checked` — the CheckboxControlValueAccessor pattern
-        // that regressed in issue #68.
-        assert_eq!(
-            compile_host_expression("onChange($any($event.target).checked)"),
-            "ctx.onChange($event.target.checked)"
-        );
-    }
-
-    #[test]
-    fn test_compile_host_expression_any_over_ctx() {
-        assert_eq!(
-            compile_host_expression("$any(ctx).foo.bar()"),
-            "ctx.foo.bar()"
-        );
-    }
-
-    #[test]
-    fn test_compile_host_expression_any_bare_identifier() {
-        // Just the argument — no member access, no call on the result.
-        assert_eq!(compile_host_expression("$any(value)"), "ctx.value");
-    }
-
-    #[test]
-    fn test_compile_host_expression_complex_ternary() {
-        let result = compile_host_expression(
-            "_getMinDate() ? _dateAdapter.toIso8601(_getMinDate()!) : null",
-        );
-        assert!(result.contains("ctx._getMinDate()"));
-        assert!(result.contains("ctx._dateAdapter.toIso8601"));
-        assert!(!result.contains("!)")); // non-null stripped
     }
 }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -676,4 +676,190 @@ mod tests {
             "expected hostVars: 4, got: {result}"
         );
     }
+
+    /// `style.X.unit` must split off the unit so the runtime gets a
+    /// 3-arg `ɵɵstyleProp(propName, expr, suffix)` — emitting
+    /// `ɵɵstyleProp("X.unit", expr)` would set `width.px` as the property
+    /// name and the unit suffix would never reach the renderer.
+    #[test]
+    fn test_host_binding_style_with_unit() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', host: { properties: { 'style.width.px': 'width' } } }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}styleProp(\"width\", ctx.width, \"px\")"),
+            "expected style.X.unit to split off the unit; got: {result}"
+        );
+        assert!(result.contains("hostVars: 2"));
+    }
+
+    // ---- AOT ↔ linker parity for `@HostListener` / `@HostBinding` (issue #58) ----
+    //
+    // Compiles a directive with each decorator target form via the AOT path
+    // and asserts the same Ivy instructions appear in the linker's output for
+    // an equivalent `host: { listeners, properties }` partial declaration.
+
+    use ngc_template_compiler::compile_all_decorators;
+    use std::io::Write;
+
+    /// Compile a `@Directive` source through the AOT pipeline. We have to
+    /// hand the source to `compile_all_decorators` via a tempfile because
+    /// the per-string entry point only knows how to recognise `@Component`.
+    fn aot_compile(source: &str) -> String {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("host.directive.ts");
+        let mut f = std::fs::File::create(&path).expect("create");
+        f.write_all(source.as_bytes()).expect("write");
+        drop(f);
+        let mut out = compile_all_decorators(&[path]).expect("compile");
+        let compiled = out.pop().expect("one file");
+        assert!(compiled.compiled, "expected AOT to compile the directive");
+        compiled.source
+    }
+
+    #[test]
+    fn parity_host_listener_event_only() {
+        let aot = aot_compile(
+            "import { Directive, HostListener } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir { @HostListener('click') onClick() {} }\n",
+        );
+        let linker =
+            parse_and_transform("{ type: HostDir, selector: '[appHost]', isStandalone: true, host: { listeners: { 'click': 'onClick()' } } }");
+
+        assert!(aot.contains(
+            "\u{0275}\u{0275}listener(\"click\", function($event) { return ctx.onClick(); })"
+        ));
+        assert!(linker.contains(
+            "i0.\u{0275}\u{0275}listener(\"click\", function($event) { return ctx.onClick(); })"
+        ));
+        assert!(aot.contains("if (rf & 1)"));
+        assert!(linker.contains("if (rf & 1)"));
+    }
+
+    #[test]
+    fn parity_host_binding_bare() {
+        let aot = aot_compile(
+            "import { Directive, HostBinding } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir { @HostBinding('disabled') isDisabled = false; }\n",
+        );
+        let linker = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, host: { properties: { 'disabled': 'isDisabled' } } }",
+        );
+
+        assert!(aot.contains("\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"));
+        assert!(linker.contains("i0.\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"));
+        assert!(aot.contains("hostVars: 1"));
+        assert!(linker.contains("hostVars: 1"));
+    }
+
+    #[test]
+    fn parity_host_binding_attr() {
+        let aot = aot_compile(
+            "import { Directive, HostBinding } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir { @HostBinding('attr.aria-label') label = 'host'; }\n",
+        );
+        let linker = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, host: { properties: { 'attr.aria-label': 'label' } } }",
+        );
+
+        assert!(aot.contains("\u{0275}\u{0275}attribute(\"aria-label\", ctx.label)"));
+        assert!(linker.contains("i0.\u{0275}\u{0275}attribute(\"aria-label\", ctx.label)"));
+        assert!(aot.contains("hostVars: 1"));
+        assert!(linker.contains("hostVars: 1"));
+    }
+
+    #[test]
+    fn parity_host_binding_class() {
+        let aot = aot_compile(
+            "import { Directive, HostBinding } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir { @HostBinding('class.active') isActive = true; }\n",
+        );
+        let linker = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, host: { properties: { 'class.active': 'isActive' } } }",
+        );
+
+        assert!(aot.contains("\u{0275}\u{0275}classProp(\"active\", ctx.isActive)"));
+        assert!(linker.contains("i0.\u{0275}\u{0275}classProp(\"active\", ctx.isActive)"));
+        assert!(aot.contains("hostVars: 2"));
+        assert!(linker.contains("hostVars: 2"));
+    }
+
+    #[test]
+    fn parity_host_binding_style_simple() {
+        let aot = aot_compile(
+            "import { Directive, HostBinding } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir { @HostBinding('style.color') color = 'red'; }\n",
+        );
+        let linker = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, host: { properties: { 'style.color': 'color' } } }",
+        );
+
+        assert!(aot.contains("\u{0275}\u{0275}styleProp(\"color\", ctx.color)"));
+        assert!(linker.contains("i0.\u{0275}\u{0275}styleProp(\"color\", ctx.color)"));
+        assert!(aot.contains("hostVars: 2"));
+        assert!(linker.contains("hostVars: 2"));
+    }
+
+    #[test]
+    fn parity_host_binding_style_with_unit() {
+        let aot = aot_compile(
+            "import { Directive, HostBinding } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir { @HostBinding('style.width.px') width = 100; }\n",
+        );
+        let linker = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, host: { properties: { 'style.width.px': 'width' } } }",
+        );
+
+        assert!(aot.contains("\u{0275}\u{0275}styleProp(\"width\", ctx.width, \"px\")"));
+        assert!(linker.contains("i0.\u{0275}\u{0275}styleProp(\"width\", ctx.width, \"px\")"));
+        assert!(aot.contains("hostVars: 2"));
+        assert!(linker.contains("hostVars: 2"));
+    }
+
+    #[test]
+    fn parity_host_mixed_listener_and_bindings() {
+        let aot = aot_compile(
+            "import { Directive, HostListener, HostBinding } from '@angular/core';\n\
+             @Directive({ selector: '[appHost]', standalone: true })\n\
+             export class HostDir {\n\
+               @HostBinding('attr.aria-label') label = 'host';\n\
+               @HostBinding('class.active') isActive = true;\n\
+               @HostBinding('disabled') isDisabled = false;\n\
+               @HostListener('click', ['$event']) onClick($event: Event) {}\n\
+             }\n",
+        );
+        let linker = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, \
+             host: { properties: { 'attr.aria-label': 'label', 'class.active': 'isActive', 'disabled': 'isDisabled' }, \
+                     listeners: { 'click': 'onClick($event)' } } }",
+        );
+
+        // attr (1) + class (2) + property (1) = 4 — listeners contribute 0.
+        assert!(aot.contains("hostVars: 4"));
+        assert!(linker.contains("hostVars: 4"));
+
+        for must_contain in [
+            "if (rf & 1)",
+            "if (rf & 2)",
+            "\u{0275}\u{0275}listener(\"click\"",
+            "\u{0275}\u{0275}attribute(\"aria-label\"",
+            "\u{0275}\u{0275}classProp(\"active\"",
+            "\u{0275}\u{0275}property(\"disabled\"",
+        ] {
+            assert!(
+                aot.contains(must_contain),
+                "AOT missing {must_contain:?}; got:\n{aot}"
+            );
+            assert!(
+                linker.contains(must_contain),
+                "linker missing {must_contain:?}; got:\n{linker}"
+            );
+        }
+    }
 }

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -177,6 +177,19 @@ pub fn generate_ivy(
             .collect();
         dc.push_str(&format!("    inputs: {{ {} }},\n", inputs.join(", ")));
     }
+    let host_props = crate::directive_codegen::build_host_props(
+        &component.host_listeners,
+        &component.host_bindings,
+    );
+    for imp in &host_props.ivy_imports {
+        gen.ivy_imports.insert(imp.clone());
+    }
+    if let Some(ref host_vars) = host_props.host_vars_prop {
+        dc.push_str(&format!("    {host_vars},\n"));
+    }
+    if let Some(ref host_bindings) = host_props.host_bindings_prop {
+        dc.push_str(&format!("    {host_bindings},\n"));
+    }
     if !gen.consts.is_empty() {
         dc.push_str(&format!("    consts: [{}],\n", gen.consts.join(", ")));
     }
@@ -3598,6 +3611,8 @@ mod tests {
             inline_styles: Vec::new(),
             style_urls: Vec::new(),
             input_properties: Vec::new(),
+            host_listeners: Vec::new(),
+            host_bindings: Vec::new(),
             animations_source: None,
         }
     }

--- a/crates/template-compiler/src/directive_codegen.rs
+++ b/crates/template-compiler/src/directive_codegen.rs
@@ -20,8 +20,9 @@ use std::collections::BTreeSet;
 use ngc_diagnostics::NgcResult;
 
 use crate::codegen::IvyOutput;
-use crate::extract::ExtractedDirective;
+use crate::extract::{ExtractedDirective, HostBindingSpec, HostListenerSpec};
 use crate::factory_codegen;
+use crate::host_codegen;
 use crate::selector;
 
 /// Generate Ivy output for a `@Directive` decorator.
@@ -54,6 +55,17 @@ pub fn generate_directive_ivy(extracted: &ExtractedDirective) -> NgcResult<IvyOu
         props.push(format!("outputs: {outputs_src}"));
     }
 
+    let host_props = build_host_props(&extracted.host_listeners, &extracted.host_bindings);
+    for imp in &host_props.ivy_imports {
+        ivy_imports.insert(imp.clone());
+    }
+    if let Some(host_vars) = host_props.host_vars_prop {
+        props.push(host_vars);
+    }
+    if let Some(host_bindings) = host_props.host_bindings_prop {
+        props.push(host_bindings);
+    }
+
     if let Some(ref export_as) = extracted.export_as {
         let parts: Vec<&str> = export_as.split(',').map(|s| s.trim()).collect();
         let arr = parts
@@ -82,6 +94,75 @@ pub fn generate_directive_ivy(extracted: &ExtractedDirective) -> NgcResult<IvyOu
     })
 }
 
+/// Result of compiling decorator-extracted host metadata into the
+/// `hostVars`/`hostBindings` properties of `ɵɵdefineDirective`/`ɵɵdefineComponent`.
+pub(crate) struct CompiledHostProps {
+    /// `hostVars: N` property string, only set when host_vars > 0.
+    pub host_vars_prop: Option<String>,
+    /// `hostBindings: function(rf, ctx) { ... }` property string.
+    pub host_bindings_prop: Option<String>,
+    /// Ivy instruction symbols referenced by the emitted statements
+    /// (e.g. `ɵɵlistener`, `ɵɵclassProp`). The caller must add these to the
+    /// import set so the rewrite step pulls them from `@angular/core`.
+    pub ivy_imports: BTreeSet<String>,
+}
+
+/// Compile `@HostListener` and `@HostBinding` extractions into `hostVars` and
+/// `hostBindings` property strings ready to splice into a define call.
+///
+/// Produces no output when both lists are empty. AOT codegen passes empty
+/// `ng_import` (decorators emit unprefixed `ɵɵlistener` / `ɵɵproperty`
+/// references); the linker passes its own `ng_import` namespace.
+pub(crate) fn build_host_props(
+    listeners: &[HostListenerSpec],
+    bindings: &[HostBindingSpec],
+) -> CompiledHostProps {
+    let mut listener_stmts = Vec::with_capacity(listeners.len());
+    let mut imports = BTreeSet::new();
+    for l in listeners {
+        listener_stmts.push(host_codegen::dispatch_listener(
+            &l.event,
+            &l.handler_expression,
+            "",
+        ));
+        imports.insert("\u{0275}\u{0275}listener".to_string());
+    }
+
+    let mut binding_stmts = Vec::with_capacity(bindings.len());
+    let mut host_vars: u32 = 0;
+    for b in bindings {
+        let (stmt, vars) = host_codegen::dispatch_property_binding(&b.target, &b.property_name, "");
+        binding_stmts.push(stmt);
+        host_vars += vars;
+        imports.insert(host_instruction_for(&b.target).to_string());
+    }
+
+    let host_bindings_fn =
+        host_codegen::build_host_bindings_function(&binding_stmts, &listener_stmts);
+
+    CompiledHostProps {
+        host_vars_prop: (host_vars > 0).then(|| format!("hostVars: {host_vars}")),
+        host_bindings_prop: host_bindings_fn.map(|f| format!("hostBindings: {f}")),
+        ivy_imports: imports,
+    }
+}
+
+/// Map a host binding target to the Ivy runtime symbol it dispatches to.
+/// Mirrors the dispatch logic in `host_codegen::dispatch_property_binding`.
+fn host_instruction_for(target: &str) -> &'static str {
+    if target.starts_with("style.") {
+        "\u{0275}\u{0275}styleProp"
+    } else if target == "class" {
+        "\u{0275}\u{0275}classMap"
+    } else if target.starts_with("class.") {
+        "\u{0275}\u{0275}classProp"
+    } else if target.starts_with("attr.") {
+        "\u{0275}\u{0275}attribute"
+    } else {
+        "\u{0275}\u{0275}property"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,6 +181,8 @@ mod tests {
             outputs_source: None,
             export_as: None,
             constructor_params: Vec::new(),
+            host_listeners: Vec::new(),
+            host_bindings: Vec::new(),
             common: DecoratorCommon {
                 decorator_span: (0, 0),
                 class_body_start: 0,
@@ -158,5 +241,139 @@ mod tests {
         extracted.export_as = Some("myDir".to_string());
         let output = generate_directive_ivy(&extracted).unwrap();
         assert!(output.static_fields[0].contains("exportAs: [\"myDir\"]"));
+    }
+
+    /// Decorator-style host listener should produce the same `ɵɵlistener`
+    /// statement shape as the linker's partial-declaration path.
+    #[test]
+    fn test_directive_host_listener() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_listeners = vec![HostListenerSpec {
+            event: "click".to_string(),
+            handler_expression: "onClick($event)".to_string(),
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(
+            def.contains(
+                "\u{0275}\u{0275}listener(\"click\", function($event) { return ctx.onClick($event); })"
+            ),
+            "expected ɵɵlistener call, got: {def}"
+        );
+        assert!(def.contains("if (rf & 1)"));
+        // listeners do not contribute hostVars
+        assert!(!def.contains("hostVars"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}listener"));
+    }
+
+    #[test]
+    fn test_directive_host_binding_bare_property() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_bindings = vec![HostBindingSpec {
+            target: "disabled".to_string(),
+            property_name: "isDisabled".to_string(),
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(def.contains("\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"));
+        assert!(def.contains("hostVars: 1"));
+        assert!(def.contains("if (rf & 2)"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}property"));
+    }
+
+    #[test]
+    fn test_directive_host_binding_attr() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_bindings = vec![HostBindingSpec {
+            target: "attr.aria-label".to_string(),
+            property_name: "label".to_string(),
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(def.contains("\u{0275}\u{0275}attribute(\"aria-label\", ctx.label)"));
+        assert!(def.contains("hostVars: 1"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}attribute"));
+    }
+
+    #[test]
+    fn test_directive_host_binding_class_prop() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_bindings = vec![HostBindingSpec {
+            target: "class.active".to_string(),
+            property_name: "isActive".to_string(),
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(def.contains("\u{0275}\u{0275}classProp(\"active\", ctx.isActive)"));
+        assert!(def.contains("hostVars: 2"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}classProp"));
+    }
+
+    #[test]
+    fn test_directive_host_binding_style_simple() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_bindings = vec![HostBindingSpec {
+            target: "style.color".to_string(),
+            property_name: "color".to_string(),
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(def.contains("\u{0275}\u{0275}styleProp(\"color\", ctx.color)"));
+        assert!(def.contains("hostVars: 2"));
+        assert!(output.ivy_imports.contains("\u{0275}\u{0275}styleProp"));
+    }
+
+    /// `style.width.px` must split off the unit suffix so the runtime gets
+    /// `ɵɵstyleProp("width", value, "px")` — not `ɵɵstyleProp("width.px", value)`.
+    #[test]
+    fn test_directive_host_binding_style_with_unit() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_bindings = vec![HostBindingSpec {
+            target: "style.width.px".to_string(),
+            property_name: "width".to_string(),
+        }];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(
+            def.contains("\u{0275}\u{0275}styleProp(\"width\", ctx.width, \"px\")"),
+            "expected ɵɵstyleProp with unit suffix, got: {def}"
+        );
+        assert!(def.contains("hostVars: 2"));
+    }
+
+    #[test]
+    fn test_directive_host_mixed_listener_and_bindings() {
+        let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
+        extracted.host_listeners = vec![HostListenerSpec {
+            event: "click".to_string(),
+            handler_expression: "onClick($event)".to_string(),
+        }];
+        extracted.host_bindings = vec![
+            HostBindingSpec {
+                target: "attr.aria-label".to_string(),
+                property_name: "label".to_string(),
+            },
+            HostBindingSpec {
+                target: "class.active".to_string(),
+                property_name: "isActive".to_string(),
+            },
+            HostBindingSpec {
+                target: "disabled".to_string(),
+                property_name: "isDisabled".to_string(),
+            },
+        ];
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        // attr (1) + class (2) + property (1) = 4
+        assert!(
+            def.contains("hostVars: 4"),
+            "expected hostVars: 4, got: {def}"
+        );
+        assert!(def.contains("\u{0275}\u{0275}listener(\"click\""));
+        assert!(def.contains("\u{0275}\u{0275}attribute(\"aria-label\""));
+        assert!(def.contains("\u{0275}\u{0275}classProp(\"active\""));
+        assert!(def.contains("\u{0275}\u{0275}property(\"disabled\""));
+        assert!(def.contains("if (rf & 1)"));
+        assert!(def.contains("if (rf & 2)"));
     }
 }

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 use ngc_diagnostics::{NgcError, NgcResult};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    Argument, Class, Decorator, Expression, FormalParameter, FormalParameters,
-    MethodDefinitionKind, ObjectPropertyKind, PropertyKey, Statement, TSTypeAnnotation,
+    Argument, ArrayExpressionElement, Class, ClassElement, Decorator, Expression, FormalParameter,
+    FormalParameters, MethodDefinitionKind, ObjectPropertyKind, PropertyKey, Statement,
+    TSTypeAnnotation,
 };
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
@@ -58,10 +59,37 @@ pub struct ExtractedComponent {
     pub style_urls: Vec<String>,
     /// Property names decorated with `@Input()`.
     pub input_properties: Vec<String>,
+    /// Method-level `@HostListener` extractions (e.g. `('click', ['$event'])`).
+    pub host_listeners: Vec<HostListenerSpec>,
+    /// Field/property-level `@HostBinding` extractions (e.g. `('class.active')`).
+    pub host_bindings: Vec<HostBindingSpec>,
     /// Raw source text of the `animations` array (e.g. `[trigger('fade', [...])]`).
     /// Passed through to the `defineComponent({ data: { animation: [...] } })`
     /// field so Angular's runtime can register triggers with the animation renderer.
     pub animations_source: Option<String>,
+}
+
+/// A method-level `@HostListener(event, [args])` extraction.
+#[derive(Debug, Clone)]
+pub struct HostListenerSpec {
+    /// Event name passed to the decorator (e.g. `"click"`, `"window:resize"`).
+    pub event: String,
+    /// The JS expression invoked by `ɵɵlistener` — already shaped as
+    /// `methodName(...args)`. Component members get `ctx.` prefixed downstream
+    /// by `host_codegen::compile_host_expression`.
+    pub handler_expression: String,
+}
+
+/// A field/property-level `@HostBinding(target?)` extraction.
+#[derive(Debug, Clone)]
+pub struct HostBindingSpec {
+    /// Decorator argument: bare property name, `attr.X`, `class.Y`, `style.Z`,
+    /// or `style.Z.unit`. Falls back to the property name when the decorator
+    /// is called with no arguments.
+    pub target: String,
+    /// The class field/getter that supplies the value. Compiled to `ctx.<name>`
+    /// at codegen time.
+    pub property_name: String,
 }
 
 impl ExtractedComponent {
@@ -182,6 +210,9 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             }
         }
 
+        let host_listeners = extract_host_listeners(&class.body);
+        let host_bindings = extract_host_bindings(&class.body);
+
         return Ok(Some(ExtractedComponent {
             class_name,
             selector: metadata.selector,
@@ -200,6 +231,8 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             inline_styles: metadata.inline_styles,
             style_urls: metadata.style_urls,
             input_properties,
+            host_listeners,
+            host_bindings,
             animations_source: metadata.animations_source,
         }));
     }
@@ -295,6 +328,10 @@ pub struct ExtractedDirective {
     pub export_as: Option<String>,
     /// Constructor parameters for DI-aware factory generation.
     pub constructor_params: Vec<ConstructorParam>,
+    /// Method-level `@HostListener` extractions.
+    pub host_listeners: Vec<HostListenerSpec>,
+    /// Field/property-level `@HostBinding` extractions.
+    pub host_bindings: Vec<HostBindingSpec>,
     /// Common decorator fields for rewriting.
     pub common: DecoratorCommon,
 }
@@ -513,6 +550,9 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             }
         }
 
+        let host_listeners = extract_host_listeners(&class.body);
+        let host_bindings = extract_host_bindings(&class.body);
+
         return Ok(Some(ExtractedDirective {
             class_name,
             selector,
@@ -521,6 +561,8 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             outputs_source,
             export_as,
             constructor_params,
+            host_listeners,
+            host_bindings,
             common: DecoratorCommon {
                 decorator_span: (decorator.span.start, decorator.span.end),
                 class_body_start,
@@ -777,6 +819,116 @@ fn source_text_of(source: &str, expr: &Expression<'_>) -> Option<String> {
     let end = expr.span().end as usize;
     if start < source.len() && end <= source.len() {
         Some(source[start..end].to_string())
+    } else {
+        None
+    }
+}
+
+/// Walk a class body and collect every method-level `@HostListener(event[, args])`.
+///
+/// `@HostListener('click', ['$event'])` on `onClick($event)` produces a spec
+/// with `event = "click"` and `handler_expression = "onClick($event)"`. The
+/// handler expression is fed to `host_codegen::compile_host_expression` at
+/// codegen time, which prefixes `onClick` with `ctx.`.
+fn extract_host_listeners(class_body: &oxc_ast::ast::ClassBody<'_>) -> Vec<HostListenerSpec> {
+    let mut listeners = Vec::new();
+    for element in &class_body.body {
+        let ClassElement::MethodDefinition(method) = element else {
+            continue;
+        };
+        if method.kind == MethodDefinitionKind::Constructor {
+            continue;
+        }
+        let method_name = match &method.key {
+            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+            PropertyKey::StringLiteral(s) => s.value.to_string(),
+            _ => continue,
+        };
+        for decorator in &method.decorators {
+            let Some(call) = decorator_call(decorator, "HostListener") else {
+                continue;
+            };
+            let event = match call.arguments.first() {
+                Some(Argument::StringLiteral(s)) => s.value.to_string(),
+                _ => continue,
+            };
+            let args_text = match call.arguments.get(1) {
+                Some(Argument::ArrayExpression(arr)) => arr
+                    .elements
+                    .iter()
+                    .filter_map(|el| match el {
+                        ArrayExpressionElement::StringLiteral(s) => Some(s.value.to_string()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                _ => String::new(),
+            };
+            let handler_expression = format!("{method_name}({args_text})");
+            listeners.push(HostListenerSpec {
+                event,
+                handler_expression,
+            });
+        }
+    }
+    listeners
+}
+
+/// Walk a class body and collect every field-level `@HostBinding(target?)`.
+///
+/// `@HostBinding('class.active') isActive = true;` produces a spec with
+/// `target = "class.active"` and `property_name = "isActive"`. When the
+/// decorator argument is omitted, Angular defaults to the property name as
+/// the target (matching `@HostBinding() class = '...'`).
+fn extract_host_bindings(class_body: &oxc_ast::ast::ClassBody<'_>) -> Vec<HostBindingSpec> {
+    let mut bindings = Vec::new();
+    for element in &class_body.body {
+        let (decorators, key) = match element {
+            ClassElement::PropertyDefinition(prop) => (&prop.decorators, &prop.key),
+            ClassElement::MethodDefinition(method)
+                if method.kind == MethodDefinitionKind::Get
+                    || method.kind == MethodDefinitionKind::Set =>
+            {
+                (&method.decorators, &method.key)
+            }
+            _ => continue,
+        };
+        let property_name = match key {
+            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+            PropertyKey::StringLiteral(s) => s.value.to_string(),
+            _ => continue,
+        };
+        for decorator in decorators {
+            let Some(call) = decorator_call(decorator, "HostBinding") else {
+                continue;
+            };
+            let target = match call.arguments.first() {
+                Some(Argument::StringLiteral(s)) => s.value.to_string(),
+                None => property_name.clone(),
+                _ => continue,
+            };
+            bindings.push(HostBindingSpec {
+                target,
+                property_name: property_name.clone(),
+            });
+        }
+    }
+    bindings
+}
+
+/// If `decorator` is `@Name(...)`, return the call expression — otherwise `None`.
+fn decorator_call<'a>(
+    decorator: &'a Decorator<'a>,
+    name: &str,
+) -> Option<&'a oxc_ast::ast::CallExpression<'a>> {
+    let Expression::CallExpression(call) = &decorator.expression else {
+        return None;
+    };
+    let Expression::Identifier(ident) = &call.callee else {
+        return None;
+    };
+    if ident.name.as_str() == name {
+        Some(call)
     } else {
         None
     }
@@ -1325,5 +1477,141 @@ export class AppModule {}
         let source = "export class PlainClass { x = 1; }\n";
         let result = extract_injectable(source, &test_path()).expect("should not error");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_host_listener_event_only() {
+        let source = r#"import { Directive, HostListener } from '@angular/core';
+
+@Directive({ selector: '[appResize]' })
+export class ResizeDirective {
+  @HostListener('window:resize')
+  onResize() {}
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.host_listeners.len(), 1);
+        assert_eq!(result.host_listeners[0].event, "window:resize");
+        assert_eq!(result.host_listeners[0].handler_expression, "onResize()");
+    }
+
+    #[test]
+    fn test_extract_host_listener_with_args() {
+        let source = r#"import { Directive, HostListener } from '@angular/core';
+
+@Directive({ selector: '[appClick]' })
+export class ClickDirective {
+  @HostListener('click', ['$event'])
+  onClick($event: MouseEvent) {}
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.host_listeners.len(), 1);
+        assert_eq!(result.host_listeners[0].event, "click");
+        assert_eq!(
+            result.host_listeners[0].handler_expression,
+            "onClick($event)"
+        );
+    }
+
+    #[test]
+    fn test_extract_host_binding_bare() {
+        let source = r#"import { Directive, HostBinding } from '@angular/core';
+
+@Directive({ selector: '[appX]' })
+export class XDirective {
+  @HostBinding('disabled') isDisabled = false;
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.host_bindings.len(), 1);
+        assert_eq!(result.host_bindings[0].target, "disabled");
+        assert_eq!(result.host_bindings[0].property_name, "isDisabled");
+    }
+
+    #[test]
+    fn test_extract_host_binding_class_attr_style() {
+        let source = r#"import { Directive, HostBinding } from '@angular/core';
+
+@Directive({ selector: '[appX]' })
+export class XDirective {
+  @HostBinding('class.active') isActive = true;
+  @HostBinding('attr.aria-label') label = 'x';
+  @HostBinding('style.width.px') width = 100;
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.host_bindings.len(), 3);
+        let targets: Vec<&str> = result
+            .host_bindings
+            .iter()
+            .map(|b| b.target.as_str())
+            .collect();
+        assert!(targets.contains(&"class.active"));
+        assert!(targets.contains(&"attr.aria-label"));
+        assert!(targets.contains(&"style.width.px"));
+    }
+
+    #[test]
+    fn test_extract_host_binding_no_arg_uses_property_name() {
+        let source = r#"import { Directive, HostBinding } from '@angular/core';
+
+@Directive({ selector: '[appX]' })
+export class XDirective {
+  @HostBinding() id = 'host';
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.host_bindings.len(), 1);
+        assert_eq!(result.host_bindings[0].target, "id");
+        assert_eq!(result.host_bindings[0].property_name, "id");
+    }
+
+    #[test]
+    fn test_extract_host_binding_on_getter() {
+        // Angular accepts @HostBinding on a getter — the value is a computed
+        // expression rather than a plain field.
+        let source = r#"import { Directive, HostBinding } from '@angular/core';
+
+@Directive({ selector: '[appX]' })
+export class XDirective {
+  @HostBinding('attr.title') get title() { return 'tip'; }
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("should extract")
+            .expect("should find directive");
+        assert_eq!(result.host_bindings.len(), 1);
+        assert_eq!(result.host_bindings[0].target, "attr.title");
+        assert_eq!(result.host_bindings[0].property_name, "title");
+    }
+
+    #[test]
+    fn test_component_extracts_host_decorators() {
+        let source = r#"import { Component, HostListener, HostBinding } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  @HostBinding('class.dark') isDark = false;
+  @HostListener('window:resize') onResize() {}
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("should extract")
+            .expect("should find component");
+        assert_eq!(result.host_listeners.len(), 1);
+        assert_eq!(result.host_bindings.len(), 1);
+        assert_eq!(result.host_listeners[0].event, "window:resize");
+        assert_eq!(result.host_bindings[0].target, "class.dark");
     }
 }

--- a/crates/template-compiler/src/host_codegen.rs
+++ b/crates/template-compiler/src/host_codegen.rs
@@ -1,0 +1,502 @@
+//! Shared host-binding codegen used by both AOT (`@HostListener` /
+//! `@HostBinding` decorator extraction) and the linker (partial-compiled
+//! npm packages).
+//!
+//! Each path collects a list of `(target, expression)` property bindings and
+//! `(event, expression)` listeners, then this module dispatches each entry
+//! to the right Ivy instruction (`ɵɵproperty`, `ɵɵattribute`, `ɵɵclassProp`,
+//! `ɵɵstyleProp`, `ɵɵclassMap`, `ɵɵlistener`) and assembles the
+//! `hostBindings` function so AOT and linker output match byte-for-byte.
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+/// Prefix used for namespaced runtime calls (e.g. `i0.`).
+fn ng_prefix(ng_import: &str) -> String {
+    if ng_import.is_empty() {
+        String::new()
+    } else {
+        format!("{ng_import}.")
+    }
+}
+
+/// Dispatch a single host property binding to the correct Ivy instruction.
+///
+/// Returns `(statement, host_vars_added)`.
+///
+/// Supported targets:
+/// - `style.X`           → `ɵɵstyleProp("X", expr)` (+2 vars)
+/// - `style.X.unit`      → `ɵɵstyleProp("X", expr, "unit")` (+2 vars)
+/// - `class.X`           → `ɵɵclassProp("X", expr)` (+2 vars)
+/// - `class`             → `ɵɵclassMap(expr)` (+2 vars)
+/// - `attr.X`            → `ɵɵattribute("X", expr)` (+1 var)
+/// - bare property `X`   → `ɵɵproperty("X", expr)` (+1 var)
+pub fn dispatch_property_binding(
+    target: &str,
+    raw_expression: &str,
+    ng_import: &str,
+) -> (String, u32) {
+    let prefix = ng_prefix(ng_import);
+    let expr = compile_host_expression(raw_expression);
+
+    if let Some(rest) = target.strip_prefix("style.") {
+        // `style.width.px` → propName=width, unit=px
+        if let Some(dot) = rest.find('.') {
+            let prop = &rest[..dot];
+            let unit = &rest[dot + 1..];
+            (
+                format!("{prefix}\u{0275}\u{0275}styleProp(\"{prop}\", {expr}, \"{unit}\")"),
+                2,
+            )
+        } else {
+            (
+                format!("{prefix}\u{0275}\u{0275}styleProp(\"{rest}\", {expr})"),
+                2,
+            )
+        }
+    } else if let Some(class_name) = target.strip_prefix("class.") {
+        (
+            format!("{prefix}\u{0275}\u{0275}classProp(\"{class_name}\", {expr})"),
+            2,
+        )
+    } else if target == "class" {
+        (format!("{prefix}\u{0275}\u{0275}classMap({expr})"), 2)
+    } else if let Some(attr_name) = target.strip_prefix("attr.") {
+        (
+            format!("{prefix}\u{0275}\u{0275}attribute(\"{attr_name}\", {expr})"),
+            1,
+        )
+    } else {
+        (
+            format!("{prefix}\u{0275}\u{0275}property(\"{target}\", {expr})"),
+            1,
+        )
+    }
+}
+
+/// Dispatch a single host event listener to a `ɵɵlistener` call.
+///
+/// `raw_expression` is the handler invocation source (e.g. `"onClick($event)"`);
+/// it is run through [`compile_host_expression`] so component members are
+/// prefixed with `ctx.`.
+pub fn dispatch_listener(event: &str, raw_expression: &str, ng_import: &str) -> String {
+    let prefix = ng_prefix(ng_import);
+    let expr = compile_host_expression(raw_expression);
+    format!("{prefix}\u{0275}\u{0275}listener(\"{event}\", function($event) {{ return {expr}; }})")
+}
+
+/// Assemble the `hostBindings` function literal from already-dispatched
+/// statements. Returns `None` when both lists are empty.
+///
+/// Listeners are emitted under `if (rf & 1)` (creation) and bindings under
+/// `if (rf & 2)` (update) — matching Angular's compiler-cli output.
+pub fn build_host_bindings_function(
+    binding_stmts: &[String],
+    listener_stmts: &[String],
+) -> Option<String> {
+    if binding_stmts.is_empty() && listener_stmts.is_empty() {
+        return None;
+    }
+    let mut body = String::new();
+    if !listener_stmts.is_empty() {
+        body.push_str("if (rf & 1) { ");
+        for stmt in listener_stmts {
+            body.push_str(stmt);
+            body.push_str("; ");
+        }
+        body.push_str("} ");
+    }
+    if !binding_stmts.is_empty() {
+        body.push_str("if (rf & 2) { ");
+        for stmt in binding_stmts {
+            body.push_str(stmt);
+            body.push_str("; ");
+        }
+        body.push('}');
+    }
+    Some(format!("function(rf, ctx) {{ {body} }}"))
+}
+
+/// Compile a host binding expression by prefixing component property
+/// references with `ctx.` and stripping TypeScript-only syntax (the `!`
+/// non-null assertion, `$any(...)` template-DSL coercion).
+///
+/// Examples:
+/// - `"checked"` → `"ctx.checked"`
+/// - `"!!checked"` → `"!!ctx.checked"`
+/// - `"disabled || null"` → `"ctx.disabled || null"`
+/// - `"onChange($any($event.target).checked)"` → `"ctx.onChange($event.target.checked)"`
+pub fn compile_host_expression(expr: &str) -> String {
+    let wrapper = format!("var __expr = {expr};");
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, &wrapper, SourceType::tsx()).parse();
+
+    if !parsed.errors.is_empty() {
+        tracing::warn!("failed to parse host expression: {expr}");
+        return expr.to_string();
+    }
+
+    let init_expr = match &parsed.program.body.first() {
+        Some(oxc_ast::ast::Statement::VariableDeclaration(decl)) => {
+            decl.declarations.first().and_then(|d| d.init.as_ref())
+        }
+        _ => None,
+    };
+
+    let init_expr = match init_expr {
+        Some(e) => e,
+        None => return expr.to_string(),
+    };
+
+    let mut ctx_inserts: Vec<u32> = Vec::new();
+    let mut remove_ranges: Vec<(u32, u32)> = Vec::new();
+
+    collect_ctx_rewrites(init_expr, &mut ctx_inserts, &mut remove_ranges, false);
+
+    let expr_offset = "var __expr = ".len() as u32;
+
+    let mut result = expr.to_string();
+
+    ctx_inserts.sort_unstable();
+    ctx_inserts.dedup();
+
+    enum Edit {
+        Insert(u32),
+        Remove(u32, u32),
+    }
+    let mut edits: Vec<Edit> = Vec::with_capacity(ctx_inserts.len() + remove_ranges.len());
+    for off in &ctx_inserts {
+        edits.push(Edit::Insert(off - expr_offset));
+    }
+    for (s, e) in &remove_ranges {
+        edits.push(Edit::Remove(s - expr_offset, e - expr_offset));
+    }
+    edits.sort_by_key(|e| {
+        std::cmp::Reverse(match e {
+            Edit::Insert(p) => *p,
+            Edit::Remove(s, _) => *s,
+        })
+    });
+
+    for edit in edits {
+        match edit {
+            Edit::Insert(off) => {
+                let off = off as usize;
+                if off <= result.len() {
+                    result.insert_str(off, "ctx.");
+                }
+            }
+            Edit::Remove(s, e) => {
+                let (s, e) = (s as usize, e as usize);
+                if s <= result.len() && e <= result.len() {
+                    result.replace_range(s..e, "");
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Recursively collect identifier positions that need a `ctx.` prefix and
+/// TypeScript non-null assertion / `$any(...)` ranges to remove.
+fn collect_ctx_rewrites(
+    expr: &oxc_ast::ast::Expression<'_>,
+    ctx_inserts: &mut Vec<u32>,
+    remove_ranges: &mut Vec<(u32, u32)>,
+    is_member_property: bool,
+) {
+    use oxc_ast::ast::*;
+
+    fn is_builtin(name: &str) -> bool {
+        matches!(
+            name,
+            "null"
+                | "undefined"
+                | "true"
+                | "false"
+                | "NaN"
+                | "Infinity"
+                | "this"
+                | "Math"
+                | "Date"
+                | "JSON"
+                | "console"
+                | "window"
+                | "document"
+                | "Array"
+                | "Object"
+                | "String"
+                | "Number"
+                | "Boolean"
+                | "Error"
+                | "RegExp"
+                | "Symbol"
+                | "Promise"
+                | "Map"
+                | "Set"
+                | "$event"
+                | "ctx"
+        )
+    }
+
+    match expr {
+        Expression::Identifier(id) if !is_member_property && !is_builtin(&id.name) => {
+            ctx_inserts.push(id.span.start);
+        }
+        Expression::CallExpression(call) => {
+            if let Expression::Identifier(id) = &call.callee {
+                if id.name == "$any" && call.arguments.len() == 1 {
+                    if let Some(arg) = call.arguments.first() {
+                        if !matches!(arg, Argument::SpreadElement(_)) {
+                            let inner = arg.to_expression();
+                            remove_ranges.push((call.span.start, inner.span().start));
+                            remove_ranges.push((inner.span().end, call.span.end));
+                            collect_ctx_rewrites(
+                                inner,
+                                ctx_inserts,
+                                remove_ranges,
+                                is_member_property,
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
+            collect_ctx_rewrites(&call.callee, ctx_inserts, remove_ranges, false);
+            for arg in &call.arguments {
+                if let Argument::SpreadElement(spread) = arg {
+                    collect_ctx_rewrites(&spread.argument, ctx_inserts, remove_ranges, false);
+                } else {
+                    collect_ctx_rewrites(arg.to_expression(), ctx_inserts, remove_ranges, false);
+                }
+            }
+        }
+        Expression::StaticMemberExpression(member) => {
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ComputedMemberExpression(member) => {
+            collect_ctx_rewrites(&member.object, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&member.expression, ctx_inserts, remove_ranges, false);
+        }
+        Expression::UnaryExpression(unary) => {
+            collect_ctx_rewrites(&unary.argument, ctx_inserts, remove_ranges, false);
+        }
+        Expression::BinaryExpression(binary) => {
+            collect_ctx_rewrites(&binary.left, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&binary.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::LogicalExpression(logical) => {
+            collect_ctx_rewrites(&logical.left, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&logical.right, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ConditionalExpression(cond) => {
+            collect_ctx_rewrites(&cond.test, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.consequent, ctx_inserts, remove_ranges, false);
+            collect_ctx_rewrites(&cond.alternate, ctx_inserts, remove_ranges, false);
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            collect_ctx_rewrites(&paren.expression, ctx_inserts, remove_ranges, false);
+        }
+        Expression::TSNonNullExpression(non_null) => {
+            collect_ctx_rewrites(
+                &non_null.expression,
+                ctx_inserts,
+                remove_ranges,
+                is_member_property,
+            );
+            let inner_end = non_null.expression.span().end;
+            let outer_end = non_null.span.end;
+            if outer_end > inner_end {
+                remove_ranges.push((inner_end, outer_end));
+            }
+        }
+        Expression::TemplateLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_) => {}
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn property_dispatch_bare() {
+        let (stmt, vars) = dispatch_property_binding("disabled", "isDisabled", "i0");
+        assert_eq!(
+            stmt,
+            "i0.\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"
+        );
+        assert_eq!(vars, 1);
+    }
+
+    #[test]
+    fn property_dispatch_attr() {
+        let (stmt, vars) = dispatch_property_binding("attr.aria-label", "label", "i0");
+        assert_eq!(
+            stmt,
+            "i0.\u{0275}\u{0275}attribute(\"aria-label\", ctx.label)"
+        );
+        assert_eq!(vars, 1);
+    }
+
+    #[test]
+    fn property_dispatch_class_prop() {
+        let (stmt, vars) = dispatch_property_binding("class.active", "isActive", "i0");
+        assert_eq!(
+            stmt,
+            "i0.\u{0275}\u{0275}classProp(\"active\", ctx.isActive)"
+        );
+        assert_eq!(vars, 2);
+    }
+
+    #[test]
+    fn property_dispatch_class_map() {
+        let (stmt, vars) = dispatch_property_binding("class", "extraClasses", "i0");
+        assert_eq!(stmt, "i0.\u{0275}\u{0275}classMap(ctx.extraClasses)");
+        assert_eq!(vars, 2);
+    }
+
+    #[test]
+    fn property_dispatch_style_simple() {
+        let (stmt, vars) = dispatch_property_binding("style.color", "color", "i0");
+        assert_eq!(stmt, "i0.\u{0275}\u{0275}styleProp(\"color\", ctx.color)");
+        assert_eq!(vars, 2);
+    }
+
+    #[test]
+    fn property_dispatch_style_with_unit() {
+        let (stmt, vars) = dispatch_property_binding("style.width.px", "width", "i0");
+        assert_eq!(
+            stmt,
+            "i0.\u{0275}\u{0275}styleProp(\"width\", ctx.width, \"px\")"
+        );
+        assert_eq!(vars, 2);
+    }
+
+    #[test]
+    fn listener_dispatch_basic() {
+        let stmt = dispatch_listener("click", "onClick($event)", "i0");
+        assert_eq!(
+            stmt,
+            "i0.\u{0275}\u{0275}listener(\"click\", function($event) { return ctx.onClick($event); })"
+        );
+    }
+
+    #[test]
+    fn listener_dispatch_global_target() {
+        let stmt = dispatch_listener("window:resize", "onResize()", "i0");
+        assert_eq!(
+            stmt,
+            "i0.\u{0275}\u{0275}listener(\"window:resize\", function($event) { return ctx.onResize(); })"
+        );
+    }
+
+    #[test]
+    fn build_function_listener_only() {
+        let listener = vec![dispatch_listener("click", "onClick()", "i0")];
+        let out = build_host_bindings_function(&[], &listener).unwrap();
+        assert!(out.starts_with("function(rf, ctx) { if (rf & 1) {"));
+        assert!(!out.contains("if (rf & 2)"));
+    }
+
+    #[test]
+    fn build_function_binding_only() {
+        let (stmt, _) = dispatch_property_binding("attr.title", "title", "i0");
+        let out = build_host_bindings_function(&[stmt], &[]).unwrap();
+        assert!(!out.contains("if (rf & 1)"));
+        assert!(out.contains("if (rf & 2) {"));
+    }
+
+    #[test]
+    fn build_function_empty_returns_none() {
+        assert!(build_host_bindings_function(&[], &[]).is_none());
+    }
+
+    #[test]
+    fn ng_import_empty_omits_prefix() {
+        let (stmt, _) = dispatch_property_binding("disabled", "isDisabled", "");
+        assert_eq!(
+            stmt,
+            "\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"
+        );
+    }
+
+    #[test]
+    fn host_expression_simple_identifier() {
+        assert_eq!(compile_host_expression("checked"), "ctx.checked");
+    }
+
+    #[test]
+    fn host_expression_negation() {
+        assert_eq!(compile_host_expression("!!checked"), "!!ctx.checked");
+    }
+
+    #[test]
+    fn host_expression_logical() {
+        assert_eq!(
+            compile_host_expression("disabled || null"),
+            "ctx.disabled || null"
+        );
+    }
+
+    #[test]
+    fn host_expression_method_call() {
+        assert_eq!(
+            compile_host_expression("toastClasses()"),
+            "ctx.toastClasses()"
+        );
+    }
+
+    #[test]
+    fn host_expression_member_chain() {
+        assert_eq!(
+            compile_host_expression("_rangeInput.rangePicker ? \"dialog\" : null"),
+            "ctx._rangeInput.rangePicker ? \"dialog\" : null"
+        );
+    }
+
+    #[test]
+    fn host_expression_ts_non_null() {
+        assert_eq!(
+            compile_host_expression("_getMinDate()!"),
+            "ctx._getMinDate()"
+        );
+    }
+
+    #[test]
+    fn host_expression_any_in_listener() {
+        assert_eq!(
+            compile_host_expression("onChange($any($event.target).checked)"),
+            "ctx.onChange($event.target.checked)"
+        );
+    }
+
+    #[test]
+    fn host_expression_any_over_ctx() {
+        assert_eq!(
+            compile_host_expression("$any(ctx).foo.bar()"),
+            "ctx.foo.bar()"
+        );
+    }
+
+    #[test]
+    fn host_expression_any_bare_identifier() {
+        assert_eq!(compile_host_expression("$any(value)"), "ctx.value");
+    }
+
+    #[test]
+    fn host_expression_complex_ternary() {
+        let result = compile_host_expression(
+            "_getMinDate() ? _dateAdapter.toIso8601(_getMinDate()!) : null",
+        );
+        assert!(result.contains("ctx._getMinDate()"));
+        assert!(result.contains("ctx._dateAdapter.toIso8601"));
+        assert!(!result.contains("!)"));
+    }
+}

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -10,6 +10,7 @@ mod codegen;
 mod directive_codegen;
 mod extract;
 mod factory_codegen;
+pub mod host_codegen;
 pub mod i18n;
 mod injectable_codegen;
 mod ng_module_codegen;

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -837,6 +837,113 @@ export class DataService {
     }
 
     #[test]
+    fn test_directive_with_host_listener_and_binding_roundtrip() {
+        // Directive uses @HostListener for an event and @HostBinding for each
+        // target form documented in issue #58 — bare property, attr.X,
+        // class.Y, style.Z, style.Z.unit. The AOT output must emit the
+        // matching ɵɵ instructions inside `hostBindings`, with hostVars
+        // accumulated only across binding-update calls (listeners contribute 0).
+        let source = r#"import { Directive, HostListener, HostBinding } from '@angular/core';
+
+@Directive({ selector: '[appHost]', standalone: true })
+export class HostDirective {
+  @HostBinding('disabled') isDisabled = false;
+  @HostBinding('attr.aria-label') label = 'host';
+  @HostBinding('class.active') isActive = true;
+  @HostBinding('style.color') color = 'red';
+  @HostBinding('style.width.px') width = 100;
+
+  @HostListener('click', ['$event']) onClick($event: Event) {}
+}
+"#;
+        let path = PathBuf::from("host.directive.ts");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        assert!(result.compiled, "should be compiled");
+        let out = &result.source;
+
+        // Listener
+        assert!(
+            out.contains(
+                "\u{0275}\u{0275}listener(\"click\", function($event) { return ctx.onClick($event); })"
+            ),
+            "expected ɵɵlistener for click; got:\n{out}"
+        );
+        // Bare property → ɵɵproperty (1 var)
+        assert!(out.contains("\u{0275}\u{0275}property(\"disabled\", ctx.isDisabled)"));
+        // attr.X → ɵɵattribute (1 var)
+        assert!(out.contains("\u{0275}\u{0275}attribute(\"aria-label\", ctx.label)"));
+        // class.X → ɵɵclassProp (2 vars)
+        assert!(out.contains("\u{0275}\u{0275}classProp(\"active\", ctx.isActive)"));
+        // style.Y → ɵɵstyleProp without unit (2 vars)
+        assert!(out.contains("\u{0275}\u{0275}styleProp(\"color\", ctx.color)"));
+        // style.Y.px → ɵɵstyleProp with unit suffix (2 vars)
+        assert!(
+            out.contains("\u{0275}\u{0275}styleProp(\"width\", ctx.width, \"px\")"),
+            "expected style.X.unit to split off the unit; got:\n{out}"
+        );
+        // 1 + 1 + 2 + 2 + 2 = 8
+        assert!(
+            out.contains("hostVars: 8"),
+            "expected hostVars: 8 (no listener contribution); got:\n{out}"
+        );
+        assert!(out.contains("if (rf & 1)"));
+        assert!(out.contains("if (rf & 2)"));
+
+        // Imports must be expanded so the rewritten file pulls each Ivy symbol.
+        for sym in [
+            "\u{0275}\u{0275}listener",
+            "\u{0275}\u{0275}property",
+            "\u{0275}\u{0275}attribute",
+            "\u{0275}\u{0275}classProp",
+            "\u{0275}\u{0275}styleProp",
+        ] {
+            assert!(
+                out.contains(sym),
+                "expected import/use of {sym} in rewritten source; got:\n{out}"
+            );
+        }
+
+        // Rewritten source must still parse.
+        let js = ngc_ts_transform::transform_source(&result.source, "host.directive.ts")
+            .expect("oxc should parse compiled source");
+        assert!(js.contains("\u{0275}dir"));
+    }
+
+    #[test]
+    fn test_component_with_host_listener_roundtrip() {
+        // Issue #58 mentions treasr-frontend's portfolio.component.ts uses
+        // @HostListener for window resize. AOT output for a component must
+        // emit the listener inside hostBindings just like directives do.
+        let source = r#"import { Component, HostListener } from '@angular/core';
+
+@Component({ selector: 'app-portfolio', standalone: true, template: '' })
+export class PortfolioComponent {
+  @HostListener('window:resize') onResize() {}
+}
+"#;
+        let path = PathBuf::from("portfolio.component.ts");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        assert!(result.compiled);
+        let out = &result.source;
+        assert!(
+            out.contains(
+                "\u{0275}\u{0275}listener(\"window:resize\", function($event) { return ctx.onResize(); })"
+            ),
+            "expected window:resize listener; got:\n{out}"
+        );
+        assert!(out.contains("if (rf & 1)"));
+        assert!(out.contains("hostBindings:"));
+        // Listener-only: no hostVars emitted.
+        assert!(
+            !out.contains("hostVars"),
+            "listener-only component should not emit hostVars; got:\n{out}"
+        );
+        let js = ngc_ts_transform::transform_source(&result.source, "portfolio.component.ts")
+            .expect("oxc should parse");
+        assert!(js.contains("\u{0275}cmp"));
+    }
+
+    #[test]
     fn test_directive_roundtrip() {
         let source = r#"import { Directive, ElementRef } from '@angular/core';
 

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -122,6 +122,8 @@ pub fn generate_template_fn(
         inline_styles: Vec::new(),
         style_urls: Vec::new(),
         input_properties: Vec::new(),
+        host_listeners: Vec::new(),
+        host_bindings: Vec::new(),
         animations_source: None,
     };
 

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -154,6 +154,8 @@ mod tests {
             inline_styles: Vec::new(),
             style_urls: Vec::new(),
             input_properties: Vec::new(),
+            host_listeners: Vec::new(),
+            host_bindings: Vec::new(),
             animations_source: None,
         }
     }


### PR DESCRIPTION
Closes #58.

## Summary

- Adds AOT extraction of method-level `@HostListener(event[, args])` and field/property/getter-level `@HostBinding(target?)` decorators on project-local `@Component` and `@Directive` classes.
- Both decorator paths feed a new shared `host_codegen` module that dispatches each entry to the right Ivy instruction (`ɵɵlistener`, `ɵɵproperty`, `ɵɵattribute`, `ɵɵclassProp`, `ɵɵclassMap`, `ɵɵstyleProp`) and assembles the `hostBindings` function with the standard `if (rf & 1)` / `if (rf & 2)` guards. The linker's partial-declaration path was refactored to consume the same module so AOT and linker output match.
- Drive-by fix in the linker: `style.X.unit` (e.g. `style.width.px`) now splits the unit suffix into the third arg of `ɵɵstyleProp` so the renderer applies the unit (previously emitted as `ɵɵstyleProp("width.px", expr)`, silently no-op).

## Target forms covered

| Decorator                                              | Emitted instruction                                    | hostVars |
| ------------------------------------------------------ | ------------------------------------------------------ | -------- |
| `@HostListener('click', ['$event'])`                   | `ɵɵlistener("click", function($event) { ... })`        | 0        |
| `@HostBinding('disabled')`                             | `ɵɵproperty("disabled", ctx.x)`                        | 1        |
| `@HostBinding('attr.aria-label')`                      | `ɵɵattribute("aria-label", ctx.x)`                     | 1        |
| `@HostBinding('class.active')`                         | `ɵɵclassProp("active", ctx.x)`                         | 2        |
| `@HostBinding('style.color')`                          | `ɵɵstyleProp("color", ctx.x)`                          | 2        |
| `@HostBinding('style.width.px')`                       | `ɵɵstyleProp("width", ctx.x, "px")`                    | 2        |

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Unit tests in `extract.rs` for each decorator shape (event-only, with args, getter, no-arg).
- [x] Unit tests in `directive_codegen.rs` for each emit form including `style.Y.px`.
- [x] Unit tests in `host_codegen.rs` covering dispatch and `compile_host_expression` rewrites.
- [x] Parity tests in `crates/linker/src/directive.rs::tests` comparing AOT output to the linker's partial-declaration output for every target form.
- [x] End-to-end roundtrip tests in `crates/template-compiler/src/lib.rs` (`@Directive` with all binding forms; `@Component` with `window:resize` listener — the treasr-frontend `portfolio.component.ts` shape).
- [x] Manual: `ngc-rs build` of treasr-frontend confirms `portfolio.component.ts` `@HostListener` fires on window resize.