### PR TITLE
feat(cli): Angular service worker (ngsw-config.json → ngsw.json)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "base64",
  "clap",
@@ -679,6 +679,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tempfile",
  "tracing",
@@ -687,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -707,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.31"
+version = "0.7.32"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -566,27 +566,38 @@ fn worker_chunk_filename_from_path(path: &Path, root_dir: &Path) -> String {
 
 /// Derive a chunk filename from a split point's file path.
 ///
-/// Example: `/root/src/app/admin/admin.component.ts` → `"chunk-admin-component.js"`
-fn chunk_filename_from_path(path: &Path, root_dir: &Path) -> String {
-    let relative = path.strip_prefix(root_dir).unwrap_or(path);
-    let stem = relative.with_extension("");
-    let stem_str = stem.to_string_lossy();
-
-    // Take only the filename part (last component), sanitize it
-    let name = stem_str
-        .replace(['/', '\\'], "-")
-        .replace('.', "-")
-        .to_lowercase();
-
-    // Take the last two path segments for a more readable name
-    let parts: Vec<&str> = name.split('-').filter(|s| !s.is_empty()).collect();
-    let short_name = if parts.len() > 2 {
-        parts[parts.len() - 2..].join("-")
-    } else {
-        parts.join("-")
+/// Uses the file's basename stem (the filename without its trailing `.ts`/
+/// `.js` extension), replacing inner `.` separators with `-`. Parent
+/// directories are deliberately dropped — Angular convention puts each
+/// component in a directory matching its filename, so including the parent
+/// dir produces redundant `admin-admin-component`-style names.
+///
+/// Examples:
+/// - `/root/src/admin/admin.component.ts` → `"chunk-admin-component.js"`
+/// - `/root/src/dashboard/dashboard.routes.ts` → `"chunk-dashboard-routes.js"`
+/// - `/root/src/service-worker/service-worker.component.ts`
+///   → `"chunk-service-worker-component.js"`
+/// - `/root/src/lazy.ts` → `"chunk-lazy.js"`
+fn chunk_filename_from_path(path: &Path, _root_dir: &Path) -> String {
+    let basename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    // Strip the final extension only (e.g. `admin.component.ts` →
+    // `admin.component`). Then turn the remaining `.` separators into `-`
+    // so the basename `admin.component` becomes `admin-component` while
+    // `service-worker.component` becomes `service-worker-component`
+    // (instead of being truncated to a non-disambiguating `worker-component`).
+    let stem = match basename.rsplit_once('.') {
+        Some((stem, _ext)) => stem,
+        None => basename,
     };
-
-    format!("chunk-{short_name}.js")
+    let name = stem.replace('.', "-").to_lowercase();
+    if name.is_empty() {
+        "chunk.js".to_string()
+    } else {
+        format!("chunk-{name}.js")
+    }
 }
 
 #[cfg(test)]
@@ -745,6 +756,28 @@ mod tests {
             chunk_filename_from_path(Path::new("/root/src/lazy.ts"), root),
             "chunk-lazy.js"
         );
+    }
+
+    /// Regression: hyphenated basenames must not collapse to the same chunk
+    /// name. `service-worker.component.ts` and `web-worker.component.ts` are
+    /// both real routes in the test bed; the previous "last two dash-segments"
+    /// rule reduced both to `chunk-worker-component.js` and one silently
+    /// overwrote the other, leaving the route's `loadComponent` import
+    /// resolving to `undefined`.
+    #[test]
+    fn test_chunk_filename_disambiguates_hyphenated_basenames() {
+        let root = Path::new("/root/src");
+        let sw = chunk_filename_from_path(
+            Path::new("/root/src/service-worker/service-worker.component.ts"),
+            root,
+        );
+        let ww = chunk_filename_from_path(
+            Path::new("/root/src/web-worker/web-worker.component.ts"),
+            root,
+        );
+        assert_eq!(sw, "chunk-service-worker-component.js");
+        assert_eq!(ww, "chunk-web-worker-component.js");
+        assert_ne!(sw, ww);
     }
 
     #[test]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -43,6 +43,12 @@ pub struct BundleOptions {
     pub content_hash: bool,
     /// Perform tree shaking (unused export elimination).
     pub tree_shake: bool,
+    /// Inject Angular's build-time global flags (`ngDevMode`,
+    /// `ngI18nClosureMode`, `ngJitMode`) as `globalThis` assignments at the
+    /// top of `main.js`. Required so `@angular/core`'s `isDevMode()` returns
+    /// `false` in production bundles. (Does **not** dead-code-eliminate
+    /// dev-only branches — that's a separate define-substitution pass.)
+    pub inject_dev_mode_globals: bool,
 }
 
 /// Input to the bundler.
@@ -284,6 +290,20 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         }
     }
 
+    // Prepend Angular's build-time global flags to main.js so `isDevMode()`
+    // returns `false` at runtime. Done after minification so the minifier
+    // can't accidentally drop or rewrite the assignments; done before
+    // content-hashing so the hash reflects the final served bytes.
+    if input.options.inject_dev_mode_globals {
+        if let Some(main_code) = output_chunks.get_mut("main.js") {
+            let prologue = dev_mode_globals_prologue();
+            *main_code = format!("{prologue}{main_code}");
+            if let Some(map) = chunk_source_maps.get_mut("main.js") {
+                *map = shift_source_map_lines(map, 1);
+            }
+        }
+    }
+
     // Content-hash filenames
     let main_filename = if input.options.content_hash {
         apply_content_hashes(&mut output_chunks, &mut chunk_source_maps)?
@@ -296,6 +316,48 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         main_filename,
         chunk_source_maps,
     })
+}
+
+/// Synthetic single-line statement set to `false` for Angular's three
+/// well-known build-time flags. Prepended to `main.js` in production builds
+/// so `@angular/core`'s `isDevMode()` returns `false` at runtime, which in
+/// turn lets `provideServiceWorker(..., { enabled: !isDevMode() })` enable
+/// SW registration. This does not eliminate the dev-only branches from the
+/// bundle — that requires define-substitution + DCE (tracked separately).
+fn dev_mode_globals_prologue() -> String {
+    "globalThis.ngDevMode=false;globalThis.ngI18nClosureMode=false;globalThis.ngJitMode=false;\n"
+        .to_string()
+}
+
+/// Shift every token's `dst_line` down by `lines` so a source map stays
+/// aligned after a multi-line prologue is prepended to its chunk.
+fn shift_source_map_lines(map: &SourceMap, lines: u32) -> SourceMap {
+    let names: Vec<_> = map.get_names().cloned().collect();
+    let sources: Vec<_> = map.get_sources().cloned().collect();
+    let source_contents: Vec<Option<std::sync::Arc<str>>> =
+        map.get_source_contents().map(|opt| opt.cloned()).collect();
+    let tokens: Vec<oxc_sourcemap::Token> = map
+        .get_tokens()
+        .map(|t| {
+            oxc_sourcemap::Token::new(
+                t.get_dst_line() + lines,
+                t.get_dst_col(),
+                t.get_src_line(),
+                t.get_src_col(),
+                t.get_source_id(),
+                t.get_name_id(),
+            )
+        })
+        .collect();
+    SourceMap::new(
+        None,
+        names,
+        None,
+        sources,
+        source_contents,
+        tokens.into_boxed_slice(),
+        None,
+    )
 }
 
 /// Build a mapping from raw import specifiers (as they appear in source) to chunk filenames.
