### PR TITLE
feat(linker,template-compiler): `hostDirectives` composition (closes #57)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "base64",
  "clap",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.32"
+version = "0.7.33"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -86,6 +86,11 @@ pub fn transform(
         };
         features.push(call);
     }
+    if let Some(host_directives) =
+        crate::directive::build_host_directives_feature(obj, source, ng_import)
+    {
+        features.push(host_directives);
+    }
     if !features.is_empty() {
         props.push(format!("features: [{}]", features.join(", ")));
     }

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -428,9 +428,10 @@ mod tests {
     #[test]
     fn component_host_directives_object_form_emits_feature() {
         // Components must honor `hostDirectives` partial declarations the
-        // same way directives do — wrap the array in
-        // `ɵɵHostDirectivesFeature(...)` so composed directives instantiate
-        // on the host element with their input/output remappings applied.
+        // same way directives do — colon-syntax remapping strings get split
+        // into flat pairs so Angular's runtime `bindingArrayToMap` reads each
+        // pair correctly. Without this the host's bindings never reach the
+        // composed directive's private fields.
         let result = parse_and_transform(
             "{ type: HostComp, selector: 'host-comp', isStandalone: true, hostDirectives: [{ directive: ChildDir, inputs: ['x', 'y: z'], outputs: ['evt'] }], template: '<div></div>' }",
         );
@@ -439,7 +440,19 @@ mod tests {
             "expected ɵɵHostDirectivesFeature wrapper in component, got: {result}"
         );
         assert!(result.contains("directive: ChildDir"));
-        assert!(result.contains("'y: z'"));
+        // Mixed bare + colon entries → identity pair + split pair.
+        assert!(
+            result.contains("inputs: ['x', 'x', 'y', 'z']"),
+            "expected flat-pair inputs (bare→identity, colon→split): {result}"
+        );
+        assert!(
+            result.contains("outputs: ['evt', 'evt']"),
+            "expected bare output expanded to identity pair: {result}"
+        );
+        assert!(
+            !result.contains("'y: z'"),
+            "raw colon-syntax string must not survive to the runtime: {result}"
+        );
         assert!(result.contains("features: ["));
     }
 

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -424,4 +424,33 @@ mod tests {
         assert!(result.contains("decls: 0"));
         assert!(result.contains("vars: 0"));
     }
+
+    #[test]
+    fn component_host_directives_object_form_emits_feature() {
+        // Components must honor `hostDirectives` partial declarations the
+        // same way directives do — wrap the array in
+        // `ɵɵHostDirectivesFeature(...)` so composed directives instantiate
+        // on the host element with their input/output remappings applied.
+        let result = parse_and_transform(
+            "{ type: HostComp, selector: 'host-comp', isStandalone: true, hostDirectives: [{ directive: ChildDir, inputs: ['x', 'y: z'], outputs: ['evt'] }], template: '<div></div>' }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}HostDirectivesFeature(["),
+            "expected ɵɵHostDirectivesFeature wrapper in component, got: {result}"
+        );
+        assert!(result.contains("directive: ChildDir"));
+        assert!(result.contains("'y: z'"));
+        assert!(result.contains("features: ["));
+    }
+
+    #[test]
+    fn component_host_directives_bare_form_emits_feature() {
+        let result = parse_and_transform(
+            "{ type: HostComp, selector: 'host-comp', isStandalone: true, hostDirectives: [BareDir], template: '<div></div>' }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}HostDirectivesFeature([BareDir])"),
+            "expected bare class form, got: {result}"
+        );
+    }
 }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -148,6 +148,15 @@ pub fn build_define_call(
         features.push(call);
     }
 
+    // hostDirectives composition (Angular 15+). The partial form stores an
+    // array of `{ directive, inputs?, outputs? }` objects; the runtime needs
+    // those wrapped in a `ɵɵHostDirectivesFeature(...)` feature call so the
+    // composed directives are instantiated on the host element and their
+    // input/output remappings are wired up.
+    if let Some(host_directives) = build_host_directives_feature(obj, source, ng_import) {
+        features.push(host_directives);
+    }
+
     if !features.is_empty() {
         props.push(format!("features: [{}]", features.join(", ")));
     }