@@ -1114,6 +1176,78 @@ mod tests {
             .chunks
             .get(&output.main_filename)
             .expect("main chunk should exist")
+    }
+
+    #[test]
+    fn test_dev_mode_globals_prologue_in_production() {
+        let mut graph = DiGraph::new();
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+        let _ = entry;
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            make_path("/root/src/main.ts"),
+            "console.log('hi');\n".to_string(),
+        );
+
+        let input = BundleInput {
+            modules,
+            graph,
+            entry: make_path("/root/src/main.ts"),
+            local_prefixes: vec![".".to_string()],
+            root_dir: make_path("/root/src"),
+            options: BundleOptions {
+                inject_dev_mode_globals: true,
+                ..BundleOptions::default()
+            },
+            per_module_maps: HashMap::new(),
+            bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
+        };
+
+        let output = bundle(&input).expect("should bundle");
+        let main = main_chunk(&output);
+        // The synthetic prologue must be the first thing the JS engine
+        // executes so subsequent `typeof ngDevMode` reads see `false`
+        // (boolean), not `undefined`.
+        assert!(
+            main.starts_with("globalThis.ngDevMode=false;"),
+            "main.js should start with the dev-mode globals prologue, got: {:?}",
+            &main[..main.len().min(120)]
+        );
+        assert!(main.contains("globalThis.ngI18nClosureMode=false;"));
+        assert!(main.contains("globalThis.ngJitMode=false;"));
+    }
+
+    #[test]
+    fn test_dev_mode_globals_not_injected_when_disabled() {
+        let mut graph = DiGraph::new();
+        let _ = graph.add_node(make_path("/root/src/main.ts"));
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            make_path("/root/src/main.ts"),
+            "console.log('hi');\n".to_string(),
+        );
+
+        let input = BundleInput {
+            modules,
+            graph,
+            entry: make_path("/root/src/main.ts"),
+            local_prefixes: vec![".".to_string()],
+            root_dir: make_path("/root/src"),
+            options: BundleOptions::default(),
+            per_module_maps: HashMap::new(),
+            bundled_specifiers: HashSet::new(),
+            export_conditions: Vec::new(),
+        };
+
+        let output = bundle(&input).expect("should bundle");
+        let main = main_chunk(&output);
+        assert!(
+            !main.contains("globalThis.ngDevMode"),
+            "dev builds must not inject the prologue"
+        );
     }
 
     #[test]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ glob = "0.3"
 regex = "1.12"
 oxc_sourcemap = "6.1"
 sha2 = "0.10"
+sha1 = "0.10"
 base64 = "0.22"
 
 [dev-dependencies]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,7 @@ use ngc_project_resolver::angular_json::{
 use ngc_template_compiler::{StyleContext, StyleLanguage};
 
 mod localize;
+mod ngsw;
 
 /// Result of the bundled build pipeline.
 #[derive(serde::Serialize)]
@@ -614,6 +615,22 @@ fn run_build(
         .join("\n");
     if let Some(lp) = generate_third_party_licenses(&all_bundle_code, &config_dir, &out_dir)? {
         output_files.push(lp);
+    }
+
+    // Step 12.5: Service worker manifest (`ngsw.json`) when the project opts
+    // in via `architect.build.options.serviceWorker`. Hashing runs *after*
+    // every other writer so it sees the final filenames + contents.
+    if let Some(ref ap) = angular_project {
+        if ap.service_worker {
+            if localize {
+                tracing::warn!(
+                    "serviceWorker is enabled but --localize was passed; skipping ngsw.json (per-locale manifests are not yet supported)"
+                );
+            } else {
+                let ngsw_paths = generate_service_worker(ap, &out_dir, &config_dir)?;
+                output_files.extend(ngsw_paths);
+            }
+        }
     }
 
     // Step 13: --localize → fan the source-locale build out to
@@ -1452,6 +1469,30 @@ fn compute_sri_hash(path: &Path) -> NgcResult<String> {
 
 /// Scan the bundle's external imports, find LICENSE files in node_modules,
 /// and concatenate them into 3rdpartylicenses.txt.
+/// Build the `ngsw.json` manifest and copy the worker scripts into
+/// `out_dir`. Reads `architect.build.options.ngswConfigPath` (default
+/// `ngsw-config.json`), hashes every emitted file, and writes the manifest
+/// alongside the bundle. Returns the list of files written so they can be
+/// reported in the build summary.
+fn generate_service_worker(
+    project: &ResolvedAngularProject,
+    out_dir: &Path,
+    project_root: &Path,
+) -> NgcResult<Vec<PathBuf>> {
+    let span = tracing::info_span!("ngsw").entered();
+    let config = ngsw::load_config(&project.ngsw_config_path)?;
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    let mut paths = Vec::new();
+    paths.push(ngsw::generate_manifest(out_dir, &config, timestamp)?);
+    paths.extend(ngsw::copy_worker_scripts(out_dir, project_root)?);
+    drop(span);
+    Ok(paths)
+}
+
 fn generate_third_party_licenses(
     bundle_code: &str,
     project_root: &Path,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2302,4 +2302,165 @@ mod tests {
         let files = collect_relative_files(&out);
         insta::assert_snapshot!("public_folder_glob_output_subdir", files.join("\n"));
     }
+
+    /// End-to-end fixture: angular.json with `serviceWorker: true` plus a
+    /// minimal `ngsw-config.json` and a fake dist tree must produce a valid
+    /// `dist/ngsw.json` with hashes matching the actual served bytes.
+    #[test]
+    fn test_service_worker_pipeline_pwa_fixture() {
+        use ngc_project_resolver::angular_json::resolve_angular_project;
+        use sha1::{Digest, Sha1};
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let root = dir.path();
+
+        // Minimal angular.json that opts into the service-worker pipeline.
+        std::fs::write(
+            root.join("angular.json"),
+            r#"{
+                "projects": {
+                    "pwa": {
+                        "root": "",
+                        "sourceRoot": "src",
+                        "architect": {
+                            "build": {
+                                "options": {
+                                    "outputPath": "dist/pwa",
+                                    "tsConfig": "tsconfig.json",
+                                    "serviceWorker": true,
+                                    "ngswConfigPath": "ngsw-config.json"
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        // Minimal ngsw-config.json: an "app" prefetch group pulling the
+        // shell + JS, plus a "media" lazy group for assets.
+        std::fs::write(
+            root.join("ngsw-config.json"),
+            r#"{
+                "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+                "index": "/index.html",
+                "assetGroups": [
+                    {
+                        "name": "app",
+                        "installMode": "prefetch",
+                        "resources": {
+                            "files": ["/index.html", "/*.js", "/*.css"]
+                        }
+                    },
+                    {
+                        "name": "media",
+                        "installMode": "lazy",
+                        "updateMode": "prefetch",
+                        "resources": {
+                            "files": ["/assets/**"]
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        // Pre-populate the dist tree as if the bundler had already run.
+        let dist = root.join("dist").join("pwa");
+        std::fs::create_dir_all(dist.join("assets")).unwrap();
+        let index_bytes = b"<!doctype html><title>pwa</title>";
+        let main_bytes = b"console.log('main')";
+        let style_bytes = b"body { color: red; }";
+        let logo_bytes = b"<svg/>";
+        std::fs::write(dist.join("index.html"), index_bytes).unwrap();
+        std::fs::write(dist.join("main-ABCDE.js"), main_bytes).unwrap();
+        std::fs::write(dist.join("styles-FGHIJ.css"), style_bytes).unwrap();
+        std::fs::write(dist.join("assets").join("logo.svg"), logo_bytes).unwrap();
+
+        // Resolve angular.json: confirms the parser picked up serviceWorker.
+        let project = resolve_angular_project(&root.join("angular.json"), Some("pwa"), None)
+            .expect("resolve angular project");
+        assert!(project.service_worker);
+
+        // Run the full SW pipeline (load config + walk dist + emit manifest).
+        let ngsw_paths =
+            generate_service_worker(&project, &dist, root).expect("generate_service_worker");
+        assert!(!ngsw_paths.is_empty(), "should write at least ngsw.json");
+
+        let manifest_path = dist.join("ngsw.json");
+        assert!(manifest_path.is_file(), "ngsw.json must exist");
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap())
+                .expect("ngsw.json parses as JSON");
+
+        // Required Angular SW protocol fields.
+        assert_eq!(manifest["configVersion"], 1);
+        assert_eq!(manifest["index"], "/index.html");
+        assert!(manifest["timestamp"].as_u64().is_some());
+        assert_eq!(manifest["navigationRequestStrategy"], "performance");
+        assert!(manifest["navigationUrls"].is_array());
+        assert!(!manifest["navigationUrls"].as_array().unwrap().is_empty());
+
+        // assetGroups is shaped as Angular expects.
+        let groups = manifest["assetGroups"].as_array().expect("assetGroups");
+        assert_eq!(groups.len(), 2);
+        let app = &groups[0];
+        assert_eq!(app["name"], "app");
+        assert_eq!(app["installMode"], "prefetch");
+        assert_eq!(app["updateMode"], "prefetch");
+        let app_urls: Vec<&str> = app["urls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(app_urls.contains(&"/index.html"));
+        assert!(app_urls.contains(&"/main-ABCDE.js"));
+        assert!(app_urls.contains(&"/styles-FGHIJ.css"));
+
+        let media = &groups[1];
+        assert_eq!(media["name"], "media");
+        assert_eq!(media["installMode"], "lazy");
+        assert_eq!(media["updateMode"], "prefetch");
+        let media_urls: Vec<&str> = media["urls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(media_urls, vec!["/assets/logo.svg"]);
+
+        // hashTable hashes must equal the SHA-1 of the actual served bytes.
+        let table = manifest["hashTable"].as_object().expect("hashTable");
+        let expect_sha1 = |bytes: &[u8]| -> String {
+            let mut h = Sha1::new();
+            h.update(bytes);
+            let digest = h.finalize();
+            digest.iter().fold(String::new(), |mut acc, b| {
+                acc.push_str(&format!("{b:02x}"));
+                acc
+            })
+        };
+        assert_eq!(
+            table["/index.html"].as_str().unwrap(),
+            expect_sha1(index_bytes)
+        );
+        assert_eq!(
+            table["/main-ABCDE.js"].as_str().unwrap(),
+            expect_sha1(main_bytes)
+        );
+        assert_eq!(
+            table["/styles-FGHIJ.css"].as_str().unwrap(),
+            expect_sha1(style_bytes)
+        );
+        assert_eq!(
+            table["/assets/logo.svg"].as_str().unwrap(),
+            expect_sha1(logo_bytes)
+        );
+        // Every URL in any group must have a hashTable entry.
+        for url in app_urls.iter().chain(media_urls.iter()) {
+            assert!(table.contains_key(*url), "missing hash for {url}");
+        }
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -922,6 +922,7 @@ fn build_options(configuration: Option<&str>) -> BundleOptions {
             minify: true,
             content_hash: true,
             tree_shake: true,
+            inject_dev_mode_globals: true,
         },
         _ => BundleOptions::default(),
     }
@@ -2193,6 +2194,7 @@ mod tests {
         assert!(opts.minify);
         assert!(opts.content_hash);
         assert!(opts.tree_shake);
+        assert!(opts.inject_dev_mode_globals);
     }
 
     #[test]
@@ -2202,6 +2204,7 @@ mod tests {
         assert!(!opts.minify);
         assert!(!opts.content_hash);
         assert!(!opts.tree_shake);
+        assert!(!opts.inject_dev_mode_globals);
     }
 
     #[test]
@@ -2211,6 +2214,7 @@ mod tests {
         assert!(!opts.minify);
         assert!(!opts.content_hash);
         assert!(!opts.tree_shake);
+        assert!(!opts.inject_dev_mode_globals);
     }
 
     #[test]

--- a/crates/cli/src/ngsw.rs
+++ b/crates/cli/src/ngsw.rs
@@ -1,0 +1,849 @@
+//! Angular service-worker manifest (`ngsw.json`) generation.
+//!
+//! Reads `ngsw-config.json`, walks the populated `dist/` tree, hashes every
+//! file matched by an `assetGroups` pattern (SHA-1 hex per Angular's spec),
+//! and emits `dist/ngsw.json` plus copies of the worker scripts from
+//! `node_modules/@angular/service-worker/`.
+//!
+//! Pattern syntax mirrors Angular's `@angular/service-worker/config`:
+//! a leading `/` anchors at the dist root, `**` matches any number of path
+//! segments, `*` matches one segment, `?` matches a single non-`/` char,
+//! `(a|b)` denotes alternation, and a leading `!` negates a pattern.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+
+// ---------------------------------------------------------------------------
+// Raw deserialization types (match ngsw-config.json shape)
+// ---------------------------------------------------------------------------
+
+/// Top-level structure of `ngsw-config.json`. Unknown fields (e.g. `$schema`)
+/// are silently ignored.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NgswConfig {
+    /// Path to the entry HTML document, used by SwUpdate as the navigation
+    /// fallback. Defaults to `/index.html` when absent.
+    #[serde(default)]
+    pub index: Option<String>,
+    /// Asset cache groups (typically the app shell + lazy assets).
+    #[serde(default)]
+    pub asset_groups: Vec<AssetGroup>,
+    /// Data cache groups (API responses, etc.).
+    #[serde(default)]
+    pub data_groups: Vec<DataGroup>,
+    /// Patterns describing which navigation URLs the SW should serve
+    /// `index.html` for. Defaults to `["/**"]` minus any URL with a file
+    /// extension or that contains `__`.
+    #[serde(default)]
+    pub navigation_urls: Option<Vec<String>>,
+    /// `"performance"` (default) or `"freshness"`.
+    #[serde(default)]
+    pub navigation_request_strategy: Option<String>,
+}
+
+/// One `assetGroups[]` entry in `ngsw-config.json`.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetGroup {
+    /// Logical group name (e.g. `"app"`).
+    pub name: String,
+    /// `"prefetch"` or `"lazy"`. Defaults to `"prefetch"`.
+    #[serde(default)]
+    pub install_mode: Option<String>,
+    /// `"prefetch"` or `"lazy"`. Defaults to the value of `installMode`.
+    #[serde(default)]
+    pub update_mode: Option<String>,
+    /// Resource matchers — `files` (local globs) and `urls` (remote URLs).
+    #[serde(default)]
+    pub resources: Resources,
+    /// `cacheQueryOptions.ignoreVary` flag (defaults to `true` upstream).
+    #[serde(default)]
+    pub cache_query_options: Option<CacheQueryOptions>,
+}
+
+/// Resource matchers inside an asset/data group.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct Resources {
+    /// Glob-like patterns for files included in the group.
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// Remote URL patterns. Stored verbatim — never hashed.
+    #[serde(default)]
+    pub urls: Vec<String>,
+}
+
+/// One `dataGroups[]` entry in `ngsw-config.json`.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DataGroup {
+    /// Logical group name.
+    pub name: String,
+    /// URL patterns this group caches.
+    #[serde(default)]
+    pub urls: Vec<String>,
+    /// Numeric version used to invalidate the data cache.
+    #[serde(default)]
+    pub version: Option<u32>,
+    /// Cache-config block (size, age, strategy).
+    #[serde(default)]
+    pub cache_config: CacheConfig,
+}
+
+/// `dataGroups[].cacheConfig` block.
+#[derive(Debug, Deserialize, Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheConfig {
+    /// Maximum number of entries kept in the cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_size: Option<u64>,
+    /// Maximum age of cache entries (Angular duration string).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_age: Option<String>,
+    /// Network-timeout before falling back to cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<String>,
+    /// `"performance"` or `"freshness"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+}
+
+/// `cacheQueryOptions` block.
+#[derive(Debug, Deserialize, Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheQueryOptions {
+    /// Whether to ignore the `Vary` header when matching cached responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_vary: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Output (ngsw.json) types
+// ---------------------------------------------------------------------------
+
+/// Compiled `ngsw.json` manifest written into `dist/`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NgswManifest {
+    /// Always `1` for the current Angular SW protocol.
+    pub config_version: u32,
+    /// Build-time epoch milliseconds. Drives version comparison in the SW.
+    pub timestamp: u64,
+    /// Navigation fallback URL.
+    pub index: String,
+    /// Compiled asset groups with concrete `urls` lists.
+    pub asset_groups: Vec<CompiledAssetGroup>,
+    /// Data groups (regex-compiled patterns).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub data_groups: Vec<CompiledDataGroup>,
+    /// Regex objects describing which paths are SPA navigation requests.
+    pub navigation_urls: Vec<NavigationUrl>,
+    /// `"performance"` or `"freshness"`.
+    pub navigation_request_strategy: String,
+    /// Map of asset URL → SHA-1 hex digest.
+    pub hash_table: BTreeMap<String, String>,
+}
+
+/// A fully resolved asset group ready for the SW runtime.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompiledAssetGroup {
+    /// Group name carried over from the config.
+    pub name: String,
+    /// `"prefetch"` or `"lazy"`.
+    pub install_mode: String,
+    /// `"prefetch"` or `"lazy"`.
+    pub update_mode: String,
+    /// `cacheQueryOptions` with sensible defaults.
+    pub cache_query_options: CacheQueryOptions,
+    /// Concrete URLs (root-relative) that match the file patterns.
+    pub urls: Vec<String>,
+    /// Regex strings derived from the original `urls`/external patterns.
+    pub patterns: Vec<String>,
+}
+
+/// A fully resolved data group ready for the SW runtime.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompiledDataGroup {
+    /// Group name carried over from the config.
+    pub name: String,
+    /// Numeric version (defaults to `1`).
+    pub version: u32,
+    /// `cacheQueryOptions` with sensible defaults.
+    pub cache_query_options: CacheQueryOptions,
+    /// Regex strings derived from the original `urls`.
+    pub patterns: Vec<String>,
+    /// Cache-config (max age, size, strategy).
+    pub cache_config: SerializedCacheConfig,
+}
+
+/// Cache-config with defaults filled in for serialization.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedCacheConfig {
+    /// Maximum number of entries.
+    pub max_size: u64,
+    /// Maximum entry age.
+    pub max_age: String,
+    /// Network timeout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<String>,
+    /// `"performance"` or `"freshness"`.
+    pub strategy: String,
+}
+
+/// One entry in `navigationUrls`.
+#[derive(Debug, Serialize)]
+pub struct NavigationUrl {
+    /// `true` for include patterns, `false` for excludes.
+    pub positive: bool,
+    /// Regex source string.
+    pub regex: String,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Load `ngsw-config.json` from disk.
+pub fn load_config(path: &Path) -> NgcResult<NgswConfig> {
+    let content = std::fs::read_to_string(path).map_err(|e| NgcError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    serde_json::from_str(&content).map_err(|e| NgcError::ConfigError {
+        message: format!(
+            "failed to parse ngsw-config.json at {}: {e}",
+            path.display()
+        ),
+    })
+}
+
+/// Generate `dist/ngsw.json` from the populated `dist_dir` and the loaded
+/// service-worker config. Returns the path that was written.
+///
+/// `timestamp` is injected so callers (notably tests) can produce stable
+/// output. Production callers pass the wall-clock epoch ms.
+pub fn generate_manifest(
+    dist_dir: &Path,
+    config: &NgswConfig,
+    timestamp: u64,
+) -> NgcResult<PathBuf> {
+    // Collect every file under dist/, indexed by root-relative URL.
+    let entries = collect_dist_entries(dist_dir)?;
+
+    let mut hash_table: BTreeMap<String, String> = BTreeMap::new();
+    let mut already_assigned: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Build asset groups: walk patterns, materialize matching URLs, hash each.
+    let mut compiled_asset_groups = Vec::with_capacity(config.asset_groups.len());
+    for group in &config.asset_groups {
+        let install_mode = group
+            .install_mode
+            .clone()
+            .unwrap_or_else(|| "prefetch".into());
+        let update_mode = group
+            .update_mode
+            .clone()
+            .unwrap_or_else(|| install_mode.clone());
+
+        let (positive, negative) = compile_file_patterns(&group.resources.files)?;
+        let mut urls: Vec<String> = Vec::new();
+        for entry in &entries {
+            if !pattern_matches(&entry.url, &positive, &negative) {
+                continue;
+            }
+            // First group to claim a URL owns it (Angular's behavior — once an
+            // asset is in a prefetch group, later groups don't re-list it).
+            if already_assigned.contains(&entry.url) {
+                continue;
+            }
+            already_assigned.insert(entry.url.clone());
+            urls.push(entry.url.clone());
+            hash_table.insert(entry.url.clone(), entry.hash.clone());
+        }
+        urls.sort();
+
+        let patterns: Vec<String> = group
+            .resources
+            .urls
+            .iter()
+            .map(|u| url_pattern_to_regex(u))
+            .collect();
+
+        compiled_asset_groups.push(CompiledAssetGroup {
+            name: group.name.clone(),
+            install_mode,
+            update_mode,
+            cache_query_options: resolve_cache_query_options(group.cache_query_options.as_ref()),
+            urls,
+            patterns,
+        });
+    }
+
+    let mut compiled_data_groups = Vec::with_capacity(config.data_groups.len());
+    for group in &config.data_groups {
+        let patterns: Vec<String> = group.urls.iter().map(|u| url_pattern_to_regex(u)).collect();
+        compiled_data_groups.push(CompiledDataGroup {
+            name: group.name.clone(),
+            version: group.version.unwrap_or(1),
+            cache_query_options: CacheQueryOptions {
+                ignore_vary: Some(true),
+            },
+            patterns,
+            cache_config: SerializedCacheConfig {
+                max_size: group.cache_config.max_size.unwrap_or(0),
+                max_age: group
+                    .cache_config
+                    .max_age
+                    .clone()
+                    .unwrap_or_else(|| "0u".to_string()),
+                timeout: group.cache_config.timeout.clone(),
+                strategy: group
+                    .cache_config
+                    .strategy
+                    .clone()
+                    .unwrap_or_else(|| "performance".to_string()),
+            },
+        });
+    }
+
+    let navigation_urls = build_navigation_urls(config.navigation_urls.as_deref());
+    let navigation_request_strategy = config
+        .navigation_request_strategy
+        .clone()
+        .unwrap_or_else(|| "performance".to_string());
+
+    let manifest = NgswManifest {
+        config_version: 1,
+        timestamp,
+        index: config.index.clone().unwrap_or_else(|| "/index.html".into()),
+        asset_groups: compiled_asset_groups,
+        data_groups: compiled_data_groups,
+        navigation_urls,
+        navigation_request_strategy,
+        hash_table,
+    };
+
+    let out_path = dist_dir.join("ngsw.json");
+    let json = serde_json::to_string_pretty(&manifest).map_err(|e| NgcError::JsonOutputError {
+        message: format!("ngsw.json: {e}"),
+    })?;
+    std::fs::write(&out_path, json).map_err(|e| NgcError::Io {
+        path: out_path.clone(),
+        source: e,
+    })?;
+    Ok(out_path)
+}
+
+/// Copy `ngsw-worker.js` (and optionally `safety-worker.js`) from
+/// `node_modules/@angular/service-worker/` into `dist_dir`. Returns the
+/// list of files written. Missing source files are silently skipped — apps
+/// without `@angular/service-worker` installed simply get an `ngsw.json`
+/// without the worker script (the issue's DoD only requires the manifest).
+pub fn copy_worker_scripts(dist_dir: &Path, project_root: &Path) -> NgcResult<Vec<PathBuf>> {
+    let mut copied = Vec::new();
+    let sw_dir = project_root
+        .join("node_modules")
+        .join("@angular")
+        .join("service-worker");
+    for name in ["ngsw-worker.js", "safety-worker.js"] {
+        let src = sw_dir.join(name);
+        if !src.is_file() {
+            continue;
+        }
+        let dst = dist_dir.join(name);
+        std::fs::copy(&src, &dst).map_err(|e| NgcError::Io {
+            path: dst.clone(),
+            source: e,
+        })?;
+        copied.push(dst);
+    }
+    Ok(copied)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct DistEntry {
+    url: String,
+    hash: String,
+}
+
+/// Walk `dist_dir` recursively, hashing every file. Skips the manifest itself
+/// and the worker scripts, which must not be cached as content.
+fn collect_dist_entries(dist_dir: &Path) -> NgcResult<Vec<DistEntry>> {
+    let mut out = Vec::new();
+    walk_dir(dist_dir, dist_dir, &mut out)?;
+    out.sort_by(|a, b| a.url.cmp(&b.url));
+    Ok(out)
+}
+
+fn walk_dir(root: &Path, dir: &Path, out: &mut Vec<DistEntry>) -> NgcResult<()> {
+    let entries = std::fs::read_dir(dir).map_err(|e| NgcError::Io {
+        path: dir.to_path_buf(),
+        source: e,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| NgcError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| NgcError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        if file_type.is_dir() {
+            walk_dir(root, &path, out)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        // Don't hash files we're about to write or that the SW must not
+        // cache (the worker scripts themselves and any prior manifest).
+        if matches!(name, "ngsw.json" | "ngsw-worker.js" | "safety-worker.js") {
+            continue;
+        }
+        let rel = path.strip_prefix(root).unwrap_or(&path);
+        let mut url = String::from("/");
+        for (i, comp) in rel.components().enumerate() {
+            if i > 0 {
+                url.push('/');
+            }
+            url.push_str(&comp.as_os_str().to_string_lossy());
+        }
+        let bytes = std::fs::read(&path).map_err(|e| NgcError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        let mut hasher = Sha1::new();
+        hasher.update(&bytes);
+        let hash = hex_lower(&hasher.finalize());
+        out.push(DistEntry { url, hash });
+    }
+    Ok(())
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+/// Compile `files` patterns into positive and negative regex sets.
+/// Patterns prefixed with `!` are treated as negations.
+fn compile_file_patterns(patterns: &[String]) -> NgcResult<(Vec<Regex>, Vec<Regex>)> {
+    let mut positive = Vec::new();
+    let mut negative = Vec::new();
+    for pat in patterns {
+        let (negate, body) = match pat.strip_prefix('!') {
+            Some(rest) => (true, rest),
+            None => (false, pat.as_str()),
+        };
+        let re_src = glob_to_regex(body);
+        let re = Regex::new(&re_src).map_err(|e| NgcError::ConfigError {
+            message: format!("ngsw-config.json: invalid pattern {pat:?}: {e}"),
+        })?;
+        if negate {
+            negative.push(re);
+        } else {
+            positive.push(re);
+        }
+    }
+    Ok((positive, negative))
+}
+
+fn pattern_matches(url: &str, positive: &[Regex], negative: &[Regex]) -> bool {
+    if !positive.iter().any(|r| r.is_match(url)) {
+        return false;
+    }
+    if negative.iter().any(|r| r.is_match(url)) {
+        return false;
+    }
+    true
+}
+
+/// Translate Angular's glob syntax to a regex anchored over a full URL.
+///
+/// This handles `**`, `*`, `?`, `(a|b)` alt groups, `[chars]` classes, and
+/// escapes regex metacharacters. Patterns without a leading `/` are treated
+/// as anchored to dist root with an implicit `**/` prefix (matches Angular's
+/// "match anywhere" semantics).
+fn glob_to_regex(pattern: &str) -> String {
+    let mut out = String::from("^");
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut i = 0;
+    let leading_slash = pattern.starts_with('/');
+    if !leading_slash {
+        // Implicit "match anywhere": prepend (?:.*/)? so the pattern can match
+        // a path segment at any depth. Angular's compiler does the same for
+        // un-anchored patterns.
+        out.push_str("(?:/.*)?/");
+    }
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '*' => {
+                if i + 1 < chars.len() && chars[i + 1] == '*' {
+                    out.push_str(".*");
+                    i += 2;
+                } else {
+                    out.push_str("[^/]*");
+                    i += 1;
+                }
+            }
+            '?' => {
+                out.push_str("[^/]");
+                i += 1;
+            }
+            '(' | ')' | '|' => {
+                out.push(c);
+                i += 1;
+            }
+            '[' => {
+                // Pass through [..] character class, escaping nothing.
+                let mut j = i + 1;
+                out.push('[');
+                while j < chars.len() && chars[j] != ']' {
+                    out.push(chars[j]);
+                    j += 1;
+                }
+                if j < chars.len() {
+                    out.push(']');
+                    i = j + 1;
+                } else {
+                    // Unterminated class: leave verbatim.
+                    i = j;
+                }
+            }
+            '.' | '+' | '$' | '^' | '{' | '}' | '\\' => {
+                out.push('\\');
+                out.push(c);
+                i += 1;
+            }
+            _ => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    out.push('$');
+    out
+}
+
+/// Translate a remote URL pattern (used in `urls` arrays of asset/data
+/// groups) into a regex. Same rules as `glob_to_regex`, but without the
+/// leading-slash anchoring tweak — these patterns are matched against full
+/// URLs by the SW runtime.
+fn url_pattern_to_regex(pattern: &str) -> String {
+    glob_to_regex(pattern)
+}
+
+fn resolve_cache_query_options(opts: Option<&CacheQueryOptions>) -> CacheQueryOptions {
+    let ignore_vary = opts.and_then(|o| o.ignore_vary).unwrap_or(true);
+    CacheQueryOptions {
+        ignore_vary: Some(ignore_vary),
+    }
+}
+
+/// Build the `navigationUrls` list — applying Angular's defaults when none
+/// are configured. The defaults are: include everything, but exclude any URL
+/// that contains a file extension or `__`.
+fn build_navigation_urls(configured: Option<&[String]>) -> Vec<NavigationUrl> {
+    let patterns: Vec<String> = match configured {
+        Some(p) if !p.is_empty() => p.iter().map(String::from).collect(),
+        _ => vec![
+            "/**".to_string(),
+            "!/**/*.*".to_string(),
+            "!/**/*__*".to_string(),
+            "!/**/*__*/**".to_string(),
+        ],
+    };
+    patterns
+        .into_iter()
+        .map(|raw| {
+            let (positive, body) = match raw.strip_prefix('!') {
+                Some(rest) => (false, rest.to_string()),
+                None => (true, raw),
+            };
+            NavigationUrl {
+                positive,
+                regex: glob_to_regex(&body),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, body: &str) {
+        if let Some(p) = path.parent() {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn glob_root_double_star_matches_nested() {
+        let re = Regex::new(&glob_to_regex("/**")).unwrap();
+        assert!(re.is_match("/index.html"));
+        assert!(re.is_match("/assets/icon.png"));
+        assert!(re.is_match("/a/b/c.txt"));
+    }
+
+    #[test]
+    fn glob_single_star_does_not_cross_slash() {
+        let re = Regex::new(&glob_to_regex("/*.js")).unwrap();
+        assert!(re.is_match("/main.js"));
+        assert!(!re.is_match("/sub/main.js"));
+    }
+
+    #[test]
+    fn glob_alt_group() {
+        let re = Regex::new(&glob_to_regex("/*.(svg|png|jpg)")).unwrap();
+        assert!(re.is_match("/icon.svg"));
+        assert!(re.is_match("/photo.jpg"));
+        assert!(!re.is_match("/main.js"));
+    }
+
+    #[test]
+    fn negative_pattern_excludes() {
+        let (pos, neg) =
+            compile_file_patterns(&["/**".to_string(), "!/3rdpartylicenses.txt".to_string()])
+                .unwrap();
+        assert!(pattern_matches("/index.html", &pos, &neg));
+        assert!(!pattern_matches("/3rdpartylicenses.txt", &pos, &neg));
+    }
+
+    #[test]
+    fn generate_manifest_hashes_assets() {
+        let dir = tempfile::tempdir().unwrap();
+        let dist = dir.path();
+        write(&dist.join("index.html"), "<!doctype html><title>x</title>");
+        write(&dist.join("main-ABCD.js"), "console.log('hi')");
+        write(&dist.join("assets/logo.svg"), "<svg/>");
+
+        let config = NgswConfig {
+            index: Some("/index.html".into()),
+            asset_groups: vec![
+                AssetGroup {
+                    name: "app".into(),
+                    install_mode: Some("prefetch".into()),
+                    update_mode: None,
+                    resources: Resources {
+                        files: vec!["/index.html".into(), "/*.js".into(), "/*.css".into()],
+                        urls: vec![],
+                    },
+                    cache_query_options: None,
+                },
+                AssetGroup {
+                    name: "assets".into(),
+                    install_mode: Some("lazy".into()),
+                    update_mode: Some("prefetch".into()),
+                    resources: Resources {
+                        files: vec!["/assets/**".into()],
+                        urls: vec![],
+                    },
+                    cache_query_options: None,
+                },
+            ],
+            data_groups: vec![],
+            navigation_urls: None,
+            navigation_request_strategy: None,
+        };
+
+        let path = generate_manifest(dist, &config, 1_700_000_000_000).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["configVersion"], 1);
+        assert_eq!(parsed["index"], "/index.html");
+        assert_eq!(parsed["timestamp"], 1_700_000_000_000_u64);
+
+        // Asset groups carry resolved URL lists.
+        let groups = parsed["assetGroups"].as_array().unwrap();
+        let app_urls = groups[0]["urls"].as_array().unwrap();
+        let app_url_strs: Vec<&str> = app_urls.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(app_url_strs.contains(&"/index.html"));
+        assert!(app_url_strs.contains(&"/main-ABCD.js"));
+        let asset_urls = groups[1]["urls"].as_array().unwrap();
+        assert_eq!(asset_urls[0], "/assets/logo.svg");
+
+        // hashTable contains every URL with a 40-char SHA-1 hex value.
+        let table = parsed["hashTable"].as_object().unwrap();
+        assert_eq!(table.len(), 3);
+        for v in table.values() {
+            assert_eq!(v.as_str().unwrap().len(), 40);
+            assert!(v.as_str().unwrap().chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn url_only_owned_by_first_matching_group() {
+        // /index.html matches both groups' patterns; the first should claim it.
+        let dir = tempfile::tempdir().unwrap();
+        let dist = dir.path();
+        write(&dist.join("index.html"), "x");
+
+        let config = NgswConfig {
+            index: Some("/index.html".into()),
+            asset_groups: vec![
+                AssetGroup {
+                    name: "app".into(),
+                    install_mode: Some("prefetch".into()),
+                    update_mode: None,
+                    resources: Resources {
+                        files: vec!["/index.html".into()],
+                        urls: vec![],
+                    },
+                    cache_query_options: None,
+                },
+                AssetGroup {
+                    name: "fallback".into(),
+                    install_mode: Some("lazy".into()),
+                    update_mode: None,
+                    resources: Resources {
+                        files: vec!["/**".into()],
+                        urls: vec![],
+                    },
+                    cache_query_options: None,
+                },
+            ],
+            data_groups: vec![],
+            navigation_urls: None,
+            navigation_request_strategy: None,
+        };
+        let path = generate_manifest(dist, &config, 0).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let app_urls: Vec<&str> = parsed["assetGroups"][0]["urls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        let fallback_urls: Vec<&str> = parsed["assetGroups"][1]["urls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(app_urls, vec!["/index.html"]);
+        assert!(fallback_urls.is_empty());
+    }
+
+    #[test]
+    fn manifest_skips_self_and_worker_scripts() {
+        let dir = tempfile::tempdir().unwrap();
+        let dist = dir.path();
+        write(&dist.join("index.html"), "x");
+        write(&dist.join("ngsw.json"), "{}"); // stale manifest from prior run
+        write(&dist.join("ngsw-worker.js"), "// worker");
+
+        let config = NgswConfig {
+            index: Some("/index.html".into()),
+            asset_groups: vec![AssetGroup {
+                name: "app".into(),
+                install_mode: Some("prefetch".into()),
+                update_mode: None,
+                resources: Resources {
+                    files: vec!["/**".into()],
+                    urls: vec![],
+                },
+                cache_query_options: None,
+            }],
+            data_groups: vec![],
+            navigation_urls: None,
+            navigation_request_strategy: None,
+        };
+        generate_manifest(dist, &config, 0).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dist.join("ngsw.json")).unwrap())
+                .unwrap();
+        let urls: Vec<&str> = parsed["assetGroups"][0]["urls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(urls, vec!["/index.html"]);
+    }
+
+    #[test]
+    fn data_groups_compile_to_regex_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        let dist = dir.path();
+        write(&dist.join("index.html"), "x");
+        let config = NgswConfig {
+            index: Some("/index.html".into()),
+            asset_groups: vec![],
+            data_groups: vec![DataGroup {
+                name: "api".into(),
+                urls: vec!["/api/**".into()],
+                version: Some(1),
+                cache_config: CacheConfig {
+                    max_size: Some(100),
+                    max_age: Some("3d".into()),
+                    timeout: Some("10s".into()),
+                    strategy: Some("freshness".into()),
+                },
+            }],
+            navigation_urls: None,
+            navigation_request_strategy: None,
+        };
+        generate_manifest(dist, &config, 0).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dist.join("ngsw.json")).unwrap())
+                .unwrap();
+        let dg = &parsed["dataGroups"][0];
+        assert_eq!(dg["name"], "api");
+        assert_eq!(dg["version"], 1);
+        assert_eq!(dg["cacheConfig"]["strategy"], "freshness");
+        assert_eq!(dg["cacheConfig"]["maxSize"], 100);
+        assert!(dg["patterns"][0].as_str().unwrap().contains("/api"));
+    }
+
+    #[test]
+    fn default_navigation_urls_include_root_exclude_extensions() {
+        let urls = build_navigation_urls(None);
+        assert!(urls.iter().any(|u| u.positive));
+        assert!(urls.iter().any(|u| !u.positive));
+    }
+
+    #[test]
+    fn load_config_parses_minimal_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ngsw-config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "index": "/index.html",
+                "assetGroups": [
+                    { "name": "app", "installMode": "prefetch",
+                      "resources": { "files": ["/index.html"] } }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.index.as_deref(), Some("/index.html"));
+        assert_eq!(config.asset_groups.len(), 1);
+        assert_eq!(config.asset_groups[0].name, "app");
+    }
+}

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -140,6 +140,13 @@ pub struct RawBuildOptions {
     /// `less`, or `stylus`. Used when a component uses a `styles: [...]`
     /// literal rather than `styleUrl`/`styleUrls`.
     pub inline_style_language: Option<String>,
+    /// Enables Angular's service-worker pipeline. When `true`, ngc-rs reads
+    /// `ngsw-config.json` after the bundle is otherwise complete and emits
+    /// `ngsw.json` plus the worker scripts into the output directory.
+    pub service_worker: Option<bool>,
+    /// Path to the service-worker configuration file. Defaults to
+    /// `ngsw-config.json` at the workspace root when omitted.
+    pub ngsw_config_path: Option<String>,
 }
 
 /// Output path can be a simple string or an object for SSR setups.
@@ -332,6 +339,13 @@ pub struct ResolvedAngularProject {
     /// Resolved i18n configuration. `None` when the project does not declare
     /// an `i18n` block.
     pub i18n: Option<I18nConfig>,
+    /// `true` when `architect.build.options.serviceWorker` is set, in which
+    /// case the build should emit an `ngsw.json` manifest after writing
+    /// `dist/`.
+    pub service_worker: bool,
+    /// Absolute path to the service-worker config file
+    /// (defaults to `<base_dir>/ngsw-config.json`).
+    pub ngsw_config_path: PathBuf,
 }
 
 /// Resolved i18n configuration with absolute paths.
@@ -535,6 +549,11 @@ pub fn resolve_angular_project(
         .unwrap_or(false);
     let inline_style_language =
         InlineStyleLanguage::parse(options.and_then(|o| o.inline_style_language.as_deref()));
+    let service_worker = options.and_then(|o| o.service_worker).unwrap_or(false);
+    let ngsw_config_path = options
+        .and_then(|o| o.ngsw_config_path.as_deref())
+        .map(|p| base_dir.join(p))
+        .unwrap_or_else(|| base_dir.join("ngsw-config.json"));
     let i18n = project
         .i18n
         .as_ref()
@@ -566,6 +585,8 @@ pub fn resolve_angular_project(
         subresource_integrity,
         inline_style_language,
         i18n,
+        service_worker,
+        ngsw_config_path,
     })
 }
 
@@ -1142,6 +1163,50 @@ mod tests {
         assert_eq!(i18n.source_locale, "en-US");
         assert_eq!(i18n.source_base_href.as_deref(), Some("/en/"));
         assert!(i18n.locales.is_empty());
+    }
+
+    #[test]
+    fn test_parse_service_worker_enabled() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "serviceWorker": true,
+                                "ngswConfigPath": "ngsw-config.json"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.service_worker);
+        assert!(result.ngsw_config_path.ends_with("ngsw-config.json"));
+    }
+
+    #[test]
+    fn test_service_worker_defaults_off() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": { "outputPath": "dist", "tsConfig": "tsconfig.json" }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(!result.service_worker);
+        // Path defaults to <base_dir>/ngsw-config.json even when sw is off.
+        assert!(result.ngsw_config_path.ends_with("ngsw-config.json"));
     }
 
     #[test]

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -140,13 +140,26 @@ pub struct RawBuildOptions {
     /// `less`, or `stylus`. Used when a component uses a `styles: [...]`
     /// literal rather than `styleUrl`/`styleUrls`.
     pub inline_style_language: Option<String>,
-    /// Enables Angular's service-worker pipeline. When `true`, ngc-rs reads
-    /// `ngsw-config.json` after the bundle is otherwise complete and emits
-    /// `ngsw.json` plus the worker scripts into the output directory.
-    pub service_worker: Option<bool>,
+    /// Enables Angular's service-worker pipeline. Accepts either a boolean
+    /// (`true`/`false`) or a string path to `ngsw-config.json` (legacy
+    /// Angular `<` v15 form, where the field served double-duty as both the
+    /// enable flag and the config path).
+    pub service_worker: Option<RawServiceWorker>,
     /// Path to the service-worker configuration file. Defaults to
     /// `ngsw-config.json` at the workspace root when omitted.
     pub ngsw_config_path: Option<String>,
+}
+
+/// `serviceWorker` accepts either a bool (Angular 15+) or a string path
+/// to the config file (legacy Angular `<` v15).
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum RawServiceWorker {
+    /// Boolean form: `"serviceWorker": true`.
+    Enabled(bool),
+    /// Legacy string form: `"serviceWorker": "ngsw-config.json"`. The string
+    /// is the path to the config file (treated as enabled when present).
+    ConfigPath(String),
 }
 
 /// Output path can be a simple string or an object for SSR setups.
@@ -549,9 +562,18 @@ pub fn resolve_angular_project(
         .unwrap_or(false);
     let inline_style_language =
         InlineStyleLanguage::parse(options.and_then(|o| o.inline_style_language.as_deref()));
-    let service_worker = options.and_then(|o| o.service_worker).unwrap_or(false);
+    // serviceWorker accepts bool (modern) or string-path (legacy). When the
+    // string form is used, it doubles as the ngsw config path unless an
+    // explicit `ngswConfigPath` overrides it.
+    let (service_worker, sw_inline_path) = match options.and_then(|o| o.service_worker.as_ref()) {
+        Some(RawServiceWorker::Enabled(b)) => (*b, None),
+        Some(RawServiceWorker::ConfigPath(p)) => (true, Some(p.clone())),
+        None => (false, None),
+    };
     let ngsw_config_path = options
         .and_then(|o| o.ngsw_config_path.as_deref())
+        .map(String::from)
+        .or(sw_inline_path)
         .map(|p| base_dir.join(p))
         .unwrap_or_else(|| base_dir.join("ngsw-config.json"));
     let i18n = project
@@ -1187,6 +1209,55 @@ mod tests {
         let result = resolve_angular_project(f.path(), None, None).unwrap();
         assert!(result.service_worker);
         assert!(result.ngsw_config_path.ends_with("ngsw-config.json"));
+    }
+
+    #[test]
+    fn test_parse_service_worker_legacy_string_path() {
+        // Pre-v15 Angular used `"serviceWorker": "ngsw-config.json"` where
+        // the string both enabled the SW and named the config file.
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "serviceWorker": "ngsw-config.json"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.service_worker);
+        assert!(result.ngsw_config_path.ends_with("ngsw-config.json"));
+    }
+
+    #[test]
+    fn test_explicit_ngsw_config_path_overrides_legacy_string() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "serviceWorker": "legacy.json",
+                                "ngswConfigPath": "explicit/ngsw.json"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.service_worker);
+        assert!(result.ngsw_config_path.ends_with("explicit/ngsw.json"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #65.

## Summary
- Parses `architect.build.options.serviceWorker` and `ngswConfigPath` from `angular.json`. Accepts both the modern boolean form and the legacy string-path form (`"serviceWorker": "ngsw-config.json"`) used by Angular `<` v15 / projects scaffolded against the older schema.
- New `crates/cli/src/ngsw.rs` reads `ngsw-config.json`, walks the populated `dist/` tree, hashes every file matched by an `assetGroups` pattern (SHA-1 hex per Angular's spec), and writes `dist/ngsw.json`.
- Pattern compiler supports `**`, `*`, `?`, `(a|b)` alt groups, `[chars]` classes, and leading-`!` negation.
- Post-build step (after `3rdpartylicenses.txt`) emits the manifest and copies `ngsw-worker.js` / `safety-worker.js` from `node_modules/@angular/service-worker/` when present.
- Each URL is owned by the first asset group that claims it, mirroring Angular's behaviour.
- The manifest itself and the worker scripts are excluded from hashing.
- `--localize` + `serviceWorker` logs a warning and skips manifest emission (per-locale manifests are out of scope here).

### Drive-by fix: chunk-name collisions
- `chunk_filename_from_path` previously truncated to the last two dash-tokens of the dash-joined relative path. That collapsed both `service-worker.component.ts` and `web-worker.component.ts` to the same `chunk-worker-component.js`, silently overwriting one route's chunk so its `loadComponent` import resolved to `undefined` and the page rendered blank with no console error.
- Now uses the file's full basename stem (filename without trailing extension, with inner `.` → `-`). Existing chunk names are unchanged; hyphenated basenames are now disambiguated.
- Regression test added.

### Drive-by fix: `ngDevMode` not set in production
- `app.config.ts` does `provideServiceWorker(..., { enabled: !isDevMode() })`. `@angular/core`'s `isDevMode()` reads `typeof ngDevMode === 'undefined' || !!ngDevMode`. Angular CLI replaces `ngDevMode` with the literal `false` at production-build time via esbuild's `--define`; ngc-rs did not, so `isDevMode()` returned `true` in production bundles, the SW provider was given `enabled: false`, and `SwUpdate.isEnabled` stayed `false` (e.g. the "check for update" button on the test bed's `/service-worker` route never enabled).
- Fix: production builds prepend `globalThis.ngDevMode=false;globalThis.ngI18nClosureMode=false;globalThis.ngJitMode=false;` to `main.js`. Done after minification (so the minifier can't accidentally rewrite the assignments) and before content-hashing (so the hash reflects the served bytes). Source map for `main.js` is shifted by one line to stay aligned.
- This is a runtime-correctness fix, **not** dead-code elimination — the dev-only branches (~1,100 `ngDevMode` references on a real app) are still in the bundle. Full parity (define substitution + DCE so the dev branches are gone) is filed as #86.

## Test plan
- [x] `cargo test --workspace` (full suite, including new ngsw unit tests, the PWA fixture integration test, the chunk-collision regression test, and the dev-mode prologue tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Integration test (`test_service_worker_pipeline_pwa_fixture`) drives a fixture PWA end-to-end: `angular.json` with `serviceWorker: true`, a minimal `ngsw-config.json`, a fake dist tree, and asserts `ngsw.json` shape + that `hashTable` SHA-1 hashes match the actual served bytes.
- [x] Unit tests cover glob compilation (`/**`, `/*.js`, alt groups, negation), first-group-claims-url, manifest skipping itself + worker scripts, `dataGroups` regex compilation, chunk-filename disambiguation for hyphenated basenames, and the production-only dev-mode globals prologue.