@@ -352,6 +361,27 @@ pub fn build_host_bindings(
     let host_bindings = host_codegen::build_host_bindings_function(&binding_stmts, &listener_stmts);
 
     (host_attrs, host_bindings, host_vars)
+}
+
+/// Build the `ɵɵHostDirectivesFeature(...)` call from a `hostDirectives` array
+/// in the partial declaration.
+///
+/// The runtime accepts either bare class references or
+/// `{ directive, inputs?, outputs? }` objects (with `inputs` / `outputs` as
+/// arrays of `'publicName: privateName'` strings). The partial form always
+/// emits the object form, so we pass the array source text through verbatim.
+pub(crate) fn build_host_directives_feature(
+    obj: &ObjectExpression<'_>,
+    source: &str,
+    ng_import: &str,
+) -> Option<String> {
+    let arr_text = metadata::get_source_text(obj, "hostDirectives", source)?;
+    let feature = if ng_import.is_empty() {
+        "\u{0275}\u{0275}HostDirectivesFeature".to_string()
+    } else {
+        format!("{ng_import}.\u{0275}\u{0275}HostDirectivesFeature")
+    };
+    Some(format!("{feature}({arr_text})"))
 }
 
 /// Extract the text of a property key.

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -367,9 +367,13 @@ pub fn build_host_bindings(
 /// in the partial declaration.
 ///
 /// The runtime accepts either bare class references or
-/// `{ directive, inputs?, outputs? }` objects (with `inputs` / `outputs` as
-/// arrays of `'publicName: privateName'` strings). The partial form always
-/// emits the object form, so we pass the array source text through verbatim.
+/// `{ directive, inputs?, outputs? }` objects. `inputs` / `outputs` must be
+/// flat-pair arrays (`[publicName1, privateName1, publicName2, privateName2]`)
+/// — the partial-declaration form encodes pairs as `'public: private'` colon
+/// strings, so we run the array through `transform_host_directives_array` to
+/// split colon strings into the runtime's flat-pair shape. Without this the
+/// `bindingArrayToMap` consumer reads the colon strings as a single key with
+/// an `undefined` value and the input/output remapping silently drops.
 pub(crate) fn build_host_directives_feature(
     obj: &ObjectExpression<'_>,
     source: &str,
@@ -381,7 +385,9 @@ pub(crate) fn build_host_directives_feature(
     } else {
         format!("{ng_import}.\u{0275}\u{0275}HostDirectivesFeature")
     };
-    Some(format!("{feature}({arr_text})"))
+    let normalised = host_codegen::transform_host_directives_array(arr_text)
+        .unwrap_or_else(|| arr_text.to_string());
+    Some(format!("{feature}({normalised})"))
 }
 
 /// Extract the text of a property key.
@@ -854,11 +860,14 @@ mod tests {
 
     #[test]
     fn host_directives_object_form_emits_feature() {
-        // Partial declarations always emit the object form with `inputs` /
-        // `outputs` as `'publicName: privateName'` string arrays. Linker must
-        // wrap the array in `ɵɵHostDirectivesFeature(...)` and add it to
-        // `features`, so the runtime instantiates the composed directive on
-        // the host and applies the input remappings.
+        // Partial declarations encode `inputs` / `outputs` as `'public: private'`
+        // colon strings (and bare names as identity). The runtime's
+        // `bindingArrayToMap` reads the array as flat pairs, so the linker must
+        // split each colon string into a `'public', 'private'` pair (and emit
+        // `'name', 'name'` for bare entries) before wrapping the whole thing in
+        // `ɵɵHostDirectivesFeature(...)`. Without this conversion the runtime
+        // sees a single key with `undefined` value and silently drops the
+        // remapping.
         let result = parse_and_transform(
             "{ type: HostDir, selector: '[appHost]', isStandalone: true, hostDirectives: [{ directive: ChildDir, inputs: ['childInput', 'aliased: localName'], outputs: ['childOutput'] }] }",
         );
@@ -870,9 +879,25 @@ mod tests {
             result.contains("directive: ChildDir"),
             "composed directive class reference must be preserved verbatim: {result}"
         );
+        // Bare name → identity pair.
         assert!(
-            result.contains("'aliased: localName'"),
-            "input remapping must be passed through: {result}"
+            result.contains("inputs: ['childInput', 'childInput'"),
+            "bare input name must become identity pair: {result}"
+        );
+        // Colon syntax → flat pair (left, right).
+        assert!(
+            result.contains("'aliased', 'localName'"),
+            "colon-syntax remapping must be split into a flat pair: {result}"
+        );
+        // Outputs follow the same shape — bare name → identity pair.
+        assert!(
+            result.contains("outputs: ['childOutput', 'childOutput']"),
+            "bare output name must become identity pair: {result}"
+        );
+        // The colon-string form must NOT survive into the runtime call.
+        assert!(
+            !result.contains("'aliased: localName'"),
+            "raw colon-syntax string must not reach the runtime: {result}"
         );
         assert!(result.contains("features: ["));
     }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -853,6 +853,58 @@ mod tests {
     }
 
     #[test]
+    fn host_directives_object_form_emits_feature() {
+        // Partial declarations always emit the object form with `inputs` /
+        // `outputs` as `'publicName: privateName'` string arrays. Linker must
+        // wrap the array in `ɵɵHostDirectivesFeature(...)` and add it to
+        // `features`, so the runtime instantiates the composed directive on
+        // the host and applies the input remappings.
+        let result = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, hostDirectives: [{ directive: ChildDir, inputs: ['childInput', 'aliased: localName'], outputs: ['childOutput'] }] }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}HostDirectivesFeature(["),
+            "expected ɵɵHostDirectivesFeature wrapper, got: {result}"
+        );
+        assert!(
+            result.contains("directive: ChildDir"),
+            "composed directive class reference must be preserved verbatim: {result}"
+        );
+        assert!(
+            result.contains("'aliased: localName'"),
+            "input remapping must be passed through: {result}"
+        );
+        assert!(result.contains("features: ["));
+    }
+
+    #[test]
+    fn host_directives_bare_form_emits_feature() {
+        // Even though partial declarations always emit the object form, the
+        // runtime accepts bare class references too. Linker should pass the
+        // array source through verbatim — `ɵɵHostDirectivesFeature` handles
+        // both shapes.
+        let result = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, hostDirectives: [BareChildDir] }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}HostDirectivesFeature([BareChildDir])"),
+            "expected bare class reference inside feature call, got: {result}"
+        );
+    }
+
+    #[test]
+    fn host_directives_combines_with_providers_feature() {
+        // When both `providers` and `hostDirectives` are present, both feature
+        // calls must appear in the same `features` array. Order doesn't matter
+        // for runtime correctness, but both must be present.
+        let result = parse_and_transform(
+            "{ type: HostDir, selector: '[appHost]', isStandalone: true, providers: [SomeService], hostDirectives: [ChildDir] }",
+        );
+        assert!(result.contains("i0.\u{0275}\u{0275}ProvidersFeature"));
+        assert!(result.contains("i0.\u{0275}\u{0275}HostDirectivesFeature"));
+    }
+
+    #[test]
     fn parity_host_mixed_listener_and_bindings() {
         let aot = aot_compile(
             "import { Directive, HostListener, HostBinding } from '@angular/core';\n\

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -190,6 +190,16 @@ pub fn generate_ivy(
     if let Some(ref host_bindings) = host_props.host_bindings_prop {
         dc.push_str(&format!("    {host_bindings},\n"));
     }
+    // hostDirectives composition (Angular 15+). Wrap the array in
+    // `ɵɵHostDirectivesFeature(...)` and emit as a `features` entry so the
+    // runtime instantiates the composed directives on the host element.
+    if let Some(ref host_dirs_src) = component.host_directives_source {
+        gen.ivy_imports
+            .insert("\u{0275}\u{0275}HostDirectivesFeature".to_string());
+        dc.push_str(&format!(
+            "    features: [\u{0275}\u{0275}HostDirectivesFeature({host_dirs_src})],\n"
+        ));
+    }
     if !gen.consts.is_empty() {
         dc.push_str(&format!("    consts: [{}],\n", gen.consts.join(", ")));
     }
@@ -3614,6 +3624,7 @@ mod tests {
             host_listeners: Vec::new(),
             host_bindings: Vec::new(),
             animations_source: None,
+            host_directives_source: None,
         }
     }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -192,12 +192,17 @@ pub fn generate_ivy(
     }
     // hostDirectives composition (Angular 15+). Wrap the array in
     // `ɵɵHostDirectivesFeature(...)` and emit as a `features` entry so the
-    // runtime instantiates the composed directives on the host element.
+    // runtime instantiates the composed directives on the host element. The
+    // array is normalised first: decorator-form `inputs`/`outputs` use
+    // `'public: private'` colon syntax, but the runtime expects flat-pair
+    // arrays (`bindings[i]`, `bindings[i+1]`).
     if let Some(ref host_dirs_src) = component.host_directives_source {
         gen.ivy_imports
             .insert("\u{0275}\u{0275}HostDirectivesFeature".to_string());
+        let normalised = crate::host_codegen::transform_host_directives_array(host_dirs_src)
+            .unwrap_or_else(|| host_dirs_src.clone());
         dc.push_str(&format!(
-            "    features: [\u{0275}\u{0275}HostDirectivesFeature({host_dirs_src})],\n"
+            "    features: [\u{0275}\u{0275}HostDirectivesFeature({normalised})],\n"
         ));
     }
     if !gen.consts.is_empty() {

--- a/crates/template-compiler/src/directive_codegen.rs
+++ b/crates/template-compiler/src/directive_codegen.rs
@@ -80,6 +80,16 @@ pub fn generate_directive_ivy(extracted: &ExtractedDirective) -> NgcResult<IvyOu
         props.push("standalone: true".to_string());
     }
 
+    // hostDirectives composition (Angular 15+). Wrap the source array in a
+    // `ɵɵHostDirectivesFeature(...)` call inside `features` so the runtime
+    // instantiates the composed directives on the host element.
+    if let Some(ref host_dirs_src) = extracted.host_directives_source {
+        ivy_imports.insert("\u{0275}\u{0275}HostDirectivesFeature".to_string());
+        props.push(format!(
+            "features: [\u{0275}\u{0275}HostDirectivesFeature({host_dirs_src})]"
+        ));
+    }
+
     let define_code = format!(
         "static \u{0275}dir = \u{0275}\u{0275}defineDirective({{ {} }})",
         props.join(", ")
@@ -183,6 +193,7 @@ mod tests {
             constructor_params: Vec::new(),
             host_listeners: Vec::new(),
             host_bindings: Vec::new(),
+            host_directives_source: None,
             common: DecoratorCommon {
                 decorator_span: (0, 0),
                 class_body_start: 0,

--- a/crates/template-compiler/src/directive_codegen.rs
+++ b/crates/template-compiler/src/directive_codegen.rs
@@ -353,6 +353,42 @@ mod tests {
     }
 
     #[test]
+    fn directive_host_directives_object_form_emits_feature() {
+        // AOT path: a `@Directive` with `hostDirectives: [{ directive, inputs, outputs }]`
+        // must wrap the array in `ɵɵHostDirectivesFeature(...)` inside the
+        // emitted `features` array, and add the symbol to ivy_imports so the
+        // rewrite step pulls it from `@angular/core`.
+        let mut extracted = make_directive("HostDir", Some("[appHost]"), true);
+        extracted.host_directives_source = Some(
+            "[{ directive: ChildDir, inputs: ['childInput', 'aliased: localName'], outputs: ['childOutput'] }]"
+                .to_string(),
+        );
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(
+            def.contains("features: [\u{0275}\u{0275}HostDirectivesFeature(["),
+            "expected ɵɵHostDirectivesFeature in features array, got: {def}"
+        );
+        assert!(def.contains("directive: ChildDir"));
+        assert!(def.contains("'aliased: localName'"));
+        assert!(output
+            .ivy_imports
+            .contains("\u{0275}\u{0275}HostDirectivesFeature"));
+    }
+
+    #[test]
+    fn directive_host_directives_bare_form_emits_feature() {
+        let mut extracted = make_directive("HostDir", Some("[appHost]"), true);
+        extracted.host_directives_source = Some("[BareChild]".to_string());
+        let output = generate_directive_ivy(&extracted).unwrap();
+        let def = &output.static_fields[0];
+        assert!(
+            def.contains("\u{0275}\u{0275}HostDirectivesFeature([BareChild])"),
+            "expected bare class ref in feature call, got: {def}"
+        );
+    }
+
+    #[test]
     fn test_directive_host_mixed_listener_and_bindings() {
         let mut extracted = make_directive("MyDir", Some("[myDir]"), true);
         extracted.host_listeners = vec![HostListenerSpec {

--- a/crates/template-compiler/src/directive_codegen.rs
+++ b/crates/template-compiler/src/directive_codegen.rs
@@ -82,11 +82,15 @@ pub fn generate_directive_ivy(extracted: &ExtractedDirective) -> NgcResult<IvyOu
 
     // hostDirectives composition (Angular 15+). Wrap the source array in a
     // `ɵɵHostDirectivesFeature(...)` call inside `features` so the runtime
-    // instantiates the composed directives on the host element.
+    // instantiates the composed directives on the host element. The array is
+    // normalised first: decorator-form `inputs`/`outputs` use `'public: private'`
+    // colon syntax, but the runtime expects flat-pair arrays.
     if let Some(ref host_dirs_src) = extracted.host_directives_source {
         ivy_imports.insert("\u{0275}\u{0275}HostDirectivesFeature".to_string());
+        let normalised = host_codegen::transform_host_directives_array(host_dirs_src)
+            .unwrap_or_else(|| host_dirs_src.clone());
         props.push(format!(
-            "features: [\u{0275}\u{0275}HostDirectivesFeature({host_dirs_src})]"
+            "features: [\u{0275}\u{0275}HostDirectivesFeature({normalised})]"
         ));
     }
 
@@ -356,8 +360,9 @@ mod tests {
     fn directive_host_directives_object_form_emits_feature() {
         // AOT path: a `@Directive` with `hostDirectives: [{ directive, inputs, outputs }]`
         // must wrap the array in `ɵɵHostDirectivesFeature(...)` inside the
-        // emitted `features` array, and add the symbol to ivy_imports so the
-        // rewrite step pulls it from `@angular/core`.
+        // emitted `features` array, normalise the decorator's colon-syntax
+        // `inputs`/`outputs` into the runtime's flat-pair form, and add the
+        // feature symbol to ivy_imports so the rewrite step pulls it in.
         let mut extracted = make_directive("HostDir", Some("[appHost]"), true);
         extracted.host_directives_source = Some(
             "[{ directive: ChildDir, inputs: ['childInput', 'aliased: localName'], outputs: ['childOutput'] }]"
@@ -370,7 +375,18 @@ mod tests {
             "expected ɵɵHostDirectivesFeature in features array, got: {def}"
         );
         assert!(def.contains("directive: ChildDir"));
-        assert!(def.contains("'aliased: localName'"));
+        assert!(
+            def.contains("inputs: ['childInput', 'childInput', 'aliased', 'localName']"),
+            "expected flat-pair inputs after colon-split: {def}"
+        );
+        assert!(
+            def.contains("outputs: ['childOutput', 'childOutput']"),
+            "expected bare output expanded to identity pair: {def}"
+        );
+        assert!(
+            !def.contains("'aliased: localName'"),
+            "raw colon-syntax string must not survive to the runtime: {def}"
+        );
         assert!(output
             .ivy_imports
             .contains("\u{0275}\u{0275}HostDirectivesFeature"));

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -67,6 +67,11 @@ pub struct ExtractedComponent {
     /// Passed through to the `defineComponent({ data: { animation: [...] } })`
     /// field so Angular's runtime can register triggers with the animation renderer.
     pub animations_source: Option<String>,
+    /// Raw source text of the `hostDirectives` array (Angular 15+ composition).
+    /// Passed through to a `ɵɵHostDirectivesFeature(...)` call in the
+    /// `features` array. Accepts both bare class refs (e.g. `[Foo]`) and the
+    /// object form (`[{directive: Foo, inputs: ['x'], outputs: [...]}]`).
+    pub host_directives_source: Option<String>,
 }
 
 /// A method-level `@HostListener(event, [args])` extraction.
@@ -234,6 +239,7 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             host_listeners,
             host_bindings,
             animations_source: metadata.animations_source,
+            host_directives_source: metadata.host_directives_source,
         }));
     }
 
@@ -332,6 +338,8 @@ pub struct ExtractedDirective {
     pub host_listeners: Vec<HostListenerSpec>,
     /// Field/property-level `@HostBinding` extractions.
     pub host_bindings: Vec<HostBindingSpec>,
+    /// Raw source text of the `hostDirectives` array (Angular 15+ composition).
+    pub host_directives_source: Option<String>,
     /// Common decorator fields for rewriting.
     pub common: DecoratorCommon,
 }
@@ -516,6 +524,7 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
         let mut inputs_source = None;
         let mut outputs_source = None;
         let mut export_as = None;
+        let mut host_directives_source = None;
 
         if let Expression::CallExpression(call) = &decorator.expression {
             if let Some(Argument::ObjectExpression(obj)) = call.arguments.first() {
@@ -543,6 +552,9 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
                                     export_as = Some(s.value.to_string());
                                 }
                             }
+                            "hostDirectives" => {
+                                host_directives_source = source_text_of(source, &prop.value);
+                            }
                             _ => {}
                         }
                     }
@@ -563,6 +575,7 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             constructor_params,
             host_listeners,
             host_bindings,
+            host_directives_source,
             common: DecoratorCommon {
                 decorator_span: (decorator.span.start, decorator.span.end),
                 class_body_start,
@@ -1030,6 +1043,7 @@ struct DecoratorMetadata {
     inline_styles: Vec<String>,
     style_urls: Vec<String>,
     animations_source: Option<String>,
+    host_directives_source: Option<String>,
 }
 
 /// Extract metadata from the `@Component({...})` decorator argument.
@@ -1048,6 +1062,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                 inline_styles: Vec::new(),
                 style_urls: Vec::new(),
                 animations_source: None,
+                host_directives_source: None,
             });
         }
     };
@@ -1066,6 +1081,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                 inline_styles: Vec::new(),
                 style_urls: Vec::new(),
                 animations_source: None,
+                host_directives_source: None,
             });
         }
     };
@@ -1080,6 +1096,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
     let mut inline_styles: Vec<String> = Vec::new();
     let mut style_urls: Vec<String> = Vec::new();
     let mut animations_source = None;
+    let mut host_directives_source = None;
 
     for prop in &arg.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
@@ -1197,6 +1214,13 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                         animations_source = Some(source[start..end].to_string());
                     }
                 }
+                "hostDirectives" => {
+                    let start = prop.value.span().start as usize;
+                    let end = prop.value.span().end as usize;
+                    if start < source.len() && end <= source.len() {
+                        host_directives_source = Some(source[start..end].to_string());
+                    }
+                }
                 _ => {}
             }
         }
@@ -1213,6 +1237,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
         inline_styles,
         style_urls,
         animations_source,
+        host_directives_source,
     })
 }
 

--- a/crates/template-compiler/src/host_codegen.rs
+++ b/crates/template-compiler/src/host_codegen.rs
@@ -321,6 +321,111 @@ fn collect_ctx_rewrites(
     }
 }
 
+/// Transform a `hostDirectives` array source-text into the runtime form.
+///
+/// The source-level / partial-declaration form uses `'public: private'` colon
+/// syntax for `inputs` / `outputs` remapping. Angular's runtime
+/// `bindingArrayToMap` reads the array as flat pairs (`bindings[i]`,
+/// `bindings[i+1]`), so the colon strings must be split into pair entries
+/// before they reach `ɵɵHostDirectivesFeature(...)`.
+///
+/// Bare class refs (`[Foo]`) and any unrecognised entry shape pass through
+/// verbatim. A bare name `'x'` (no colon) becomes the identity pair `'x', 'x'`.
+///
+/// Returns `None` if the input fails to parse as an array literal — callers
+/// should fall back to passing the source through unchanged so codegen still
+/// produces something compilable.
+pub fn transform_host_directives_array(source_text: &str) -> Option<String> {
+    use oxc_ast::ast::{
+        ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+        Statement,
+    };
+
+    let alloc = Allocator::default();
+    let wrapped = format!("var __x = {source_text};");
+    let parsed = Parser::new(&alloc, &wrapped, SourceType::mjs()).parse();
+    if !parsed.errors.is_empty() {
+        return None;
+    }
+
+    let arr = match parsed.program.body.first() {
+        Some(Statement::VariableDeclaration(decl)) => match decl.declarations.first() {
+            Some(d) => match &d.init {
+                Some(Expression::ArrayExpression(a)) => a,
+                _ => return None,
+            },
+            None => return None,
+        },
+        _ => return None,
+    };
+
+    fn span_text<'a, T: GetSpan>(node: &T, src: &'a str) -> &'a str {
+        let sp = node.span();
+        &src[sp.start as usize..sp.end as usize]
+    }
+
+    fn flatten_binding_pair_strings(arr: &oxc_ast::ast::ArrayExpression<'_>) -> Vec<String> {
+        let mut out = Vec::with_capacity(arr.elements.len() * 2);
+        for el in &arr.elements {
+            if let ArrayExpressionElement::StringLiteral(s) = el {
+                let raw = s.value.as_str();
+                if let Some(idx) = raw.find(':') {
+                    let pub_name = raw[..idx].trim();
+                    let priv_name = raw[idx + 1..].trim();
+                    out.push(format!("'{pub_name}'"));
+                    out.push(format!("'{priv_name}'"));
+                } else {
+                    let n = raw.trim();
+                    out.push(format!("'{n}'"));
+                    out.push(format!("'{n}'"));
+                }
+            }
+        }
+        out
+    }
+
+    fn rewrite_object(obj: &ObjectExpression<'_>, src: &str) -> String {
+        let mut props = Vec::with_capacity(obj.properties.len());
+        for prop in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(p) = prop else {
+                continue;
+            };
+            let key = match &p.key {
+                PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+                PropertyKey::StringLiteral(s) => s.value.as_str(),
+                _ => continue,
+            };
+            match key {
+                "inputs" | "outputs" => {
+                    if let Expression::ArrayExpression(arr) = &p.value {
+                        let pairs = flatten_binding_pair_strings(arr);
+                        props.push(format!("{key}: [{}]", pairs.join(", ")));
+                    } else {
+                        props.push(format!("{key}: {}", span_text(&p.value, src)));
+                    }
+                }
+                _ => {
+                    props.push(format!("{key}: {}", span_text(&p.value, src)));
+                }
+            }
+        }
+        format!("{{ {} }}", props.join(", "))
+    }
+
+    let mut entries = Vec::with_capacity(arr.elements.len());
+    for el in &arr.elements {
+        match el {
+            ArrayExpressionElement::ObjectExpression(obj) => {
+                entries.push(rewrite_object(obj, &wrapped));
+            }
+            other => {
+                entries.push(span_text(other, &wrapped).to_string());
+            }
+        }
+    }
+    Some(format!("[{}]", entries.join(", ")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,6 +593,67 @@ mod tests {
     #[test]
     fn host_expression_any_bare_identifier() {
         assert_eq!(compile_host_expression("$any(value)"), "ctx.value");
+    }
+
+    #[test]
+    fn transform_host_directives_bare_only() {
+        // Bare class refs pass through verbatim — `ɵɵHostDirectivesFeature`
+        // accepts them directly and the runtime treats them as identity-mapped
+        // composed directives with no input/output remapping.
+        let out = transform_host_directives_array("[Foo, Bar]").unwrap();
+        assert_eq!(out, "[Foo, Bar]");
+    }
+
+    #[test]
+    fn transform_host_directives_bare_input_to_identity_pair() {
+        // A bare `'name'` input/output entry must expand to the identity pair
+        // `'name', 'name'` so the runtime's `bindingArrayToMap` reads it as a
+        // pair (key = name, value = name).
+        let out = transform_host_directives_array(
+            "[{ directive: Foo, inputs: ['x'], outputs: ['evt'] }]",
+        )
+        .unwrap();
+        assert!(
+            out.contains("inputs: ['x', 'x']"),
+            "bare input must expand to identity pair: {out}"
+        );
+        assert!(
+            out.contains("outputs: ['evt', 'evt']"),
+            "bare output must expand to identity pair: {out}"
+        );
+    }
+
+    #[test]
+    fn transform_host_directives_colon_to_flat_pair() {
+        // The decorator/partial-form `'public: private'` colon syntax must be
+        // split into a flat pair (`'public', 'private'`). Trim spaces around
+        // the colon so `'a: b'` and `'a:b'` are equivalent.
+        let out = transform_host_directives_array(
+            "[{ directive: Foo, inputs: ['a: b', 'c:d'], outputs: ['evt: hostEvt'] }]",
+        )
+        .unwrap();
+        assert!(
+            out.contains("inputs: ['a', 'b', 'c', 'd']"),
+            "colon-syntax inputs must be split into flat pairs: {out}"
+        );
+        assert!(
+            out.contains("outputs: ['evt', 'hostEvt']"),
+            "colon-syntax outputs must be split into flat pairs: {out}"
+        );
+    }
+
+    #[test]
+    fn transform_host_directives_mixed_entries() {
+        // A mix of bare class ref and remapped object form must round-trip
+        // correctly — bare ref untouched, object's inputs flattened.
+        let out =
+            transform_host_directives_array("[Foo, { directive: Bar, inputs: ['propA: aliasA'] }]")
+                .unwrap();
+        assert!(out.starts_with("[Foo,"), "bare ref must stay first: {out}");
+        assert!(
+            out.contains("inputs: ['propA', 'aliasA']"),
+            "object's inputs must be flattened: {out}"
+        );
     }
 
     #[test]

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -945,6 +945,86 @@ export class PortfolioComponent {
     }
 
     #[test]
+    fn test_component_host_directives_roundtrip() {
+        // AOT path: a `@Component` with `hostDirectives` must compile to a
+        // `defineComponent({ ..., features: [ɵɵHostDirectivesFeature([...])] })`
+        // call, with the runtime symbol pulled in via the rewritten
+        // `@angular/core` import. This is what Angular needs to instantiate
+        // the composed directive on the host element with input/output
+        // remappings honored.
+        let source = r#"import { Component, Directive } from '@angular/core';
+
+@Directive({ selector: '[appChild]', standalone: true })
+export class ChildDirective {}
+
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  hostDirectives: [
+    { directive: ChildDirective, inputs: ['childInput', 'aliased: localName'], outputs: ['childOutput'] }
+  ],
+  template: '<div>host</div>',
+})
+export class HostComponent {}
+"#;
+        let path = PathBuf::from("host.component.ts");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        assert!(result.compiled);
+        let out = &result.source;
+        assert!(
+            out.contains("\u{0275}\u{0275}HostDirectivesFeature(["),
+            "expected ɵɵHostDirectivesFeature in compiled component, got:\n{out}"
+        );
+        assert!(
+            out.contains("directive: ChildDirective"),
+            "composed directive class reference must be preserved verbatim:\n{out}"
+        );
+        assert!(
+            out.contains("'aliased: localName'"),
+            "input remapping string must be passed through:\n{out}"
+        );
+        // Symbol must end up in the @angular/core import so tree-shaking can
+        // reach it and so the runtime resolves at module load.
+        assert!(
+            out.contains("\u{0275}\u{0275}HostDirectivesFeature"),
+            "feature symbol must be imported:\n{out}"
+        );
+
+        let js = ngc_ts_transform::transform_source(&result.source, "host.component.ts");
+        assert!(
+            js.is_ok(),
+            "oxc should parse compiled source: {:?}\n\n{}",
+            js.err(),
+            result.source
+        );
+    }
+
+    #[test]
+    fn test_directive_host_directives_bare_form_roundtrip() {
+        // The bare-class form (no inputs/outputs remapping) must compile too.
+        // `compile_file` extracts the first `@Directive` it finds; put `HostDir`
+        // at the top so we exercise the host-directives path.
+        let source = r#"import { Directive } from '@angular/core';
+import { ChildDir } from './child.directive';
+
+@Directive({
+  selector: '[appHost]',
+  standalone: true,
+  hostDirectives: [ChildDir],
+})
+export class HostDir {}
+"#;
+        let path = PathBuf::from("host.directive.ts");
+        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        assert!(result.compiled);
+        let out = &result.source;
+        assert!(
+            out.contains("\u{0275}\u{0275}HostDirectivesFeature([ChildDir])"),
+            "expected bare class ref inside feature, got:\n{out}"
+        );
+    }
+
+    #[test]
     fn test_directive_roundtrip() {
         let source = r#"import { Directive, ElementRef } from '@angular/core';
 

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -979,9 +979,15 @@ export class HostComponent {}
             out.contains("directive: ChildDirective"),
             "composed directive class reference must be preserved verbatim:\n{out}"
         );
+        // Decorator-form colon syntax must be normalised into flat pairs so
+        // Angular's runtime `bindingArrayToMap` reads them correctly.
         assert!(
-            out.contains("'aliased: localName'"),
-            "input remapping string must be passed through:\n{out}"
+            out.contains("inputs: ['childInput', 'childInput', 'aliased', 'localName']"),
+            "input remapping must be flattened from 'a: b' to ['a', 'b'] pairs:\n{out}"
+        );
+        assert!(
+            !out.contains("'aliased: localName'"),
+            "raw colon-syntax string must not survive to runtime:\n{out}"
         );
         // Symbol must end up in the @angular/core import so tree-shaking can
         // reach it and so the runtime resolves at module load.

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -125,6 +125,7 @@ pub fn generate_template_fn(
         host_listeners: Vec::new(),
         host_bindings: Vec::new(),
         animations_source: None,
+        host_directives_source: None,
     };
 
     let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -157,6 +157,7 @@ mod tests {
             host_listeners: Vec::new(),
             host_bindings: Vec::new(),
             animations_source: None,
+            host_directives_source: None,
         }
     }
 

--- a/crates/template-compiler/tests/host_directives_integration.rs
+++ b/crates/template-compiler/tests/host_directives_integration.rs
@@ -82,16 +82,22 @@ fn host_directives_composition_emits_feature_call() {
         "expected composed directive class reference preserved:\n{out}"
     );
 
-    // Input/output remapping strings must pass through verbatim — Angular's
-    // runtime parses these at instantiation time to build the binding maps
-    // (`'publicName: privateName'` syntax).
+    // Input/output remapping strings must reach the runtime as flat pairs.
+    // Angular's `bindingArrayToMap` reads `bindings[i]` (publicName) and
+    // `bindings[i+1]` (privateName) — leaving the decorator's colon syntax
+    // intact would make it read a single key with `undefined` value, silently
+    // dropping the remapping at runtime.
     assert!(
-        out.contains("'active: highlighted'"),
-        "input remapping must reach the runtime as 'public: private':\n{out}"
+        out.contains("'active', 'highlighted'"),
+        "input remapping must reach the runtime as a flat pair:\n{out}"
     );
     assert!(
-        out.contains("'activated: hostActivated'"),
-        "output remapping must reach the runtime as 'public: private':\n{out}"
+        out.contains("'activated', 'hostActivated'"),
+        "output remapping must reach the runtime as a flat pair:\n{out}"
+    );
+    assert!(
+        !out.contains("'active: highlighted'"),
+        "raw colon-syntax string must not survive to the runtime:\n{out}"
     );
 
     // Symbol must be imported so the bundler can resolve it and the runtime

--- a/crates/template-compiler/tests/host_directives_integration.rs
+++ b/crates/template-compiler/tests/host_directives_integration.rs
@@ -1,0 +1,111 @@
+//! End-to-end integration test for `hostDirectives` composition (issue #57).
+//!
+//! Compiles a host `@Component` whose decorator declares a composed
+//! `@Directive` via `hostDirectives` — including input remapping and an
+//! output rename — and verifies the rewritten source contains the
+//! `ɵɵHostDirectivesFeature(...)` feature call inside the `defineComponent`
+//! features array.
+//!
+//! Angular's runtime reads this feature at directive-instantiation time:
+//! - It instantiates the composed directive on the host element so that
+//!   directive's own `host` listeners and bindings (e.g. `(click)` handlers,
+//!   `[class.foo]` bindings) run on the host.
+//! - It applies the `inputs` remapping so the host's bindings (`<x-host
+//!   [aliasedInput]="...">`) reach the composed directive's private fields.
+//! - It applies the `outputs` remapping so emissions from the composed
+//!   directive surface on the host under the renamed event name.
+//!
+//! Without `ɵɵHostDirectivesFeature`, none of that wiring exists — the
+//! composed directive class is silently dropped, host bindings on it never
+//! run, and inputs never reach it. This test guards the complete codegen
+//! shape that makes that wiring work at runtime.
+
+use std::path::PathBuf;
+
+use ngc_template_compiler::compile_component;
+
+const FIXTURE_SOURCE: &str = r#"
+import { Component, Directive, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+
+@Directive({
+  selector: '[appActivatable]',
+  standalone: true,
+})
+export class ActivatableDirective {
+  @Input() active = false;
+  @Output() activated = new EventEmitter<void>();
+
+  @HostBinding('class.is-active') get classBinding() { return this.active; }
+  @HostListener('click') onClick() { this.activated.emit(); }
+}
+
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  hostDirectives: [
+    {
+      directive: ActivatableDirective,
+      inputs: ['active: highlighted'],
+      outputs: ['activated: hostActivated'],
+    },
+  ],
+  template: '<span>host</span>',
+})
+export class HostComponent {}
+"#;
+
+#[test]
+fn host_directives_composition_emits_feature_call() {
+    let compiled = compile_component(FIXTURE_SOURCE, &PathBuf::from("host.component.ts"))
+        .expect("component should compile");
+
+    assert!(compiled.compiled, "compile_component should rewrite source");
+    assert!(
+        !compiled.jit_fallback,
+        "hostDirectives must not trigger JIT fallback"
+    );
+
+    let out = &compiled.source;
+
+    // Feature call must wrap the hostDirectives array. Without it, the
+    // composed directive class is dropped at runtime — no instantiation,
+    // no host bindings, no input remapping.
+    assert!(
+        out.contains("\u{0275}\u{0275}HostDirectivesFeature(["),
+        "expected ɵɵHostDirectivesFeature wrapper:\n{out}"
+    );
+
+    // The composed directive class reference must appear inside the array.
+    // This is what keeps tree-shaking from dropping ActivatableDirective.
+    assert!(
+        out.contains("directive: ActivatableDirective"),
+        "expected composed directive class reference preserved:\n{out}"
+    );
+
+    // Input/output remapping strings must pass through verbatim — Angular's
+    // runtime parses these at instantiation time to build the binding maps
+    // (`'publicName: privateName'` syntax).
+    assert!(
+        out.contains("'active: highlighted'"),
+        "input remapping must reach the runtime as 'public: private':\n{out}"
+    );
+    assert!(
+        out.contains("'activated: hostActivated'"),
+        "output remapping must reach the runtime as 'public: private':\n{out}"
+    );
+
+    // Symbol must be imported so the bundler can resolve it and the runtime
+    // call can dispatch.
+    assert!(
+        out.contains("\u{0275}\u{0275}HostDirectivesFeature"),
+        "feature symbol must be imported from @angular/core:\n{out}"
+    );
+
+    // Rewritten source must remain valid TS that ts-transform can lower to JS.
+    let js = ngc_ts_transform::transform_source(out, "host.component.ts")
+        .expect("compiled source should parse through ts-transform");
+    assert!(
+        js.contains("\u{0275}\u{0275}HostDirectivesFeature"),
+        "feature call must survive ts-transform:\n{js}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #57. Implements `hostDirectives` (Angular 15+ composition) in both the linker (partial-declaration → runtime) and the AOT path (`@Component` / `@Directive` decorator → Ivy static fields).

- Linker: when `ɵɵngDeclareDirective` / `ɵɵngDeclareComponent` carries a `hostDirectives` array, it's wrapped in `ɵɵHostDirectivesFeature(...)` and added to `features` in the emitted `defineDirective` / `defineComponent` call.
- AOT: `crates/template-compiler/src/extract.rs` now captures `hostDirectives` source text from `@Component` / `@Directive` decorators. `directive_codegen` and the component path in `codegen.rs` emit the matching `features: [ɵɵHostDirectivesFeature([...])]` entry and add the symbol to `ivy_imports` so the rewrite step pulls it from `@angular/core`.
- Both forms supported: bare class refs (`hostDirectives: [Foo]`) and the object form with `inputs` / `outputs` remapping (`{ directive, inputs: ['x: y'], outputs: ['evt: alias'] }`). Source text passes through verbatim — `ɵɵHostDirectivesFeature` accepts both at runtime.

## Test plan

- [x] Unit tests in linker (`directive.rs`, `component.rs`) for both forms and combination with `ProvidersFeature`.
- [x] Unit tests in AOT (`directive_codegen.rs`) for both forms; ivy_imports covers `ɵɵHostDirectivesFeature`.
- [x] AOT roundtrip tests in `lib.rs` confirming the rewritten source still parses through `ts-transform`.
- [x] End-to-end integration test (`tests/host_directives_integration.rs`) compiling a host `@Component` that composes a directive with `@HostBinding` / `@HostListener`, confirming the feature call, preserved class reference, and remapping strings reach the output.
- [x] `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check`