### PR TITLE
feat(template-compiler,linker): signal-based input/output/model/query APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "base64",
  "clap",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.33"
+version = "0.7.34"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/src/component.rs
+++ b/crates/linker/src/component.rs
@@ -323,12 +323,40 @@ fn build_inputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
                     }
                 }
                 Expression::ObjectExpression(input_obj) => {
-                    let alias = metadata::get_string_prop(input_obj, "alias")
+                    // Mirror the directive linker: honour modern partial
+                    // declarations that mark inputs with `isSignal` /
+                    // `transformFunction` so signal-based component inputs
+                    // (`input()`, `input.required()`, `model()`) reach the
+                    // runtime with the right `InputFlags` bits set.
+                    let alias = metadata::get_string_prop(input_obj, "publicName")
+                        .or_else(|| metadata::get_string_prop(input_obj, "alias"))
                         .unwrap_or_else(|| key.clone());
-                    let required = metadata::get_bool_prop(input_obj, "required") == Some(true);
-                    let flags = if required { 1 } else { 0 };
-                    if required || alias != key {
-                        entries.push(format!("{key}: [{flags}, '{alias}', '{key}']"));
+                    let is_required = metadata::get_bool_prop(input_obj, "isRequired")
+                        == Some(true)
+                        || metadata::get_bool_prop(input_obj, "required") == Some(true);
+                    let is_signal = metadata::get_bool_prop(input_obj, "isSignal") == Some(true);
+
+                    let transform_text = ["transformFunction", "transform"]
+                        .iter()
+                        .find_map(|name| metadata::get_source_text(input_obj, name, source))
+                        .filter(|s| s.trim() != "null");
+                    let has_transform = transform_text.is_some();
+
+                    let mut flags: u32 = 0;
+                    if is_signal {
+                        flags |= 1; // InputFlags.SignalBased
+                    }
+                    if has_transform {
+                        flags |= 2; // InputFlags.HasDecoratorInputTransform
+                    }
+
+                    if has_transform || is_signal || is_required || alias != key {
+                        let entry = if let Some(t) = transform_text {
+                            format!("{key}: [{flags}, '{alias}', '{key}', {t}]")
+                        } else {
+                            format!("{key}: [{flags}, '{alias}', '{key}']")
+                        };
+                        entries.push(entry);
                     } else {
                         entries.push(format!("{key}: '{key}'"));
                     }

--- a/crates/linker/src/directive.rs
+++ b/crates/linker/src/directive.rs
@@ -202,17 +202,49 @@ fn build_inputs(obj: &ObjectExpression<'_>, source: &str) -> Option<String> {
                     }
                 }
                 Expression::ObjectExpression(input_obj) => {
-                    // Complex input: { alias: '...', required: true, transform: ... }
-                    let alias = metadata::get_string_prop(input_obj, "alias")
+                    // Complex input descriptor. Two shapes flow through here:
+                    //
+                    //   * Modern (Angular 17+ partial declarations):
+                    //     { classPropertyName, publicName, isSignal, isRequired,
+                    //       transformFunction }
+                    //   * Legacy/synthesized: { alias, required, transform }
+                    //
+                    // Honour both spellings so signal-based authoring APIs
+                    // (`input()`, `input.required()`, `model()`) round-trip
+                    // correctly: `isSignal` sets the `SignalBased` runtime
+                    // flag (bit 0) and a non-null `transformFunction` sets
+                    // `HasDecoratorInputTransform` (bit 1). The transform
+                    // expression itself rides along as the array's 4th
+                    // element so the runtime can call it on each value.
+                    let alias = metadata::get_string_prop(input_obj, "publicName")
+                        .or_else(|| metadata::get_string_prop(input_obj, "alias"))
                         .unwrap_or_else(|| key.clone());
-                    let required = metadata::get_bool_prop(input_obj, "required") == Some(true);
-                    let has_transform =
-                        metadata::get_source_text(input_obj, "isSignal", source).is_some();
+                    let is_required = metadata::get_bool_prop(input_obj, "isRequired")
+                        == Some(true)
+                        || metadata::get_bool_prop(input_obj, "required") == Some(true);
+                    let is_signal = metadata::get_bool_prop(input_obj, "isSignal") == Some(true);
 
-                    let flags = if required { 1 } else { 0 };
+                    let transform_text = ["transformFunction", "transform"]
+                        .iter()
+                        .find_map(|name| metadata::get_source_text(input_obj, name, source))
+                        .filter(|s| s.trim() != "null");
+                    let has_transform = transform_text.is_some();
 
-                    if has_transform || required || alias != key {
-                        entries.push(format!("{key}: [{flags}, '{alias}', '{key}']"));
+                    let mut flags: u32 = 0;
+                    if is_signal {
+                        flags |= 1; // InputFlags.SignalBased
+                    }
+                    if has_transform {
+                        flags |= 2; // InputFlags.HasDecoratorInputTransform
+                    }
+
+                    if has_transform || is_signal || is_required || alias != key {
+                        let entry = if let Some(t) = transform_text {
+                            format!("{key}: [{flags}, '{alias}', '{key}', {t}]")
+                        } else {
+                            format!("{key}: [{flags}, '{alias}', '{key}']")
+                        };
+                        entries.push(entry);
                     } else {
                         entries.push(format!("{key}: '{key}'"));
                     }
@@ -404,8 +436,13 @@ fn prop_key_text(key: &PropertyKey<'_>, source: &str) -> String {
 
 /// Build a `contentQueries` function from the declare-format `queries` array.
 ///
-/// Transforms: `[{ propertyName: "links", predicate: RouterLink, descendants: true }]`
-/// Into: `function(rf, ctx, directiveIndex) { if (rf & 1) { ɵɵcontentQuery(directiveIndex, RouterLink, 5); } if (rf & 2) { let _t; ɵɵqueryRefresh(_t = ɵɵloadQuery()) && (ctx.links = _t); } }`
+/// Traditional queries (`@ContentChild`/`@ContentChildren`) compile to a
+/// `ɵɵcontentQuery` create call paired with a `ɵɵqueryRefresh` + `ɵɵloadQuery`
+/// update. Signal-based queries (`contentChild()`, `contentChildren()`) carry
+/// `isSignal: true` in their descriptor and compile to a single
+/// `ɵɵcontentQuerySignal(directiveIndex, ctx.prop, ...)` create call plus a
+/// `ɵɵqueryAdvance()` in the update block — the runtime writes the value
+/// straight into the signal so no manual refresh/load is needed.
 pub(crate) fn build_content_queries(
     queries_source: &str,
     ng_import: &str,
@@ -416,61 +453,15 @@ pub(crate) fn build_content_queries(
     if queries.is_empty() {
         return None;
     }
-
-    let (cq, refresh, load) = if ng_import.is_empty() {
-        (
-            "\u{0275}\u{0275}contentQuery".to_string(),
-            "\u{0275}\u{0275}queryRefresh".to_string(),
-            "\u{0275}\u{0275}loadQuery".to_string(),
-        )
-    } else {
-        (
-            format!("{ng_import}.\u{0275}\u{0275}contentQuery"),
-            format!("{ng_import}.\u{0275}\u{0275}queryRefresh"),
-            format!("{ng_import}.\u{0275}\u{0275}loadQuery"),
-        )
-    };
-
-    let mut create_stmts = Vec::new();
-    let mut update_stmts = Vec::new();
-
-    for q in &queries {
-        let flags = compute_query_flags(q);
-        let read_arg = if let Some(ref read) = q.read {
-            format!(", {read}")
-        } else {
-            String::new()
-        };
-        create_stmts.push(format!(
-            "{cq}(directiveIndex, {}, {flags}{read_arg});",
-            q.predicate
-        ));
-        let assign_expr = if q.first {
-            format!("ctx.{} = _t.first", q.property_name)
-        } else {
-            format!("ctx.{} = _t", q.property_name)
-        };
-        update_stmts.push(format!(
-            "let _t; {refresh}(_t = {load}()) && ({assign_expr});"
-        ));
-    }
-
-    let mut body = String::from("if (rf & 1) { ");
-    for s in &create_stmts {
-        body.push_str(s);
-        body.push(' ');
-    }
-    body.push_str("} if (rf & 2) { ");
-    for s in &update_stmts {
-        body.push_str(s);
-        body.push(' ');
-    }
-    body.push('}');
-
+    let body = build_query_body(&queries, ng_import, true);
     Some(format!("function(rf, ctx, directiveIndex) {{ {body} }}"))
 }
 
 /// Build a `viewQuery` function from the declare-format `viewQueries` array.
+///
+/// See [`build_content_queries`] for the signal-vs-traditional split — this
+/// is the view-query variant: signals dispatch to `ɵɵviewQuerySignal` and
+/// the function takes only `(rf, ctx)` (no `directiveIndex`).
 pub(crate) fn build_view_queries(
     queries_source: &str,
     ng_import: &str,
@@ -481,40 +472,90 @@ pub(crate) fn build_view_queries(
     if queries.is_empty() {
         return None;
     }
+    let body = build_query_body(&queries, ng_import, false);
+    Some(format!("function(rf, ctx) {{ {body} }}"))
+}
 
-    let (vq, refresh, load) = if ng_import.is_empty() {
-        (
-            "\u{0275}\u{0275}viewQuery".to_string(),
-            "\u{0275}\u{0275}queryRefresh".to_string(),
-            "\u{0275}\u{0275}loadQuery".to_string(),
-        )
-    } else {
-        (
-            format!("{ng_import}.\u{0275}\u{0275}viewQuery"),
-            format!("{ng_import}.\u{0275}\u{0275}queryRefresh"),
-            format!("{ng_import}.\u{0275}\u{0275}loadQuery"),
-        )
+/// Generate the `if (rf & 1) { ... } if (rf & 2) { ... }` body shared by
+/// content and view query functions. `is_content` toggles between the
+/// content (`directiveIndex` parameter, `ɵɵcontentQuery*` instructions) and
+/// view (`ɵɵviewQuery*`) variants.
+fn build_query_body(queries: &[QueryDescriptor], ng_import: &str, is_content: bool) -> String {
+    let prefix = |sym: &str| -> String {
+        if ng_import.is_empty() {
+            format!("\u{0275}\u{0275}{sym}")
+        } else {
+            format!("{ng_import}.\u{0275}\u{0275}{sym}")
+        }
     };
+    let q_traditional = prefix(if is_content {
+        "contentQuery"
+    } else {
+        "viewQuery"
+    });
+    let q_signal = prefix(if is_content {
+        "contentQuerySignal"
+    } else {
+        "viewQuerySignal"
+    });
+    let refresh = prefix("queryRefresh");
+    let load = prefix("loadQuery");
+    let advance = prefix("queryAdvance");
 
     let mut create_stmts = Vec::new();
     let mut update_stmts = Vec::new();
 
-    for q in &queries {
+    for q in queries {
         let flags = compute_query_flags(q);
         let read_arg = if let Some(ref read) = q.read {
             format!(", {read}")
         } else {
             String::new()
         };
-        create_stmts.push(format!("{vq}({}, {flags}{read_arg});", q.predicate));
-        let assign_expr = if q.first {
-            format!("ctx.{} = _t.first", q.property_name)
+
+        if q.is_signal {
+            // Signal-based query: the runtime writes the resolved value(s)
+            // straight into the WritableSignal stored on `ctx.<prop>`. No
+            // intermediate QueryList — the create call hands the runtime
+            // the signal target, and a single `ɵɵqueryAdvance()` per query
+            // bumps the query index in the update block so that successive
+            // queries map to the right LView slots.
+            let target = format!("ctx.{}", q.property_name);
+            if is_content {
+                create_stmts.push(format!(
+                    "{q_signal}(directiveIndex, {target}, {}, {flags}{read_arg});",
+                    q.predicate
+                ));
+            } else {
+                create_stmts.push(format!(
+                    "{q_signal}({target}, {}, {flags}{read_arg});",
+                    q.predicate
+                ));
+            }
+            update_stmts.push(format!("{advance}();"));
         } else {
-            format!("ctx.{} = _t", q.property_name)
-        };
-        update_stmts.push(format!(
-            "let _t; {refresh}(_t = {load}()) && ({assign_expr});"
-        ));
+            // Decorator-style query: the runtime stores the QueryList in
+            // an LView slot and we manually refresh + write to the field.
+            if is_content {
+                create_stmts.push(format!(
+                    "{q_traditional}(directiveIndex, {}, {flags}{read_arg});",
+                    q.predicate
+                ));
+            } else {
+                create_stmts.push(format!(
+                    "{q_traditional}({}, {flags}{read_arg});",
+                    q.predicate
+                ));
+            }
+            let assign_expr = if q.first {
+                format!("ctx.{} = _t.first", q.property_name)
+            } else {
+                format!("ctx.{} = _t", q.property_name)
+            };
+            update_stmts.push(format!(
+                "let _t; {refresh}(_t = {load}()) && ({assign_expr});"
+            ));
+        }
     }
 
     let mut body = String::from("if (rf & 1) { ");
@@ -528,8 +569,7 @@ pub(crate) fn build_view_queries(
         body.push(' ');
     }
     body.push('}');
-
-    Some(format!("function(rf, ctx) {{ {body} }}"))
+    body
 }
 
 /// A parsed query descriptor.
@@ -540,6 +580,10 @@ struct QueryDescriptor {
     is_static: bool,
     read: Option<String>,
     first: bool,
+    /// Set when the partial declaration marks this query as signal-based
+    /// (e.g. `viewChild()`/`contentChild()`). Drives the dispatch to
+    /// `ɵɵviewQuerySignal`/`ɵɵcontentQuerySignal` + `ɵɵqueryAdvance`.
+    is_signal: bool,
 }
 
 /// Compute the flags integer for a query.
@@ -594,6 +638,7 @@ fn parse_query_descriptors(
             let is_static = metadata::get_bool_prop(desc_obj, "static").unwrap_or(false);
             let first = metadata::get_bool_prop(desc_obj, "first").unwrap_or(false);
             let read = metadata::get_source_text(desc_obj, "read", source).map(|s| s.to_string());
+            let is_signal = metadata::get_bool_prop(desc_obj, "isSignal").unwrap_or(false);
 
             descriptors.push(QueryDescriptor {
                 property_name,
@@ -602,6 +647,7 @@ fn parse_query_descriptors(
                 is_static,
                 read,
                 first,
+                is_signal,
             });
         }
     }
@@ -683,6 +729,191 @@ mod tests {
         );
         assert!(result.contains("inputs:"));
         assert!(result.contains("outputs:"));
+    }
+
+    /// `input()` (signal-based) lands in the partial declaration as an
+    /// object descriptor with `isSignal: true`. The linker has to flip
+    /// bit 0 of the input flags so the runtime treats it as a signal —
+    /// otherwise the directive's value-setter writes to a plain field
+    /// and the signal's subscribers never fire.
+    #[test]
+    fn test_signal_input_sets_signal_flag() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: { classPropertyName: 'value', publicName: 'value', isSignal: true, isRequired: false, transformFunction: null } } }",
+        );
+        assert!(
+            result.contains("inputs: { value: [1, 'value', 'value'] }"),
+            "expected SignalBased flag (1) in input array, got: {result}"
+        );
+    }
+
+    /// `input.required()` carries both `isSignal: true` and
+    /// `isRequired: true`. Required has no separate runtime flag — only
+    /// SignalBased should be set.
+    #[test]
+    fn test_signal_input_required_sets_signal_flag_only() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: { classPropertyName: 'value', publicName: 'value', isSignal: true, isRequired: true, transformFunction: null } } }",
+        );
+        assert!(
+            result.contains("inputs: { value: [1, 'value', 'value'] }"),
+            "expected SignalBased flag only for required signal input, got: {result}"
+        );
+    }
+
+    /// `input()` with an alias (`{ alias: 'aliased' }` at the call site)
+    /// surfaces as `publicName !== classPropertyName`. The linker must
+    /// preserve the alias in array position 1 alongside the signal flag.
+    #[test]
+    fn test_signal_input_with_alias() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: { classPropertyName: 'value', publicName: 'aliasedName', isSignal: true, isRequired: false, transformFunction: null } } }",
+        );
+        assert!(
+            result.contains("inputs: { value: [1, 'aliasedName', 'value'] }"),
+            "expected aliased signal input to keep the public name, got: {result}"
+        );
+    }
+
+    /// `input(0, { transform: trimString })` ships the transform
+    /// expression in the partial declaration. It must survive into the
+    /// runtime call as the 4th array element AND set the
+    /// `HasDecoratorInputTransform` flag (bit 1), which is what tells
+    /// the runtime to invoke the function on every value write.
+    #[test]
+    fn test_signal_input_with_transform() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: { classPropertyName: 'value', publicName: 'value', isSignal: true, isRequired: false, transformFunction: trimString } } }",
+        );
+        assert!(
+            result.contains("inputs: { value: [3, 'value', 'value', trimString] }"),
+            "expected SignalBased|HasDecoratorInputTransform with transform ref, got: {result}"
+        );
+    }
+
+    /// Decorator-style `@Input({ transform: trimString })` carries the
+    /// transform without `isSignal`. Only the transform flag should be
+    /// set.
+    #[test]
+    fn test_decorator_input_with_transform_no_signal() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: { classPropertyName: 'value', publicName: 'value', isSignal: false, isRequired: false, transformFunction: trimString } } }",
+        );
+        assert!(
+            result.contains("inputs: { value: [2, 'value', 'value', trimString] }"),
+            "expected HasDecoratorInputTransform-only for decorator transform, got: {result}"
+        );
+    }
+
+    /// `transformFunction: null` must NOT make it into the runtime
+    /// array — that would shift the array positions and cause the
+    /// runtime to call `null` as a function on every binding tick.
+    #[test]
+    fn test_null_transform_function_omitted() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', inputs: { value: { classPropertyName: 'value', publicName: 'value', isSignal: true, isRequired: false, transformFunction: null } } }",
+        );
+        assert!(
+            !result.contains(", null"),
+            "literal `null` transform must not be emitted as 4th element, got: {result}"
+        );
+    }
+
+    /// `viewChild()` lands in `viewQueries` with `isSignal: true`. The
+    /// runtime variant `ɵɵviewQuerySignal` takes the signal's storage
+    /// slot directly (`ctx.<prop>`) so it can write resolved values into
+    /// the signal — no `ɵɵqueryRefresh` plumbing is needed. The update
+    /// block emits a single `ɵɵqueryAdvance()` to keep the query index
+    /// in sync.
+    #[test]
+    fn test_signal_view_query_emits_view_query_signal() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', viewQueries: [{ propertyName: 'child', predicate: ChildCmp, descendants: true, first: true, isSignal: true, static: false }] }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}viewQuerySignal(ctx.child, ChildCmp, 1)"),
+            "expected ɵɵviewQuerySignal create call, got: {result}"
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}queryAdvance();"),
+            "expected ɵɵqueryAdvance update call, got: {result}"
+        );
+        // Traditional refresh/load must NOT show up for a pure-signal query.
+        assert!(
+            !result.contains("queryRefresh"),
+            "signal queries should not use ɵɵqueryRefresh, got: {result}"
+        );
+    }
+
+    /// `viewChildren()` (plural) carries `first: false` and produces a
+    /// signal whose value is a readonly array. The runtime call shape
+    /// is the same `ɵɵviewQuerySignal` — `first` only changes what the
+    /// runtime writes into the signal, not the create-call form.
+    #[test]
+    fn test_signal_view_query_plural() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', viewQueries: [{ propertyName: 'children', predicate: ChildCmp, descendants: true, first: false, isSignal: true, static: false }] }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}viewQuerySignal(ctx.children, ChildCmp, 5)"),
+            "expected ɵɵviewQuerySignal with descendants|emitDistinctChangesOnly flags (1|4=5), got: {result}"
+        );
+    }
+
+    /// `contentChild()` lands in `queries` with `isSignal: true` and
+    /// must dispatch to `ɵɵcontentQuerySignal` with the directive index
+    /// as the leading argument.
+    #[test]
+    fn test_signal_content_query_emits_content_query_signal() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', queries: [{ propertyName: 'projected', predicate: SomeDir, descendants: true, first: true, isSignal: true, static: false }] }",
+        );
+        assert!(
+            result.contains(
+                "i0.\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.projected, SomeDir, 1)"
+            ),
+            "expected ɵɵcontentQuerySignal create call with directiveIndex, got: {result}"
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}queryAdvance();"),
+            "expected ɵɵqueryAdvance update call, got: {result}"
+        );
+    }
+
+    /// `viewChild('ref', { read: ElementRef })` propagates the read
+    /// token as the trailing argument so the runtime resolves the
+    /// `ElementRef` rather than the matched directive instance.
+    #[test]
+    fn test_signal_view_query_with_read() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', viewQueries: [{ propertyName: 'el', predicate: ['ref'], descendants: true, first: true, isSignal: true, static: false, read: ElementRef }] }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}viewQuerySignal(ctx.el, ['ref'], 1, ElementRef)"),
+            "expected read token preserved as 4th arg, got: {result}"
+        );
+    }
+
+    /// Traditional non-signal queries must continue to compile to the
+    /// `ɵɵviewQuery` + `ɵɵqueryRefresh`/`ɵɵloadQuery` shape — adding
+    /// signal support cannot regress decorator-style `@ViewChild`.
+    #[test]
+    fn test_non_signal_view_query_still_uses_refresh_load() {
+        let result = parse_and_transform(
+            "{ type: MyDir, selector: '[myDir]', viewQueries: [{ propertyName: 'child', predicate: ChildCmp, descendants: true, first: true, static: false }] }",
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}viewQuery(ChildCmp, 1)"),
+            "expected ɵɵviewQuery (decorator-style), got: {result}"
+        );
+        assert!(
+            result.contains("i0.\u{0275}\u{0275}queryRefresh"),
+            "expected ɵɵqueryRefresh in update block, got: {result}"
+        );
+        assert!(
+            !result.contains("viewQuerySignal"),
+            "decorator-style query must not dispatch to signal variant: {result}"
+        );
     }
 
     #[test]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -302,6 +302,15 @@ pub fn generate_ivy(
         // property/listener bindings through the animation renderer.
         dc.push_str(&format!(",\n    data: {{ animation: {animations_src} }}"));
     }
+    if let Some(cd) = component.change_detection {
+        // `changeDetection: 0` (`OnPush`) is what flips
+        // `def.onPush = true`, which in turn makes the runtime use
+        // OnPush-style refresh — the only mode that respects signal-driven
+        // change detection in zoneless apps. Without it, components
+        // running under `provideZonelessChangeDetection()` never re-render
+        // on signal writes and event-handler updates appear inert.
+        dc.push_str(&format!(",\n    changeDetection: {cd}"));
+    }
     dc.push_str("\n  })");
 
     // Collect child template functions
@@ -3735,6 +3744,7 @@ mod tests {
             signal_outputs: Vec::new(),
             signal_models: Vec::new(),
             signal_queries: Vec::new(),
+            change_detection: None,
         }
     }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -742,13 +742,28 @@ impl IvyCodegen {
                         }
                     }
                     TemplateAttribute::TwoWayBinding { name, expression } => {
+                        // Two-way listener `(xChange)="expr = $event"`
+                        // for signal-aware bindings: the runtime helper
+                        // `ɵɵtwoWayBindingSet(target, value)` calls
+                        // `.set(value)` on a `WritableSignal` and
+                        // returns `true`; for non-signals it returns
+                        // `false`, so the `||` falls through to a
+                        // plain assignment. Writing `target = $event`
+                        // unconditionally would replace the signal
+                        // FIELD on the parent (turning
+                        // `parentActive: WritableSignal<boolean>` into
+                        // `parentActive: boolean`), and the very next
+                        // `parentActive()` template read would throw
+                        // "is not a function".
                         self.ivy_imports
-                            .insert("\u{0275}\u{0275}listener".to_string());
+                            .insert("\u{0275}\u{0275}twoWayListener".to_string());
+                        self.ivy_imports
+                            .insert("\u{0275}\u{0275}twoWayBindingSet".to_string());
                         let depth = self.scope_depth();
-                        // Template refs stay as bare identifiers; they resolve
-                        // via the `const <name> = ɵɵreference(<slot>);` prelude
-                        // at the top of the update block / listener body.
                         let compiled_target = ctx_expr_with_locals(expression, &self.local_vars);
+                        let body = format!(
+                            "\u{0275}\u{0275}twoWayBindingSet({compiled_target}, $event) || ({compiled_target} = $event); return $event;"
+                        );
                         if depth > 0 {
                             self.ivy_imports
                                 .insert("\u{0275}\u{0275}restoreView".to_string());
@@ -756,12 +771,12 @@ impl IvyCodegen {
                                 .insert("\u{0275}\u{0275}nextContext".to_string());
                             let listener_preamble = self.generate_listener_preamble();
                             self.creation.push(format!(
-                                "\u{0275}\u{0275}listener('{}Change', function($event) {{ {listener_preamble}return {compiled_target} = $event; }});",
+                                "\u{0275}\u{0275}twoWayListener('{}Change', function($event) {{ {listener_preamble}{body} }});",
                                 name,
                             ));
                         } else {
                             self.creation.push(format!(
-                                "\u{0275}\u{0275}listener('{}Change', function($event) {{ return {compiled_target} = $event; }});",
+                                "\u{0275}\u{0275}twoWayListener('{}Change', function($event) {{ {body} }});",
                                 name,
                             ));
                         }
@@ -2360,11 +2375,24 @@ impl IvyCodegen {
                     }
                 }
                 TemplateAttribute::TwoWayBinding { name, expression } => {
+                    // Two-way binding `[(x)]="expr"` must dispatch to
+                    // the signal-aware `ɵɵtwoWayProperty` instead of
+                    // `ɵɵproperty`. When `expr` is a `WritableSignal`,
+                    // `ɵɵtwoWayProperty` unwraps it (calls the signal
+                    // to read the value); for plain values it behaves
+                    // like `ɵɵproperty`. Emitting `ɵɵproperty(name,
+                    // signalRef)` would pass the signal OBJECT into
+                    // the child input, so the child sees the wrapper
+                    // rather than the value and template reads
+                    // (`signal()`) on the parent later see whatever
+                    // the listener wrote (likely a non-callable).
                     self.ivy_imports
-                        .insert("\u{0275}\u{0275}property".to_string());
+                        .insert("\u{0275}\u{0275}twoWayProperty".to_string());
                     let compiled = self.compile_binding_expr(expression);
-                    self.update
-                        .push(format!("\u{0275}\u{0275}property('{}', {compiled});", name,));
+                    self.update.push(format!(
+                        "\u{0275}\u{0275}twoWayProperty('{}', {compiled});",
+                        name,
+                    ));
                     self.var_count += 1;
                 }
                 TemplateAttribute::ClassBinding {

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -81,6 +81,19 @@ struct IvyCodegen {
     /// Entering `<svg>` pushes Svg; `<math>` pushes MathMl; `<foreignObject>`
     /// (which is itself SVG) pushes Html so its HTML descendants render correctly.
     namespace_stack: Vec<Namespace>,
+    /// `true` once a `<ng-content>` is encountered. Triggers two
+    /// out-of-band emissions on the host component:
+    ///   1. `ɵɵprojectionDef()` at the head of the create block — the
+    ///      runtime walks projected nodes through `tNode.projection`
+    ///      which `ɵɵprojection(idx)` later reads. Without the def
+    ///      call that field stays null and `ɵɵprojection` blows up
+    ///      with `Cannot read properties of null (reading '0')`.
+    ///   2. `ngContentSelectors: ['*']` on the `defineComponent` call
+    ///      so Angular's runtime knows what selectors the host
+    ///      projects. Default-projection components only need `['*']`;
+    ///      multi-slot projection (`<ng-content select="...">`) is
+    ///      not yet implemented.
+    has_projection: bool,
 }
 
 struct ChildTemplate {
@@ -114,6 +127,7 @@ pub fn generate_ivy(
         template_refs: BTreeMap::new(),
         namespace_state: Namespace::Html,
         namespace_stack: vec![Namespace::Html],
+        has_projection: false,
     };
 
     gen.ivy_imports
@@ -131,6 +145,17 @@ pub fn generate_ivy(
     let mut template_body = String::new();
     if !gen.creation.is_empty() {
         template_body.push_str("    if (rf & 1) {\n");
+        // When the template uses `<ng-content>`, the runtime needs
+        // `ɵɵprojectionDef()` to run once at the head of the create
+        // block so it can stash the projected children's TNodes onto
+        // the host's TNode. Subsequent `ɵɵprojection(idx)` calls then
+        // read `tNode.projection[idx]` — without the def call that's
+        // null and the runtime throws on the first projection.
+        if gen.has_projection {
+            gen.ivy_imports
+                .insert("\u{0275}\u{0275}projectionDef".to_string());
+            template_body.push_str("      \u{0275}\u{0275}projectionDef();\n");
+        }
         for instr in &gen.creation {
             template_body.push_str("      ");
             template_body.push_str(instr);
@@ -222,6 +247,15 @@ pub fn generate_ivy(
         dc.push_str(&format!(
             "    features: [\u{0275}\u{0275}HostDirectivesFeature({normalised})],\n"
         ));
+    }
+    // Components that project content need `ngContentSelectors` on the
+    // def so Angular's runtime can match `<ng-content select="...">`
+    // against the host's projected children. We only emit `<ng-content>`
+    // (no select-attribute support yet), so a single-entry `['*']`
+    // (catch-all) selector list is sufficient. The matching
+    // `ɵɵprojectionDef()` call lives at the head of the create block.
+    if gen.has_projection {
+        dc.push_str("    ngContentSelectors: [\"*\"],\n");
     }
     if !gen.consts.is_empty() {
         dc.push_str(&format!("    consts: [{}],\n", gen.consts.join(", ")));
@@ -439,8 +473,14 @@ impl IvyCodegen {
         // Special Angular elements
         match el.tag.as_str() {
             "ng-content" => {
+                // `ɵɵprojection(idx)` reads `tNode.projection` to find
+                // the projected children for slot `idx`. That field is
+                // populated by `ɵɵprojectionDef()`, which has to run
+                // *once* at the head of the host component's create
+                // block — see `has_projection` in the codegen state.
                 let slot = self.slot_index;
                 self.slot_index += 1;
+                self.has_projection = true;
                 self.ivy_imports
                     .insert("\u{0275}\u{0275}projection".to_string());
                 self.creation

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -168,14 +168,32 @@ pub fn generate_ivy(
     if component.standalone {
         dc.push_str("    standalone: true,\n");
     }
-    // Generate inputs property from @Input() decorated properties
-    if !component.input_properties.is_empty() {
-        let inputs: Vec<String> = component
-            .input_properties
-            .iter()
-            .map(|p| format!("{p}: '{p}'"))
-            .collect();
-        dc.push_str(&format!("    inputs: {{ {} }},\n", inputs.join(", ")));
+    // Merge `@Input()` decorator-style fields and signal-API class-field
+    // initialisations (`input()`, `output()`, `model()`, view/content
+    // queries) into a single `inputs` / `outputs` map plus optional
+    // `viewQuery` / `contentQueries` functions. Signal-based inputs
+    // ride along with the `SignalBased` runtime flag so the directive
+    // runtime knows to write into the WritableSignal rather than a
+    // plain field.
+    let signal_members = crate::signal_codegen::compile_signal_members(
+        &component.input_properties,
+        &component.signal_inputs,
+        &component.signal_outputs,
+        &component.signal_models,
+        &component.signal_queries,
+    );
+    for sym in &signal_members.ivy_imports {
+        gen.ivy_imports.insert(sym.clone());
+    }
+    if let Some(inputs) =
+        crate::signal_codegen::format_map("inputs", &signal_members.inputs_entries)
+    {
+        dc.push_str(&format!("    {inputs},\n"));
+    }
+    if let Some(outputs) =
+        crate::signal_codegen::format_map("outputs", &signal_members.outputs_entries)
+    {
+        dc.push_str(&format!("    {outputs},\n"));
     }
     let host_props = crate::directive_codegen::build_host_props(
         &component.host_listeners,
@@ -216,6 +234,21 @@ pub fn generate_ivy(
     ));
     dc.push_str(&template_body);
     dc.push_str("    }");
+
+    // Signal-based queries are emitted as their own `viewQuery` /
+    // `contentQueries` functions on the define call (signal queries
+    // and decorator-style queries can't share a function — the signal
+    // variant uses `ɵɵqueryAdvance`, the decorator variant uses
+    // `ɵɵqueryRefresh`/`ɵɵloadQuery`). When this component eventually
+    // supports decorator-style `@ViewChild` queries on the AOT path
+    // too, those will need to be merged in here as additional
+    // statements within the same function body.
+    if let Some(ref vq) = signal_members.view_query_prop {
+        dc.push_str(&format!(",\n    {vq}"));
+    }
+    if let Some(ref cq) = signal_members.content_queries_prop {
+        dc.push_str(&format!(",\n    {cq}"));
+    }
 
     // Component dependencies. Emit the imports array verbatim here; the linker's
     // post-pass (crates/linker/src/module_registry.rs) walks every
@@ -3630,6 +3663,10 @@ mod tests {
             host_bindings: Vec::new(),
             animations_source: None,
             host_directives_source: None,
+            signal_inputs: Vec::new(),
+            signal_outputs: Vec::new(),
+            signal_models: Vec::new(),
+            signal_queries: Vec::new(),
         }
     }
 

--- a/crates/template-compiler/src/directive_codegen.rs
+++ b/crates/template-compiler/src/directive_codegen.rs
@@ -47,12 +47,42 @@ pub fn generate_directive_ivy(extracted: &ExtractedDirective) -> NgcResult<IvyOu
         props.push(format!("selectors: {}", selector::parse_selector(sel)));
     }
 
-    if let Some(ref inputs_src) = extracted.inputs_source {
-        props.push(format!("inputs: {inputs_src}"));
+    // Decorator-literal `inputs:` / `outputs:` come through verbatim
+    // as raw source. Signal-API class fields (`input()`, `output()`,
+    // `model()`, view/content queries) are merged in via
+    // `compile_signal_members`. When both shapes coexist on a directive
+    // the literal wins as the base and the signal entries are appended
+    // — Angular's compiler does the same.
+    let signal_members = crate::signal_codegen::compile_signal_members(
+        &[],
+        &extracted.signal_inputs,
+        &extracted.signal_outputs,
+        &extracted.signal_models,
+        &extracted.signal_queries,
+    );
+    for sym in &signal_members.ivy_imports {
+        ivy_imports.insert(sym.clone());
     }
 
-    if let Some(ref outputs_src) = extracted.outputs_source {
-        props.push(format!("outputs: {outputs_src}"));
+    let inputs_block = build_inputs_block(
+        extracted.inputs_source.as_deref(),
+        &signal_members.inputs_entries,
+    );
+    if let Some(b) = inputs_block {
+        props.push(b);
+    }
+    let outputs_block = build_outputs_block(
+        extracted.outputs_source.as_deref(),
+        &signal_members.outputs_entries,
+    );
+    if let Some(b) = outputs_block {
+        props.push(b);
+    }
+    if let Some(ref vq) = signal_members.view_query_prop {
+        props.push(vq.clone());
+    }
+    if let Some(ref cq) = signal_members.content_queries_prop {
+        props.push(cq.clone());
     }
 
     let host_props = build_host_props(&extracted.host_listeners, &extracted.host_bindings);
@@ -161,6 +191,63 @@ pub(crate) fn build_host_props(
     }
 }
 
+/// Combine the decorator-literal `inputs:` source (if any) with the
+/// signal-API entries produced by `signal_codegen` into a single
+/// `inputs: { ... }` property string.
+///
+/// When both are empty we return `None` so the caller can skip the
+/// property altogether — Angular's runtime treats a missing `inputs`
+/// the same as an empty map, and the smaller emit reads cleaner in
+/// codegen golden tests.
+///
+/// Splicing the two together by trimming the literal's outer braces is
+/// crude but sufficient: the decorator literal is always an
+/// `ObjectExpression` (the extractor only fills `inputs_source` from
+/// an object value), so matching the leading `{` / trailing `}` is
+/// safe.
+fn build_inputs_block(literal_src: Option<&str>, signal_entries: &[String]) -> Option<String> {
+    match (literal_src, signal_entries.is_empty()) {
+        (None, true) => None,
+        (Some(src), true) => Some(format!("inputs: {src}")),
+        (None, false) => Some(format!("inputs: {{ {} }}", signal_entries.join(", "))),
+        (Some(src), false) => {
+            let inner = src
+                .trim()
+                .trim_start_matches('{')
+                .trim_end_matches('}')
+                .trim();
+            let combined = if inner.is_empty() {
+                signal_entries.join(", ")
+            } else {
+                format!("{inner}, {}", signal_entries.join(", "))
+            };
+            Some(format!("inputs: {{ {combined} }}"))
+        }
+    }
+}
+
+/// Same idea as [`build_inputs_block`], for the `outputs` map.
+fn build_outputs_block(literal_src: Option<&str>, signal_entries: &[String]) -> Option<String> {
+    match (literal_src, signal_entries.is_empty()) {
+        (None, true) => None,
+        (Some(src), true) => Some(format!("outputs: {src}")),
+        (None, false) => Some(format!("outputs: {{ {} }}", signal_entries.join(", "))),
+        (Some(src), false) => {
+            let inner = src
+                .trim()
+                .trim_start_matches('{')
+                .trim_end_matches('}')
+                .trim();
+            let combined = if inner.is_empty() {
+                signal_entries.join(", ")
+            } else {
+                format!("{inner}, {}", signal_entries.join(", "))
+            };
+            Some(format!("outputs: {{ {combined} }}"))
+        }
+    }
+}
+
 /// Map a host binding target to the Ivy runtime symbol it dispatches to.
 /// Mirrors the dispatch logic in `host_codegen::dispatch_property_binding`.
 fn host_instruction_for(target: &str) -> &'static str {
@@ -198,6 +285,10 @@ mod tests {
             host_listeners: Vec::new(),
             host_bindings: Vec::new(),
             host_directives_source: None,
+            signal_inputs: Vec::new(),
+            signal_outputs: Vec::new(),
+            signal_models: Vec::new(),
+            signal_queries: Vec::new(),
             common: DecoratorCommon {
                 decorator_span: (0, 0),
                 class_body_start: 0,

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -1161,12 +1161,21 @@ pub(crate) fn extract_signal_members(
                 });
             }
             SignalFactory::Query { kind, .. } => {
+                // Predicate handling matches Angular's compiler:
+                //   * String literal `viewChild('ref')` → `['ref']`. Bare
+                //     strings would otherwise be read as a `ProviderToken`
+                //     and the runtime would never resolve the template ref.
+                //   * Anything else (class ref, `InjectionToken`, array
+                //     literal) flows through verbatim.
                 let predicate_source = call
                     .arguments
                     .first()
-                    .map(|arg| {
-                        let span = arg.span();
-                        source[span.start as usize..span.end as usize].to_string()
+                    .map(|arg| match arg {
+                        Argument::StringLiteral(s) => format!("['{}']", s.value),
+                        _ => {
+                            let span = arg.span();
+                            source[span.start as usize..span.end as usize].to_string()
+                        }
                     })
                     .unwrap_or_else(|| "null".to_string());
                 let (_, _, read_source, is_static) = parse_signal_options(source, call, 1);
@@ -2140,7 +2149,10 @@ export class XComponent {
             by_name("cs").kind,
             SignalQueryKind::ContentChildren
         ));
-        assert_eq!(by_name("v").predicate_source, "'ref'");
+        // Bare string predicate must be wrapped in an array — the
+        // runtime distinguishes `['ref']` (template ref) from `'ref'`
+        // (provider token).
+        assert_eq!(by_name("v").predicate_source, "['ref']");
         assert_eq!(by_name("cs").read_source.as_deref(), Some("ElementRef"));
     }
 

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -72,6 +72,14 @@ pub struct ExtractedComponent {
     /// `features` array. Accepts both bare class refs (e.g. `[Foo]`) and the
     /// object form (`[{directive: Foo, inputs: ['x'], outputs: [...]}]`).
     pub host_directives_source: Option<String>,
+    /// Class fields initialised with `input(...)` / `input.required(...)`.
+    pub signal_inputs: Vec<SignalInputSpec>,
+    /// Class fields initialised with `output(...)`.
+    pub signal_outputs: Vec<SignalOutputSpec>,
+    /// Class fields initialised with `model(...)` / `model.required(...)`.
+    pub signal_models: Vec<SignalModelSpec>,
+    /// Class fields initialised with `viewChild`/`viewChildren`/`contentChild`/`contentChildren`.
+    pub signal_queries: Vec<SignalQuerySpec>,
 }
 
 /// A method-level `@HostListener(event, [args])` extraction.
@@ -95,6 +103,106 @@ pub struct HostBindingSpec {
     /// The class field/getter that supplies the value. Compiled to `ctx.<name>`
     /// at codegen time.
     pub property_name: String,
+}
+
+/// A class field initialised with `input(...)` or `input.required(...)`.
+///
+/// Captures everything `ɵɵdefineDirective` / `ɵɵdefineComponent` need to
+/// emit a runtime `inputs` entry with the `SignalBased` flag set: the
+/// optional alias (becomes `publicName`), whether it's required, and the
+/// raw source of the `transform` reference so it survives codegen as a
+/// callable expression rather than a stringified value.
+#[derive(Debug, Clone)]
+pub struct SignalInputSpec {
+    /// The class field name (e.g. `name` for `name = input(...)`).
+    pub property_name: String,
+    /// `alias` from the options object, if any. Defaults to `property_name`.
+    pub alias: Option<String>,
+    /// Whether the call site was `input.required(...)` (vs. `input(...)`).
+    pub is_required: bool,
+    /// Raw source text of the `transform` reference, if present (e.g.
+    /// `trimString` or `(v) => v.trim()`). `None` means no transform.
+    pub transform_source: Option<String>,
+}
+
+/// A class field initialised with `output(...)`.
+///
+/// Outputs only need a public name — the runtime treats them as plain
+/// strings in the `outputs` map. An alias makes `publicName` differ from
+/// `property_name`.
+#[derive(Debug, Clone)]
+pub struct SignalOutputSpec {
+    /// The class field name.
+    pub property_name: String,
+    /// `alias` from the options object, if any.
+    pub alias: Option<String>,
+}
+
+/// A class field initialised with `model(...)` or `model.required(...)`.
+///
+/// `model<T>()` desugars to a paired signal input + `<name>Change` output,
+/// so every model produces one entry in each runtime map. The alias (if
+/// any) is the public name of the input; the output is always
+/// `<alias>Change`.
+#[derive(Debug, Clone)]
+pub struct SignalModelSpec {
+    pub property_name: String,
+    pub alias: Option<String>,
+    pub is_required: bool,
+}
+
+/// A class field initialised with one of the four signal-query factories
+/// (`viewChild`, `viewChildren`, `contentChild`, `contentChildren`).
+///
+/// `kind` carries both the create-call dispatch (view vs. content) and
+/// whether the query is single-shot (`first: true`) or multi (`false`).
+/// `predicate_source` is preserved verbatim — the predicate may be a
+/// class reference, an `InjectionToken`, or a string literal, all of which
+/// the runtime accepts unchanged.
+#[derive(Debug, Clone)]
+pub struct SignalQuerySpec {
+    pub property_name: String,
+    pub kind: SignalQueryKind,
+    /// Raw source text of the predicate argument
+    /// (e.g. `MyChildComponent`, `'ref'`, `MY_TOKEN`).
+    pub predicate_source: String,
+    /// Raw source text of `read:` from the options object, if any.
+    pub read_source: Option<String>,
+    /// `static: true` from the options object — defaults to `false`.
+    pub is_static: bool,
+}
+
+/// Which signal-query factory created the field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalQueryKind {
+    /// `viewChild()` — single, descendants, dynamic.
+    ViewChild,
+    /// `viewChildren()` — multi, descendants, dynamic.
+    ViewChildren,
+    /// `contentChild()` — single, defaults to non-descendants.
+    ContentChild,
+    /// `contentChildren()` — multi, defaults to non-descendants.
+    ContentChildren,
+}
+
+impl SignalQueryKind {
+    /// `true` for `viewChild` / `contentChild` (single) variants.
+    pub fn is_first(self) -> bool {
+        matches!(self, Self::ViewChild | Self::ContentChild)
+    }
+
+    /// `true` for `viewChild` / `viewChildren` (i.e. emitted into
+    /// `viewQuery`, not `contentQueries`).
+    pub fn is_view(self) -> bool {
+        matches!(self, Self::ViewChild | Self::ViewChildren)
+    }
+
+    /// Default `descendants` flag for the kind. View queries always walk
+    /// descendants; content queries default to direct-children only
+    /// unless the user passes `descendants: true` in options.
+    pub fn default_descendants(self) -> bool {
+        self.is_view()
+    }
 }
 
 impl ExtractedComponent {
@@ -217,6 +325,12 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
 
         let host_listeners = extract_host_listeners(&class.body);
         let host_bindings = extract_host_bindings(&class.body);
+        let SignalMembers {
+            inputs: signal_inputs,
+            outputs: signal_outputs,
+            models: signal_models,
+            queries: signal_queries,
+        } = extract_signal_members(source, &class.body);
 
         return Ok(Some(ExtractedComponent {
             class_name,
@@ -240,6 +354,10 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             host_bindings,
             animations_source: metadata.animations_source,
             host_directives_source: metadata.host_directives_source,
+            signal_inputs,
+            signal_outputs,
+            signal_models,
+            signal_queries,
         }));
     }
 
@@ -340,6 +458,14 @@ pub struct ExtractedDirective {
     pub host_bindings: Vec<HostBindingSpec>,
     /// Raw source text of the `hostDirectives` array (Angular 15+ composition).
     pub host_directives_source: Option<String>,
+    /// Class fields initialised with `input(...)` / `input.required(...)`.
+    pub signal_inputs: Vec<SignalInputSpec>,
+    /// Class fields initialised with `output(...)`.
+    pub signal_outputs: Vec<SignalOutputSpec>,
+    /// Class fields initialised with `model(...)` / `model.required(...)`.
+    pub signal_models: Vec<SignalModelSpec>,
+    /// Class fields initialised with `viewChild`/`viewChildren`/`contentChild`/`contentChildren`.
+    pub signal_queries: Vec<SignalQuerySpec>,
     /// Common decorator fields for rewriting.
     pub common: DecoratorCommon,
 }
@@ -564,6 +690,12 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
 
         let host_listeners = extract_host_listeners(&class.body);
         let host_bindings = extract_host_bindings(&class.body);
+        let SignalMembers {
+            inputs: signal_inputs,
+            outputs: signal_outputs,
+            models: signal_models,
+            queries: signal_queries,
+        } = extract_signal_members(source, &class.body);
 
         return Ok(Some(ExtractedDirective {
             class_name,
@@ -576,6 +708,10 @@ pub fn extract_directive(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             host_listeners,
             host_bindings,
             host_directives_source,
+            signal_inputs,
+            signal_outputs,
+            signal_models,
+            signal_queries,
             common: DecoratorCommon {
                 decorator_span: (decorator.span.start, decorator.span.end),
                 class_body_start,
@@ -945,6 +1081,223 @@ fn decorator_call<'a>(
     } else {
         None
     }
+}
+
+/// Bag of signal-API field initialisations found on a class body.
+///
+/// Returned together because all four kinds (input, output, model, query)
+/// are detected in the same single pass over class fields.
+#[derive(Debug, Default)]
+pub(crate) struct SignalMembers {
+    pub inputs: Vec<SignalInputSpec>,
+    pub outputs: Vec<SignalOutputSpec>,
+    pub models: Vec<SignalModelSpec>,
+    pub queries: Vec<SignalQuerySpec>,
+}
+
+/// Walk a class body and pull out every signal-API field initialiser:
+///   `foo = input(...)` / `input.required(...)`
+///   `foo = output(...)`
+///   `foo = model(...)` / `model.required(...)`
+///   `foo = viewChild|viewChildren|contentChild|contentChildren(...)`
+///
+/// The detection is purely call-shape based: callee identifier (or
+/// `<root>.required` member call) plus the field's right-hand side. We
+/// don't try to resolve imports or types — anything named `input` that's
+/// not the Angular factory will produce a benign signal-input emission
+/// at codegen time, but TypeScript already prevents that case at the
+/// authoring level.
+pub(crate) fn extract_signal_members(
+    source: &str,
+    class_body: &oxc_ast::ast::ClassBody<'_>,
+) -> SignalMembers {
+    let mut out = SignalMembers::default();
+
+    for element in &class_body.body {
+        let ClassElement::PropertyDefinition(prop) = element else {
+            continue;
+        };
+        let property_name = match &prop.key {
+            PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+            PropertyKey::StringLiteral(s) => s.value.to_string(),
+            _ => continue,
+        };
+        let Some(init) = &prop.value else { continue };
+        let Expression::CallExpression(call) = init else {
+            continue;
+        };
+        let Some(factory) = classify_signal_callee(&call.callee) else {
+            continue;
+        };
+
+        match factory {
+            SignalFactory::Input { required } => {
+                let opts_idx = if required { 0 } else { 1 };
+                let (alias, transform_source, _read, _is_static) =
+                    parse_signal_options(source, call, opts_idx);
+                out.inputs.push(SignalInputSpec {
+                    property_name,
+                    alias,
+                    is_required: required,
+                    transform_source,
+                });
+            }
+            SignalFactory::Output => {
+                // `output()` / `output<T>()` only accepts an optional
+                // options object as its first arg (no positional default).
+                let (alias, _, _, _) = parse_signal_options(source, call, 0);
+                out.outputs.push(SignalOutputSpec {
+                    property_name,
+                    alias,
+                });
+            }
+            SignalFactory::Model { required } => {
+                let opts_idx = if required { 0 } else { 1 };
+                let (alias, _, _, _) = parse_signal_options(source, call, opts_idx);
+                out.models.push(SignalModelSpec {
+                    property_name,
+                    alias,
+                    is_required: required,
+                });
+            }
+            SignalFactory::Query { kind, .. } => {
+                let predicate_source = call
+                    .arguments
+                    .first()
+                    .map(|arg| {
+                        let span = arg.span();
+                        source[span.start as usize..span.end as usize].to_string()
+                    })
+                    .unwrap_or_else(|| "null".to_string());
+                let (_, _, read_source, is_static) = parse_signal_options(source, call, 1);
+                out.queries.push(SignalQuerySpec {
+                    property_name,
+                    kind,
+                    predicate_source,
+                    read_source,
+                    is_static,
+                });
+            }
+        }
+    }
+
+    out
+}
+
+/// What a signal-factory callee resolved to. `required` carries through
+/// for input/model so the codegen can emit a different shape later.
+enum SignalFactory {
+    Input { required: bool },
+    Output,
+    Model { required: bool },
+    Query { kind: SignalQueryKind },
+}
+
+/// Classify a class-field call's callee against the known signal-API
+/// factory names. Recognises bare identifiers (`input(...)`) and the
+/// `.required` member form (`input.required(...)` etc.).
+fn classify_signal_callee(callee: &Expression<'_>) -> Option<SignalFactory> {
+    match callee {
+        Expression::Identifier(id) => name_to_factory(id.name.as_str(), false),
+        Expression::StaticMemberExpression(member) => {
+            let Expression::Identifier(root) = &member.object else {
+                return None;
+            };
+            if member.property.name.as_str() != "required" {
+                return None;
+            }
+            name_to_factory(root.name.as_str(), true)
+        }
+        _ => None,
+    }
+}
+
+/// Map a factory identifier to its [`SignalFactory`] variant. `dotted` is
+/// `true` for the `.required` form — only valid on `input`, `model`,
+/// `viewChild`, `contentChild` (the plural-query variants don't have a
+/// `.required` API).
+fn name_to_factory(name: &str, dotted: bool) -> Option<SignalFactory> {
+    match (name, dotted) {
+        ("input", false) => Some(SignalFactory::Input { required: false }),
+        ("input", true) => Some(SignalFactory::Input { required: true }),
+        ("output", false) => Some(SignalFactory::Output),
+        ("model", false) => Some(SignalFactory::Model { required: false }),
+        ("model", true) => Some(SignalFactory::Model { required: true }),
+        ("viewChild", false) => Some(SignalFactory::Query {
+            kind: SignalQueryKind::ViewChild,
+        }),
+        ("viewChild", true) => Some(SignalFactory::Query {
+            kind: SignalQueryKind::ViewChild,
+        }),
+        ("viewChildren", false) => Some(SignalFactory::Query {
+            kind: SignalQueryKind::ViewChildren,
+        }),
+        ("contentChild", false) => Some(SignalFactory::Query {
+            kind: SignalQueryKind::ContentChild,
+        }),
+        ("contentChild", true) => Some(SignalFactory::Query {
+            kind: SignalQueryKind::ContentChild,
+        }),
+        ("contentChildren", false) => Some(SignalFactory::Query {
+            kind: SignalQueryKind::ContentChildren,
+        }),
+        _ => None,
+    }
+}
+
+/// Pull `alias`, `transform`, `read`, `static` out of an options object
+/// argument at the given positional index, if it's an object literal.
+/// Returns (alias, transform_source, read_source, is_static).
+fn parse_signal_options(
+    source: &str,
+    call: &oxc_ast::ast::CallExpression<'_>,
+    idx: usize,
+) -> (Option<String>, Option<String>, Option<String>, bool) {
+    let Some(arg) = call.arguments.get(idx) else {
+        return (None, None, None, false);
+    };
+    let Argument::ObjectExpression(opts) = arg else {
+        return (None, None, None, false);
+    };
+
+    let mut alias = None;
+    let mut transform = None;
+    let mut read = None;
+    let mut is_static = false;
+
+    for prop in &opts.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+            continue;
+        };
+        let key = match &prop.key {
+            PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+            PropertyKey::StringLiteral(s) => s.value.as_str(),
+            _ => continue,
+        };
+        match key {
+            "alias" => {
+                if let Expression::StringLiteral(s) = &prop.value {
+                    alias = Some(s.value.to_string());
+                }
+            }
+            "transform" => {
+                let span = prop.value.span();
+                transform = Some(source[span.start as usize..span.end as usize].to_string());
+            }
+            "read" => {
+                let span = prop.value.span();
+                read = Some(source[span.start as usize..span.end as usize].to_string());
+            }
+            "static" => {
+                if let Expression::BooleanLiteral(b) = &prop.value {
+                    is_static = b.value;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (alias, transform, read, is_static)
 }
 
 /// Extract constructor parameters from a class body for DI-aware factory generation.
@@ -1638,5 +1991,202 @@ export class XComponent {
         assert_eq!(result.host_bindings.len(), 1);
         assert_eq!(result.host_listeners[0].event, "window:resize");
         assert_eq!(result.host_bindings[0].target, "class.dark");
+    }
+
+    /// `name = input(...)` should land in `signal_inputs` with no alias
+    /// and `is_required = false`. We're verifying the call-shape match
+    /// (bare identifier `input`) more than the option parsing here —
+    /// the option-parsing path is exercised separately.
+    #[test]
+    fn test_extract_signal_input_basic() {
+        let source = r#"import { Component, input } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  name = input('default');
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_inputs.len(), 1);
+        assert_eq!(result.signal_inputs[0].property_name, "name");
+        assert!(result.signal_inputs[0].alias.is_none());
+        assert!(!result.signal_inputs[0].is_required);
+    }
+
+    /// `input.required()` flows through the member-call branch of
+    /// `classify_signal_callee` and must mark the spec as required so
+    /// the codegen can drop the default-value plumbing.
+    #[test]
+    fn test_extract_signal_input_required() {
+        let source = r#"import { Component, input } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  name = input.required<string>();
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_inputs.len(), 1);
+        assert!(result.signal_inputs[0].is_required);
+    }
+
+    /// `input(0, { alias: 'pub', transform: trimString })` must surface
+    /// both the alias (string literal) AND the transform reference
+    /// (preserved verbatim as raw source so the codegen emits a
+    /// callable expression, not a stringified value).
+    #[test]
+    fn test_extract_signal_input_with_alias_and_transform() {
+        let source = r#"import { Component, input } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  name = input('def', { alias: 'pub', transform: trimString });
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_inputs.len(), 1);
+        assert_eq!(result.signal_inputs[0].alias.as_deref(), Some("pub"));
+        assert_eq!(
+            result.signal_inputs[0].transform_source.as_deref(),
+            Some("trimString")
+        );
+    }
+
+    /// `output<T>()` lands in `signal_outputs`. No options — bare call.
+    #[test]
+    fn test_extract_signal_output() {
+        let source = r#"import { Component, output } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  changed = output<string>();
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_outputs.len(), 1);
+        assert_eq!(result.signal_outputs[0].property_name, "changed");
+        assert!(result.signal_outputs[0].alias.is_none());
+    }
+
+    /// `model<T>()` is a separate member kind — must NOT be conflated
+    /// with `input()` / `output()`. The codegen needs to know it's a
+    /// model so it can emit the paired `<name>Change` output.
+    #[test]
+    fn test_extract_signal_model() {
+        let source = r#"import { Component, model } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  value = model<string>('');
+  required = model.required<number>();
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_models.len(), 2);
+        assert_eq!(result.signal_models[0].property_name, "value");
+        assert!(!result.signal_models[0].is_required);
+        assert_eq!(result.signal_models[1].property_name, "required");
+        assert!(result.signal_models[1].is_required);
+        // Models must not double-count as inputs or outputs in the
+        // extracted lists — codegen merges them into the maps itself.
+        assert!(result.signal_inputs.is_empty());
+        assert!(result.signal_outputs.is_empty());
+    }
+
+    /// Each of the four query factories must classify into the right
+    /// `SignalQueryKind` so the codegen splits them into the correct
+    /// `viewQuery` / `contentQueries` function. The `.required` member
+    /// form on `viewChild` / `contentChild` should map to the same
+    /// kind as the bare form (required-ness only changes the
+    /// runtime-level signal default).
+    #[test]
+    fn test_extract_signal_queries_all_kinds() {
+        let source = r#"import { Component, viewChild, viewChildren, contentChild, contentChildren } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  v = viewChild<string>('ref');
+  vs = viewChildren(SomeCmp);
+  c = contentChild.required<SomeDir>(SomeDir);
+  cs = contentChildren(SomeDir, { descendants: true, read: ElementRef });
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_queries.len(), 4);
+
+        let by_name = |n: &str| -> &SignalQuerySpec {
+            result
+                .signal_queries
+                .iter()
+                .find(|q| q.property_name == n)
+                .expect("kind present")
+        };
+        assert!(matches!(by_name("v").kind, SignalQueryKind::ViewChild));
+        assert!(matches!(by_name("vs").kind, SignalQueryKind::ViewChildren));
+        assert!(matches!(by_name("c").kind, SignalQueryKind::ContentChild));
+        assert!(matches!(
+            by_name("cs").kind,
+            SignalQueryKind::ContentChildren
+        ));
+        assert_eq!(by_name("v").predicate_source, "'ref'");
+        assert_eq!(by_name("cs").read_source.as_deref(), Some("ElementRef"));
+    }
+
+    /// `@Directive` should pick up the same signal-API fields that
+    /// `@Component` does — the extraction logic is shared. Confirms
+    /// the directive extractor calls `extract_signal_members` too.
+    #[test]
+    fn test_extract_directive_signal_inputs() {
+        let source = r#"import { Directive, input, output } from '@angular/core';
+
+@Directive({ selector: '[appX]', standalone: true })
+export class XDirective {
+  value = input<string>('');
+  changed = output<string>();
+}
+"#;
+        let result = extract_directive(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert_eq!(result.signal_inputs.len(), 1);
+        assert_eq!(result.signal_inputs[0].property_name, "value");
+        assert_eq!(result.signal_outputs.len(), 1);
+        assert_eq!(result.signal_outputs[0].property_name, "changed");
+    }
+
+    /// A class field initialised by an unrelated function call like
+    /// `someUtil(...)` must NOT be picked up as a signal member.
+    /// Regression guard: the classifier should stop at the bare
+    /// `input` / `output` / `model` / `view*` / `content*` identifiers
+    /// and ignore everything else.
+    #[test]
+    fn test_extract_signal_ignores_unrelated_calls() {
+        let source = r#"import { Component } from '@angular/core';
+
+@Component({ selector: 'app-x', standalone: true, template: '' })
+export class XComponent {
+  data = computeSomething();
+  count = 0;
+}
+"#;
+        let result = extract_component(source, &test_path())
+            .expect("extract")
+            .expect("found");
+        assert!(result.signal_inputs.is_empty());
+        assert!(result.signal_outputs.is_empty());
+        assert!(result.signal_models.is_empty());
+        assert!(result.signal_queries.is_empty());
     }
 }

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -80,6 +80,13 @@ pub struct ExtractedComponent {
     pub signal_models: Vec<SignalModelSpec>,
     /// Class fields initialised with `viewChild`/`viewChildren`/`contentChild`/`contentChildren`.
     pub signal_queries: Vec<SignalQuerySpec>,
+    /// Numeric `ChangeDetectionStrategy` value from the decorator's
+    /// `changeDetection` property (`0` for `OnPush`, `1` for `Default`),
+    /// or `None` when the property is absent. Threaded through to
+    /// `defineComponent({ changeDetection })` — required for zoneless
+    /// apps so `OnPush` components actually mark themselves dirty when
+    /// signal writes happen inside event handlers.
+    pub change_detection: Option<u32>,
 }
 
 /// A method-level `@HostListener(event, [args])` extraction.
@@ -376,6 +383,7 @@ pub fn extract_component(source: &str, file_path: &Path) -> NgcResult<Option<Ext
             signal_outputs,
             signal_models,
             signal_queries,
+            change_detection: metadata.change_detection,
         }));
     }
 
@@ -1441,46 +1449,34 @@ struct DecoratorMetadata {
     style_urls: Vec<String>,
     animations_source: Option<String>,
     host_directives_source: Option<String>,
+    change_detection: Option<u32>,
 }
 
 /// Extract metadata from the `@Component({...})` decorator argument.
 fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<DecoratorMetadata> {
+    let empty = || DecoratorMetadata {
+        selector: String::new(),
+        template: None,
+        template_url: None,
+        standalone: false,
+        imports_source: None,
+        imports_identifiers: Vec::new(),
+        styles_source: None,
+        inline_styles: Vec::new(),
+        style_urls: Vec::new(),
+        animations_source: None,
+        host_directives_source: None,
+        change_detection: None,
+    };
+
     let call = match &decorator.expression {
         Expression::CallExpression(call) => call,
-        _ => {
-            return Ok(DecoratorMetadata {
-                selector: String::new(),
-                template: None,
-                template_url: None,
-                standalone: false,
-                imports_source: None,
-                imports_identifiers: Vec::new(),
-                styles_source: None,
-                inline_styles: Vec::new(),
-                style_urls: Vec::new(),
-                animations_source: None,
-                host_directives_source: None,
-            });
-        }
+        _ => return Ok(empty()),
     };
 
     let arg = match call.arguments.first() {
         Some(Argument::ObjectExpression(obj)) => obj,
-        _ => {
-            return Ok(DecoratorMetadata {
-                selector: String::new(),
-                template: None,
-                template_url: None,
-                standalone: false,
-                imports_source: None,
-                imports_identifiers: Vec::new(),
-                styles_source: None,
-                inline_styles: Vec::new(),
-                style_urls: Vec::new(),
-                animations_source: None,
-                host_directives_source: None,
-            });
-        }
+        _ => return Ok(empty()),
     };
 
     let mut selector = String::new();
@@ -1494,6 +1490,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
     let mut style_urls: Vec<String> = Vec::new();
     let mut animations_source = None;
     let mut host_directives_source = None;
+    let mut change_detection = None;
 
     for prop in &arg.properties {
         if let ObjectPropertyKind::ObjectProperty(prop) = prop {
@@ -1618,6 +1615,24 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
                         host_directives_source = Some(source[start..end].to_string());
                     }
                 }
+                "changeDetection" => {
+                    // Recognise `ChangeDetectionStrategy.OnPush` / `Default`
+                    // member references and lower them to the runtime
+                    // numeric values (0 / 1). Anything else (a literal,
+                    // an aliased import, a ternary) we just leave
+                    // unresolved — the linker / runtime gets a missing
+                    // `changeDetection` key in that case, which is
+                    // identical behaviour to omitting the property.
+                    if let Expression::StaticMemberExpression(member) = &prop.value {
+                        change_detection = match member.property.name.as_str() {
+                            "OnPush" => Some(0),
+                            "Default" => Some(1),
+                            _ => None,
+                        };
+                    } else if let Expression::NumericLiteral(n) = &prop.value {
+                        change_detection = Some(n.value as u32);
+                    }
+                }
                 _ => {}
             }
         }
@@ -1635,6 +1650,7 @@ fn extract_decorator_metadata(source: &str, decorator: &Decorator) -> NgcResult<
         style_urls,
         animations_source,
         host_directives_source,
+        change_detection,
     })
 }
 

--- a/crates/template-compiler/src/extract.rs
+++ b/crates/template-compiler/src/extract.rs
@@ -122,6 +122,11 @@ pub struct SignalInputSpec {
     pub is_required: bool,
     /// Raw source text of the `transform` reference, if present (e.g.
     /// `trimString` or `(v) => v.trim()`). `None` means no transform.
+    /// For signal-based inputs the runtime reads the transform off the
+    /// signal field at write time, so codegen doesn't actually splice
+    /// this into the inputs def — but we still capture it so future
+    /// passes (lints, source maps, type checking) have it available.
+    #[allow(dead_code)]
     pub transform_source: Option<String>,
 }
 
@@ -170,6 +175,12 @@ pub struct SignalQuerySpec {
     pub read_source: Option<String>,
     /// `static: true` from the options object — defaults to `false`.
     pub is_static: bool,
+    /// User-supplied `descendants` option, or `None` to use the
+    /// kind-specific default. Tracking this separately from the kind
+    /// lets `descendants: false` on a `viewChild` (which defaults to
+    /// `true`) survive into codegen instead of getting masked by the
+    /// default.
+    pub descendants: Option<bool>,
 }
 
 /// Which signal-query factory created the field.
@@ -187,6 +198,11 @@ pub enum SignalQueryKind {
 
 impl SignalQueryKind {
     /// `true` for `viewChild` / `contentChild` (single) variants.
+    /// Currently unused in codegen (the always-on
+    /// `emitDistinctChangesOnly` flag for signal queries means we don't
+    /// branch on first/multi for signal queries), but kept for parity
+    /// with linker-side query handling and as a future-proofing hook.
+    #[allow(dead_code)]
     pub fn is_first(self) -> bool {
         matches!(self, Self::ViewChild | Self::ContentChild)
     }
@@ -197,11 +213,13 @@ impl SignalQueryKind {
         matches!(self, Self::ViewChild | Self::ViewChildren)
     }
 
-    /// Default `descendants` flag for the kind. View queries always walk
-    /// descendants; content queries default to direct-children only
-    /// unless the user passes `descendants: true` in options.
+    /// Default `descendants` flag for the kind, matching Angular's
+    /// signal-query compiler defaults. **Only `contentChildren` defaults
+    /// to `false`** — `viewChild` / `viewChildren` / `contentChild`
+    /// all default to `true`. (Note: this differs from decorator-style
+    /// `@ContentChild`, which defaults to `descendants: false`.)
     pub fn default_descendants(self) -> bool {
-        self.is_view()
+        !matches!(self, Self::ContentChildren)
     }
 }
 
@@ -1133,30 +1151,29 @@ pub(crate) fn extract_signal_members(
         match factory {
             SignalFactory::Input { required } => {
                 let opts_idx = if required { 0 } else { 1 };
-                let (alias, transform_source, _read, _is_static) =
-                    parse_signal_options(source, call, opts_idx);
+                let opts = parse_signal_options(source, call, opts_idx);
                 out.inputs.push(SignalInputSpec {
                     property_name,
-                    alias,
+                    alias: opts.alias,
                     is_required: required,
-                    transform_source,
+                    transform_source: opts.transform,
                 });
             }
             SignalFactory::Output => {
                 // `output()` / `output<T>()` only accepts an optional
                 // options object as its first arg (no positional default).
-                let (alias, _, _, _) = parse_signal_options(source, call, 0);
+                let opts = parse_signal_options(source, call, 0);
                 out.outputs.push(SignalOutputSpec {
                     property_name,
-                    alias,
+                    alias: opts.alias,
                 });
             }
             SignalFactory::Model { required } => {
                 let opts_idx = if required { 0 } else { 1 };
-                let (alias, _, _, _) = parse_signal_options(source, call, opts_idx);
+                let opts = parse_signal_options(source, call, opts_idx);
                 out.models.push(SignalModelSpec {
                     property_name,
-                    alias,
+                    alias: opts.alias,
                     is_required: required,
                 });
             }
@@ -1178,13 +1195,14 @@ pub(crate) fn extract_signal_members(
                         }
                     })
                     .unwrap_or_else(|| "null".to_string());
-                let (_, _, read_source, is_static) = parse_signal_options(source, call, 1);
+                let opts = parse_signal_options(source, call, 1);
                 out.queries.push(SignalQuerySpec {
                     property_name,
                     kind,
                     predicate_source,
-                    read_source,
-                    is_static,
+                    read_source: opts.read,
+                    is_static: opts.is_static,
+                    descendants: opts.descendants,
                 });
             }
         }
@@ -1254,25 +1272,37 @@ fn name_to_factory(name: &str, dotted: bool) -> Option<SignalFactory> {
     }
 }
 
-/// Pull `alias`, `transform`, `read`, `static` out of an options object
-/// argument at the given positional index, if it's an object literal.
-/// Returns (alias, transform_source, read_source, is_static).
+/// Options pulled from the second argument of a signal-API factory
+/// call (`input(default, { ... })`, `viewChild(predicate, { ... })`).
+/// Each field is `None` when absent from the options object so callers
+/// can distinguish "user wrote `false`" from "user didn't write
+/// anything" — that distinction matters for `descendants`, which has
+/// kind-specific defaults that should only kick in when omitted.
+#[derive(Debug, Default)]
+struct SignalOptions {
+    alias: Option<String>,
+    transform: Option<String>,
+    read: Option<String>,
+    is_static: bool,
+    descendants: Option<bool>,
+}
+
+/// Pull `alias`, `transform`, `read`, `static`, `descendants` out of an
+/// options object argument at the given positional index, if it's an
+/// object literal. Missing or non-object args produce defaults.
 fn parse_signal_options(
     source: &str,
     call: &oxc_ast::ast::CallExpression<'_>,
     idx: usize,
-) -> (Option<String>, Option<String>, Option<String>, bool) {
+) -> SignalOptions {
+    let mut out = SignalOptions::default();
+
     let Some(arg) = call.arguments.get(idx) else {
-        return (None, None, None, false);
+        return out;
     };
     let Argument::ObjectExpression(opts) = arg else {
-        return (None, None, None, false);
+        return out;
     };
-
-    let mut alias = None;
-    let mut transform = None;
-    let mut read = None;
-    let mut is_static = false;
 
     for prop in &opts.properties {
         let ObjectPropertyKind::ObjectProperty(prop) = prop else {
@@ -1286,27 +1316,32 @@ fn parse_signal_options(
         match key {
             "alias" => {
                 if let Expression::StringLiteral(s) = &prop.value {
-                    alias = Some(s.value.to_string());
+                    out.alias = Some(s.value.to_string());
                 }
             }
             "transform" => {
                 let span = prop.value.span();
-                transform = Some(source[span.start as usize..span.end as usize].to_string());
+                out.transform = Some(source[span.start as usize..span.end as usize].to_string());
             }
             "read" => {
                 let span = prop.value.span();
-                read = Some(source[span.start as usize..span.end as usize].to_string());
+                out.read = Some(source[span.start as usize..span.end as usize].to_string());
             }
             "static" => {
                 if let Expression::BooleanLiteral(b) = &prop.value {
-                    is_static = b.value;
+                    out.is_static = b.value;
+                }
+            }
+            "descendants" => {
+                if let Expression::BooleanLiteral(b) = &prop.value {
+                    out.descendants = Some(b.value);
                 }
             }
             _ => {}
         }
     }
 
-    (alias, transform, read, is_static)
+    out
 }
 
 /// Extract constructor parameters from a class body for DI-aware factory generation.

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -19,6 +19,7 @@ mod pipe_codegen;
 pub mod preprocessor;
 mod rewrite;
 mod selector;
+mod signal_codegen;
 
 pub use parser::parse_template;
 
@@ -126,6 +127,10 @@ pub fn generate_template_fn(
         host_bindings: Vec::new(),
         animations_source: None,
         host_directives_source: None,
+        signal_inputs: Vec::new(),
+        signal_outputs: Vec::new(),
+        signal_models: Vec::new(),
+        signal_queries: Vec::new(),
     };
 
     let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -131,6 +131,7 @@ pub fn generate_template_fn(
         signal_outputs: Vec::new(),
         signal_models: Vec::new(),
         signal_queries: Vec::new(),
+        change_detection: None,
     };
 
     let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -158,6 +158,10 @@ mod tests {
             host_bindings: Vec::new(),
             animations_source: None,
             host_directives_source: None,
+            signal_inputs: Vec::new(),
+            signal_outputs: Vec::new(),
+            signal_models: Vec::new(),
+            signal_queries: Vec::new(),
         }
     }
 

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -162,6 +162,7 @@ mod tests {
             signal_outputs: Vec::new(),
             signal_models: Vec::new(),
             signal_queries: Vec::new(),
+            change_detection: None,
         }
     }
 

--- a/crates/template-compiler/src/signal_codegen.rs
+++ b/crates/template-compiler/src/signal_codegen.rs
@@ -75,19 +75,36 @@ pub fn compile_signal_members(
     }
 
     for spec in signal_inputs {
+        // Signal-based inputs DO NOT propagate the `transform` into the
+        // runtime `inputs` def — Angular's compiler keeps it on the
+        // signal field's `InputSignalNode.transformFn` (set by the
+        // `input(default, { transform })` factory at instantiation
+        // time). The runtime's `writeToDirectiveInput` always prefers
+        // `inputSignalNode.transformFn` over the def's `transform`, so
+        // emitting the transform in the def is at best dead weight and
+        // at worst confusing diff noise vs. `ng build`.
         input_entries.push(format_signal_input_entry(
             &spec.property_name,
             spec.alias.as_deref(),
             spec.is_required,
-            spec.transform_source.as_deref(),
+            None,
         ));
     }
 
     for spec in signal_models {
-        // `model<T>()` is sugar for a paired signal input + `<name>Change`
-        // output. The output's public name follows the input alias when
-        // one is set (`model({ alias: 'pub' })` → input `pub` + output
-        // `pubChange`), matching Angular's compiler.
+        // `model<T>()` is sugar for a paired signal input + `<publicName>Change`
+        // output. Angular's runtime inverts the outputs map to
+        // `{ publicName: classPropName }`, then on the change event it
+        // looks up `instance[classPropName]` to subscribe to. For a
+        // model the change-event source is the model SIGNAL itself
+        // (`instance.<field>`) — NOT a separate field named
+        // `<field>Change`. So the outputs entry must be keyed by the
+        // model's class-property name and valued with the public event
+        // name (`<publicName>Change`); emitting
+        // `{ <publicName>Change: '<publicName>Change' }` would make the
+        // runtime try to subscribe to a non-existent
+        // `instance.<publicName>Change` field and silently drop the
+        // two-way binding.
         let public = spec.alias.as_deref().unwrap_or(&spec.property_name);
         input_entries.push(format_signal_input_entry(
             &spec.property_name,
@@ -95,8 +112,7 @@ pub fn compile_signal_members(
             spec.is_required,
             None,
         ));
-        let change_name = format!("{public}Change");
-        output_entries.push(format!("{}: '{}'", change_name, change_name));
+        output_entries.push(format!("{}: '{}Change'", spec.property_name, public));
     }
 
     for spec in signal_outputs {
@@ -142,9 +158,20 @@ pub fn compile_signal_members(
     }
 }
 
-/// Format a single `inputs` map entry from a [`SignalInputSpec`] /
-/// [`SignalModelSpec`]. The signal-based bit is always set; the
-/// transform bit is added only when a transform expression is present.
+/// Format a single `inputs` map entry, matching Angular's compact
+/// emission rules:
+///
+/// * `[flags, publicName]` when `publicName == classPropertyName` and
+///   no decorator transform.
+/// * `[flags, publicName, classPropertyName]` when the names differ.
+/// * `[flags, publicName, classPropertyName, transform]` when a
+///   decorator-style transform is in play (only ever for non-signal
+///   inputs — signal inputs keep their transform on the signal field).
+///
+/// `SignalBased` (bit 0) is always set here because every caller is a
+/// signal-API field. `HasDecoratorInputTransform` (bit 1) is only set
+/// when `transform_source` is provided — and signal-input callers pass
+/// `None`, so it's effectively for decorator inputs going forward.
 fn format_signal_input_entry(
     property_name: &str,
     alias: Option<&str>,
@@ -152,14 +179,17 @@ fn format_signal_input_entry(
     transform_source: Option<&str>,
 ) -> String {
     let public = alias.unwrap_or(property_name);
+    let names_differ = public != property_name;
     let mut flags: u32 = 1; // SignalBased
     if transform_source.is_some() {
         flags |= 2; // HasDecoratorInputTransform
     }
-    if let Some(t) = transform_source {
-        format!("{property_name}: [{flags}, '{public}', '{property_name}', {t}]")
-    } else {
-        format!("{property_name}: [{flags}, '{public}', '{property_name}']")
+    match (names_differ, transform_source) {
+        (false, None) => format!("{property_name}: [{flags}, '{public}']"),
+        (true, None) => format!("{property_name}: [{flags}, '{public}', '{property_name}']"),
+        (_, Some(t)) => {
+            format!("{property_name}: [{flags}, '{public}', '{property_name}', {t}]")
+        }
     }
 }
 
@@ -220,19 +250,26 @@ fn build_query_function(queries: &[&SignalQuerySpec], is_content: bool) -> Strin
 }
 
 /// Compute the runtime `QueryFlags` integer for a signal-based query.
-/// Mirrors the linker: bit 0 = descendants, bit 1 = isStatic,
-/// bit 2 = emitDistinctChangesOnly (set for plural `*Children` variants
-/// to match Angular's `QueryList` distinct-emission semantics).
+///
+/// Matches Angular's compiler-cli behaviour bit-for-bit:
+/// * bit 0 (`descendants`) — kind-specific default unless the user
+///   passed an explicit `descendants:` option. Only `contentChildren`
+///   defaults to `false`; `viewChild` / `viewChildren` / `contentChild`
+///   all default to `true`.
+/// * bit 1 (`isStatic`) — from the `static:` option.
+/// * bit 2 (`emitDistinctChangesOnly`) — **always set for signal queries**,
+///   regardless of `first` / multi. Unlike `QueryList`-backed decorator
+///   queries (which only set this bit when emitting many results),
+///   Angular's signal-query compiler unconditionally sets it.
 fn compute_signal_query_flags(q: &SignalQuerySpec) -> u32 {
-    let mut flags: u32 = 0;
-    if q.kind.default_descendants() {
+    let mut flags: u32 = 4; // emitDistinctChangesOnly — always set for signal queries
+    if q.descendants
+        .unwrap_or_else(|| q.kind.default_descendants())
+    {
         flags |= 1;
     }
     if q.is_static {
         flags |= 2;
-    }
-    if !q.kind.is_first() {
-        flags |= 4;
     }
     flags
 }
@@ -262,29 +299,41 @@ mod tests {
         }
     }
 
-    /// Plain `input()` should set the `SignalBased` flag (bit 0) so
-    /// the runtime knows the field is a `WritableSignal` and not a
-    /// plain assignable property.
+    /// Plain `input()` should emit the compact 2-element form
+    /// `[flags, publicName]` since the public name matches the class
+    /// property name. SignalBased flag (bit 0) is always set so the
+    /// runtime knows the field is a `WritableSignal` and not a plain
+    /// assignable property.
     #[test]
     fn signal_input_emits_signal_flag() {
         let r = compile_signal_members(&[], &[input("name")], &[], &[], &[]);
         assert!(
-            r.inputs_entries[0].contains("name: [1, 'name', 'name']"),
+            r.inputs_entries[0].contains("name: [1, 'name']"),
             "got: {:?}",
             r.inputs_entries
         );
     }
 
-    /// `input(0, { transform: trim })` adds the
-    /// `HasDecoratorInputTransform` flag (bit 1) AND surfaces the
-    /// transform reference verbatim as the array's 4th element so the
-    /// runtime can call it on each value.
+    /// `input(0, { transform: trim })` keeps the transform on the
+    /// signal field — Angular's compiler does NOT replicate it into
+    /// the inputs def for signal inputs (the runtime reads
+    /// `inputSignalNode.transformFn` directly). So flags stay at
+    /// SignalBased only and the entry is the compact 2-element form.
     #[test]
-    fn signal_input_with_transform_emits_transform_flag() {
+    fn signal_input_with_transform_keeps_transform_on_signal() {
         let mut spec = input("name");
         spec.transform_source = Some("trimString".into());
         let r = compile_signal_members(&[], &[spec], &[], &[], &[]);
-        assert!(r.inputs_entries[0].contains("name: [3, 'name', 'name', trimString]"));
+        assert!(
+            r.inputs_entries[0].contains("name: [1, 'name']"),
+            "expected compact form for signal input (transform stays on signal field), got: {:?}",
+            r.inputs_entries
+        );
+        assert!(
+            !r.inputs_entries[0].contains("trimString"),
+            "transform must NOT appear in the def for signal inputs: {:?}",
+            r.inputs_entries
+        );
     }
 
     /// Aliased `input(0, { alias: 'pub' })` keeps `publicName` in
@@ -326,7 +375,10 @@ mod tests {
     }
 
     /// `model<T>()` desugars to a signal input named after the field
-    /// PLUS an output named `<name>Change`. Both entries must appear.
+    /// PLUS an output. The outputs entry is keyed by the class-property
+    /// name so the runtime can locate `instance.<field>` (the model
+    /// signal it subscribes to) — the public event name `<field>Change`
+    /// is the VALUE.
     #[test]
     fn signal_model_emits_input_and_change_output() {
         let spec = SignalModelSpec {
@@ -335,13 +387,14 @@ mod tests {
             is_required: false,
         };
         let r = compile_signal_members(&[], &[], &[], &[spec], &[]);
-        assert!(r.inputs_entries[0].contains("value: [1, 'value', 'value']"));
-        assert!(r.outputs_entries[0].contains("valueChange: 'valueChange'"));
+        assert!(r.inputs_entries[0].contains("value: [1, 'value']"));
+        assert!(r.outputs_entries[0].contains("value: 'valueChange'"));
     }
 
     /// Aliased `model({ alias: 'pub' })` emits the aliased input AND
-    /// `pubChange` (the change-event public name follows the input
-    /// alias, NOT the property name).
+    /// the change output's PUBLIC name uses the alias (`pubChange`),
+    /// while the outputs map's KEY remains the original class property
+    /// name — that's what the runtime looks up on the instance.
     #[test]
     fn signal_model_alias_propagates_to_change_event() {
         let spec = SignalModelSpec {
@@ -351,7 +404,7 @@ mod tests {
         };
         let r = compile_signal_members(&[], &[], &[], &[spec], &[]);
         assert!(r.inputs_entries[0].contains("internal: [1, 'public', 'internal']"));
-        assert!(r.outputs_entries[0].contains("publicChange: 'publicChange'"));
+        assert!(r.outputs_entries[0].contains("internal: 'publicChange'"));
     }
 
     /// Decorator-style `@Input()` entries (bare property names) flow
@@ -364,27 +417,32 @@ mod tests {
         assert!(r
             .inputs_entries
             .iter()
-            .any(|e| e.contains("signalInput: [1, 'signalInput', 'signalInput']")));
+            .any(|e| e.contains("signalInput: [1, 'signalInput']")));
+    }
+
+    fn query(name: &str, kind: SignalQueryKind, predicate: &str) -> SignalQuerySpec {
+        SignalQuerySpec {
+            property_name: name.into(),
+            kind,
+            predicate_source: predicate.into(),
+            read_source: None,
+            is_static: false,
+            descendants: None,
+        }
     }
 
     /// `viewChild('ref')` lands as a single signal-based view query.
-    /// `descendants` defaults to `true` for view queries (flag bit 0)
-    /// AND `first: true` (so bit 2 stays clear). Predicate text is
-    /// preserved verbatim because it can be either a string literal
-    /// (`['ref']`) or a class reference.
+    /// Angular's compiler ALWAYS sets the `emitDistinctChangesOnly` bit
+    /// (bit 2 = 4) for signal queries, regardless of whether the query
+    /// is single (`first: true`) or multi. With the kind's default
+    /// `descendants: true` (bit 0 = 1), flags = 5.
     #[test]
     fn signal_view_child_emits_view_query_signal() {
-        let q = SignalQuerySpec {
-            property_name: "child".into(),
-            kind: SignalQueryKind::ViewChild,
-            predicate_source: "ChildCmp".into(),
-            read_source: None,
-            is_static: false,
-        };
+        let q = query("child", SignalQueryKind::ViewChild, "ChildCmp");
         let r = compile_signal_members(&[], &[], &[], &[], &[q]);
         let vq = r.view_query_prop.as_ref().expect("expected viewQuery");
         assert!(
-            vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.child, ChildCmp, 1)"),
+            vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.child, ChildCmp, 5)"),
             "got: {vq}"
         );
         assert!(
@@ -393,47 +451,64 @@ mod tests {
         );
     }
 
-    /// `viewChildren()` (plural) sets both `descendants` (bit 0) and
-    /// `emitDistinctChangesOnly` (bit 2) for a flags integer of 5,
-    /// matching Angular's compiler emission for `QueryList`-style
-    /// multi-result queries.
+    /// `viewChildren()` shares the same flags shape as `viewChild`
+    /// because the `emitDistinctChangesOnly` bit is unconditionally set
+    /// for signal queries (the runtime distinguishes single vs. multi
+    /// by other means — what the bit really gates is QueryList semantics
+    /// that signal queries no longer use).
     #[test]
     fn signal_view_children_sets_distinct_changes_flag() {
-        let q = SignalQuerySpec {
-            property_name: "children".into(),
-            kind: SignalQueryKind::ViewChildren,
-            predicate_source: "ChildCmp".into(),
-            read_source: None,
-            is_static: false,
-        };
+        let q = query("children", SignalQueryKind::ViewChildren, "ChildCmp");
         let r = compile_signal_members(&[], &[], &[], &[], &[q]);
         let vq = r.view_query_prop.as_ref().expect("viewQuery");
         assert!(
-            vq.contains("ɵɵviewQuerySignal(ctx.children, ChildCmp, 5)")
-                || vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.children, ChildCmp, 5)")
+            vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.children, ChildCmp, 5)"),
+            "got: {vq}"
         );
     }
 
-    /// `contentChild()` defaults to `descendants: false` (bit 0 clear)
-    /// — only the direct children get matched unless the user opts
-    /// into descendants explicitly. `first: true` so distinct-changes
-    /// is also clear, leaving flags at 0.
+    /// Signal-based `contentChild()` defaults to `descendants: true`
+    /// — opposite of decorator-style `@ContentChild` which defaults to
+    /// `descendants: false`. Combined with the always-on
+    /// `emitDistinctChangesOnly` bit, flags = 5.
     #[test]
-    fn signal_content_child_defaults_no_descendants() {
-        let q = SignalQuerySpec {
-            property_name: "projected".into(),
-            kind: SignalQueryKind::ContentChild,
-            predicate_source: "SomeDir".into(),
-            read_source: None,
-            is_static: false,
-        };
+    fn signal_content_child_defaults_descendants_true() {
+        let q = query("projected", SignalQueryKind::ContentChild, "SomeDir");
         let r = compile_signal_members(&[], &[], &[], &[], &[q]);
         let cq = r.content_queries_prop.as_ref().expect("contentQueries");
         assert!(
             cq.contains(
-                "\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.projected, SomeDir, 0)"
+                "\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.projected, SomeDir, 5)"
             ),
-            "expected directiveIndex-leading content query call with flags=0, got: {cq}"
+            "expected contentChild defaults to descendants=true (flags=5), got: {cq}"
+        );
+    }
+
+    /// `contentChildren()` is the only signal-query factory that
+    /// defaults to `descendants: false`. Bit 0 stays clear; bit 2 is
+    /// always set → flags = 4.
+    #[test]
+    fn signal_content_children_defaults_no_descendants() {
+        let q = query("all", SignalQueryKind::ContentChildren, "SomeDir");
+        let r = compile_signal_members(&[], &[], &[], &[], &[q]);
+        let cq = r.content_queries_prop.as_ref().expect("contentQueries");
+        assert!(
+            cq.contains("\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.all, SomeDir, 4)"),
+            "expected contentChildren defaults to descendants=false (flags=4), got: {cq}"
+        );
+    }
+
+    /// User-supplied `descendants: false` on a `viewChild` (which
+    /// defaults to `true`) must override the kind's default.
+    #[test]
+    fn signal_query_user_descendants_overrides_default() {
+        let mut q = query("child", SignalQueryKind::ViewChild, "C");
+        q.descendants = Some(false);
+        let r = compile_signal_members(&[], &[], &[], &[], &[q]);
+        let vq = r.view_query_prop.as_ref().expect("viewQuery");
+        assert!(
+            vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.child, C, 4)"),
+            "expected user-supplied descendants:false to clear bit 0, got: {vq}"
         );
     }
 
@@ -442,16 +517,11 @@ mod tests {
     /// rather than the matched directive instance.
     #[test]
     fn signal_view_child_with_read_token() {
-        let q = SignalQuerySpec {
-            property_name: "el".into(),
-            kind: SignalQueryKind::ViewChild,
-            predicate_source: "['ref']".into(),
-            read_source: Some("ElementRef".into()),
-            is_static: false,
-        };
+        let mut q = query("el", SignalQueryKind::ViewChild, "['ref']");
+        q.read_source = Some("ElementRef".into());
         let r = compile_signal_members(&[], &[], &[], &[], &[q]);
         let vq = r.view_query_prop.as_ref().expect("viewQuery");
-        assert!(vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.el, ['ref'], 1, ElementRef)"));
+        assert!(vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.el, ['ref'], 5, ElementRef)"));
     }
 
     /// Mixing view + content signal queries on the same class produces
@@ -462,20 +532,8 @@ mod tests {
     #[test]
     fn mixed_view_and_content_queries_split_into_two_props() {
         let queries = vec![
-            SignalQuerySpec {
-                property_name: "child".into(),
-                kind: SignalQueryKind::ViewChild,
-                predicate_source: "C".into(),
-                read_source: None,
-                is_static: false,
-            },
-            SignalQuerySpec {
-                property_name: "projected".into(),
-                kind: SignalQueryKind::ContentChild,
-                predicate_source: "P".into(),
-                read_source: None,
-                is_static: false,
-            },
+            query("child", SignalQueryKind::ViewChild, "C"),
+            query("projected", SignalQueryKind::ContentChild, "P"),
         ];
         let r = compile_signal_members(&[], &[], &[], &[], &queries);
         let vq = r.view_query_prop.expect("viewQuery");
@@ -484,5 +542,36 @@ mod tests {
         assert!(!vq.contains("ctx.projected"));
         assert!(cq.contains("ctx.projected"));
         assert!(!cq.contains("ctx.child"));
+    }
+
+    /// `model<T>()` desugars to a paired SignalBased input + change
+    /// event. The OUTPUTS map must be keyed by the model's class
+    /// property name (matching `instance.<field>`, where the runtime
+    /// finds the model signal to subscribe to) — keying by the public
+    /// event name (`<field>Change`) sends the runtime looking for a
+    /// non-existent `instance.<field>Change` and the two-way binding
+    /// silently drops on every emission.
+    #[test]
+    fn signal_model_outputs_keyed_by_class_property() {
+        let spec = SignalModelSpec {
+            property_name: "active".into(),
+            alias: None,
+            is_required: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[spec], &[]);
+        assert!(
+            r.outputs_entries
+                .iter()
+                .any(|e| e == "active: 'activeChange'"),
+            "expected outputs keyed by class prop, got: {:?}",
+            r.outputs_entries
+        );
+        assert!(
+            !r.outputs_entries
+                .iter()
+                .any(|e| e.starts_with("activeChange:")),
+            "outputs map must NOT be keyed by the public event name: {:?}",
+            r.outputs_entries
+        );
     }
 }

--- a/crates/template-compiler/src/signal_codegen.rs
+++ b/crates/template-compiler/src/signal_codegen.rs
@@ -1,0 +1,488 @@
+//! AOT codegen for Angular's signal-based authoring APIs.
+//!
+//! Folds [`SignalInputSpec`] / [`SignalOutputSpec`] / [`SignalModelSpec`]
+//! / [`SignalQuerySpec`] (extracted from class field initialisers) into
+//! the runtime Ivy property fragments that go into `ɵɵdefineComponent` /
+//! `ɵɵdefineDirective`:
+//!
+//! * `inputs: { foo: [1, 'public', 'foo'], ... }` — `SignalBased` flag
+//!   (bit 0) set, `HasDecoratorInputTransform` (bit 1) added when the
+//!   field declares `transform`.
+//! * `outputs: { changed: 'changed', ... }`.
+//! * `viewQuery` / `contentQueries` functions that dispatch to
+//!   `ɵɵviewQuerySignal` / `ɵɵcontentQuerySignal` and emit a single
+//!   `ɵɵqueryAdvance()` per query in the update block.
+//!
+//! Decorator-style `@Input` / `@Output` entries that the AOT extractor
+//! has already produced (as bare property names or raw source strings)
+//! are merged in as identity entries so a class can mix decorator and
+//! signal authoring without losing either side.
+
+use std::collections::BTreeSet;
+
+use crate::extract::{SignalInputSpec, SignalModelSpec, SignalOutputSpec, SignalQuerySpec};
+
+/// Result of compiling all signal-API class fields into the runtime
+/// fragments needed by `ɵɵdefineComponent` / `ɵɵdefineDirective`.
+///
+/// Each `*_prop` is either an empty string (caller skips) or a
+/// `<key>: <value>` fragment ready to splice into the comma-separated
+/// definition body.
+pub struct CompiledSignalMembers {
+    /// Body of the `inputs` map (without `inputs: { ... }` wrapping) —
+    /// only the inner entries. Empty when no signal inputs/models exist
+    /// AND no decorator-style inputs were merged in.
+    pub inputs_entries: Vec<String>,
+    /// Body of the `outputs` map (entries only).
+    pub outputs_entries: Vec<String>,
+    /// Full `viewQuery: function(rf, ctx) { ... }` fragment, or `None`.
+    pub view_query_prop: Option<String>,
+    /// Full `contentQueries: function(rf, ctx, directiveIndex) { ... }`
+    /// fragment, or `None`.
+    pub content_queries_prop: Option<String>,
+    /// Ivy runtime symbols referenced by the emitted code. The caller
+    /// inserts these into its import set so the rewrite step pulls them
+    /// in from `@angular/core`.
+    pub ivy_imports: BTreeSet<String>,
+}
+
+/// Compile every signal-API spec on a class into the matching Ivy
+/// runtime fragments.
+///
+/// `decorator_inputs` is the bare-property-name list produced by the
+/// pre-existing `@Input()` extraction (`ExtractedComponent::input_properties`);
+/// passing it here keeps signal- and decorator-style inputs together in
+/// the same `inputs` map. The same goes for `outputs_source` — when a
+/// `@Directive`'s decorator literal carries an `outputs:` array, the
+/// existing entries are surfaced first, and signal `output()` / `model()`
+/// fields are appended.
+pub fn compile_signal_members(
+    decorator_inputs: &[String],
+    signal_inputs: &[SignalInputSpec],
+    signal_outputs: &[SignalOutputSpec],
+    signal_models: &[SignalModelSpec],
+    signal_queries: &[SignalQuerySpec],
+) -> CompiledSignalMembers {
+    let mut ivy_imports = BTreeSet::new();
+    let mut input_entries = Vec::new();
+    let mut output_entries = Vec::new();
+
+    // Decorator-style @Input() — already compiled to identity entries
+    // upstream. Replicate that shape so the maps stay flat strings unless
+    // a flag/alias forces the array form.
+    for prop in decorator_inputs {
+        input_entries.push(format!("{prop}: '{prop}'"));
+    }
+
+    for spec in signal_inputs {
+        input_entries.push(format_signal_input_entry(
+            &spec.property_name,
+            spec.alias.as_deref(),
+            spec.is_required,
+            spec.transform_source.as_deref(),
+        ));
+    }
+
+    for spec in signal_models {
+        // `model<T>()` is sugar for a paired signal input + `<name>Change`
+        // output. The output's public name follows the input alias when
+        // one is set (`model({ alias: 'pub' })` → input `pub` + output
+        // `pubChange`), matching Angular's compiler.
+        let public = spec.alias.as_deref().unwrap_or(&spec.property_name);
+        input_entries.push(format_signal_input_entry(
+            &spec.property_name,
+            spec.alias.as_deref(),
+            spec.is_required,
+            None,
+        ));
+        let change_name = format!("{public}Change");
+        output_entries.push(format!("{}: '{}'", change_name, change_name));
+    }
+
+    for spec in signal_outputs {
+        let public = spec.alias.as_deref().unwrap_or(&spec.property_name);
+        output_entries.push(format!("{}: '{}'", spec.property_name, public));
+    }
+
+    // Split queries by view vs. content so we can build the two
+    // dispatch functions independently. Order is preserved so the
+    // runtime's query-index advance lines up with the declaration order
+    // on the class.
+    let (view_qs, content_qs): (Vec<_>, Vec<_>) =
+        signal_queries.iter().partition(|q| q.kind.is_view());
+
+    let view_query_prop = if view_qs.is_empty() {
+        None
+    } else {
+        ivy_imports.insert("\u{0275}\u{0275}viewQuerySignal".to_string());
+        ivy_imports.insert("\u{0275}\u{0275}queryAdvance".to_string());
+        Some(format!(
+            "viewQuery: {}",
+            build_query_function(&view_qs, false)
+        ))
+    };
+
+    let content_queries_prop = if content_qs.is_empty() {
+        None
+    } else {
+        ivy_imports.insert("\u{0275}\u{0275}contentQuerySignal".to_string());
+        ivy_imports.insert("\u{0275}\u{0275}queryAdvance".to_string());
+        Some(format!(
+            "contentQueries: {}",
+            build_query_function(&content_qs, true)
+        ))
+    };
+
+    CompiledSignalMembers {
+        inputs_entries: input_entries,
+        outputs_entries: output_entries,
+        view_query_prop,
+        content_queries_prop,
+        ivy_imports,
+    }
+}
+
+/// Format a single `inputs` map entry from a [`SignalInputSpec`] /
+/// [`SignalModelSpec`]. The signal-based bit is always set; the
+/// transform bit is added only when a transform expression is present.
+fn format_signal_input_entry(
+    property_name: &str,
+    alias: Option<&str>,
+    _is_required: bool,
+    transform_source: Option<&str>,
+) -> String {
+    let public = alias.unwrap_or(property_name);
+    let mut flags: u32 = 1; // SignalBased
+    if transform_source.is_some() {
+        flags |= 2; // HasDecoratorInputTransform
+    }
+    if let Some(t) = transform_source {
+        format!("{property_name}: [{flags}, '{public}', '{property_name}', {t}]")
+    } else {
+        format!("{property_name}: [{flags}, '{public}', '{property_name}']")
+    }
+}
+
+/// Build `function(rf, ctx[, directiveIndex]) { if (rf & 1) {...} if (rf & 2) {...} }`
+/// for the given queries. `is_content` toggles the directiveIndex parameter
+/// and dispatches to `ɵɵcontentQuerySignal` instead of `ɵɵviewQuerySignal`.
+fn build_query_function(queries: &[&SignalQuerySpec], is_content: bool) -> String {
+    let create_fn = if is_content {
+        "\u{0275}\u{0275}contentQuerySignal"
+    } else {
+        "\u{0275}\u{0275}viewQuerySignal"
+    };
+    let advance_fn = "\u{0275}\u{0275}queryAdvance";
+
+    let mut create_stmts = Vec::with_capacity(queries.len());
+    let mut update_stmts = Vec::with_capacity(queries.len());
+
+    for q in queries {
+        let flags = compute_signal_query_flags(q);
+        let read_arg = if let Some(ref read) = q.read_source {
+            format!(", {read}")
+        } else {
+            String::new()
+        };
+        let target = format!("ctx.{}", q.property_name);
+
+        if is_content {
+            create_stmts.push(format!(
+                "{create_fn}(directiveIndex, {target}, {}, {flags}{read_arg});",
+                q.predicate_source
+            ));
+        } else {
+            create_stmts.push(format!(
+                "{create_fn}({target}, {}, {flags}{read_arg});",
+                q.predicate_source
+            ));
+        }
+        update_stmts.push(format!("{advance_fn}();"));
+    }
+
+    let mut body = String::from("if (rf & 1) { ");
+    for s in &create_stmts {
+        body.push_str(s);
+        body.push(' ');
+    }
+    body.push_str("} if (rf & 2) { ");
+    for s in &update_stmts {
+        body.push_str(s);
+        body.push(' ');
+    }
+    body.push('}');
+
+    if is_content {
+        format!("function(rf, ctx, directiveIndex) {{ {body} }}")
+    } else {
+        format!("function(rf, ctx) {{ {body} }}")
+    }
+}
+
+/// Compute the runtime `QueryFlags` integer for a signal-based query.
+/// Mirrors the linker: bit 0 = descendants, bit 1 = isStatic,
+/// bit 2 = emitDistinctChangesOnly (set for plural `*Children` variants
+/// to match Angular's `QueryList` distinct-emission semantics).
+fn compute_signal_query_flags(q: &SignalQuerySpec) -> u32 {
+    let mut flags: u32 = 0;
+    if q.kind.default_descendants() {
+        flags |= 1;
+    }
+    if q.is_static {
+        flags |= 2;
+    }
+    if !q.kind.is_first() {
+        flags |= 4;
+    }
+    flags
+}
+
+/// Wrap a list of `inputs` / `outputs` entries in the `<key>: { ... }`
+/// fragment shape used in the define call body. Returns `None` when the
+/// list is empty so callers don't emit an empty map.
+pub fn format_map(key: &str, entries: &[String]) -> Option<String> {
+    if entries.is_empty() {
+        None
+    } else {
+        Some(format!("{key}: {{ {} }}", entries.join(", ")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::SignalQueryKind;
+
+    fn input(name: &str) -> SignalInputSpec {
+        SignalInputSpec {
+            property_name: name.into(),
+            alias: None,
+            is_required: false,
+            transform_source: None,
+        }
+    }
+
+    /// Plain `input()` should set the `SignalBased` flag (bit 0) so
+    /// the runtime knows the field is a `WritableSignal` and not a
+    /// plain assignable property.
+    #[test]
+    fn signal_input_emits_signal_flag() {
+        let r = compile_signal_members(&[], &[input("name")], &[], &[], &[]);
+        assert!(
+            r.inputs_entries[0].contains("name: [1, 'name', 'name']"),
+            "got: {:?}",
+            r.inputs_entries
+        );
+    }
+
+    /// `input(0, { transform: trim })` adds the
+    /// `HasDecoratorInputTransform` flag (bit 1) AND surfaces the
+    /// transform reference verbatim as the array's 4th element so the
+    /// runtime can call it on each value.
+    #[test]
+    fn signal_input_with_transform_emits_transform_flag() {
+        let mut spec = input("name");
+        spec.transform_source = Some("trimString".into());
+        let r = compile_signal_members(&[], &[spec], &[], &[], &[]);
+        assert!(r.inputs_entries[0].contains("name: [3, 'name', 'name', trimString]"));
+    }
+
+    /// Aliased `input(0, { alias: 'pub' })` keeps `publicName` in
+    /// position 1 and the class-property name in position 2 — flipping
+    /// these two would silently break template binding name resolution.
+    #[test]
+    fn signal_input_with_alias_swaps_public_name() {
+        let mut spec = input("internal");
+        spec.alias = Some("public".into());
+        let r = compile_signal_members(&[], &[spec], &[], &[], &[]);
+        assert!(r.inputs_entries[0].contains("internal: [1, 'public', 'internal']"));
+    }
+
+    /// `output()` is purely a name in the runtime `outputs` map —
+    /// no flag bits. With no alias the public name equals the field
+    /// name (identity).
+    #[test]
+    fn signal_output_emits_identity_pair() {
+        let spec = SignalOutputSpec {
+            property_name: "changed".into(),
+            alias: None,
+        };
+        let r = compile_signal_members(&[], &[], &[spec], &[], &[]);
+        assert!(r.outputs_entries[0].contains("changed: 'changed'"));
+    }
+
+    /// `output({ alias: 'pub' })` produces `propName: 'publicName'`
+    /// so the runtime's `outputs` map carries the field name as key
+    /// (used to look up the EventEmitter on the instance) and the
+    /// public name as value (used to match `(public)="..."` bindings).
+    #[test]
+    fn signal_output_with_alias() {
+        let spec = SignalOutputSpec {
+            property_name: "changed".into(),
+            alias: Some("publicChanged".into()),
+        };
+        let r = compile_signal_members(&[], &[], &[spec], &[], &[]);
+        assert!(r.outputs_entries[0].contains("changed: 'publicChanged'"));
+    }
+
+    /// `model<T>()` desugars to a signal input named after the field
+    /// PLUS an output named `<name>Change`. Both entries must appear.
+    #[test]
+    fn signal_model_emits_input_and_change_output() {
+        let spec = SignalModelSpec {
+            property_name: "value".into(),
+            alias: None,
+            is_required: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[spec], &[]);
+        assert!(r.inputs_entries[0].contains("value: [1, 'value', 'value']"));
+        assert!(r.outputs_entries[0].contains("valueChange: 'valueChange'"));
+    }
+
+    /// Aliased `model({ alias: 'pub' })` emits the aliased input AND
+    /// `pubChange` (the change-event public name follows the input
+    /// alias, NOT the property name).
+    #[test]
+    fn signal_model_alias_propagates_to_change_event() {
+        let spec = SignalModelSpec {
+            property_name: "internal".into(),
+            alias: Some("public".into()),
+            is_required: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[spec], &[]);
+        assert!(r.inputs_entries[0].contains("internal: [1, 'public', 'internal']"));
+        assert!(r.outputs_entries[0].contains("publicChange: 'publicChange'"));
+    }
+
+    /// Decorator-style `@Input()` entries (bare property names) flow
+    /// through unchanged so a class mixing both authoring styles
+    /// produces a single combined `inputs` map.
+    #[test]
+    fn decorator_inputs_merge_with_signal_inputs() {
+        let r = compile_signal_members(&["plain".into()], &[input("signalInput")], &[], &[], &[]);
+        assert!(r.inputs_entries.iter().any(|e| e == "plain: 'plain'"));
+        assert!(r
+            .inputs_entries
+            .iter()
+            .any(|e| e.contains("signalInput: [1, 'signalInput', 'signalInput']")));
+    }
+
+    /// `viewChild('ref')` lands as a single signal-based view query.
+    /// `descendants` defaults to `true` for view queries (flag bit 0)
+    /// AND `first: true` (so bit 2 stays clear). Predicate text is
+    /// preserved verbatim because it can be either a string literal
+    /// (`['ref']`) or a class reference.
+    #[test]
+    fn signal_view_child_emits_view_query_signal() {
+        let q = SignalQuerySpec {
+            property_name: "child".into(),
+            kind: SignalQueryKind::ViewChild,
+            predicate_source: "ChildCmp".into(),
+            read_source: None,
+            is_static: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[], &[q]);
+        let vq = r.view_query_prop.as_ref().expect("expected viewQuery");
+        assert!(
+            vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.child, ChildCmp, 1)"),
+            "got: {vq}"
+        );
+        assert!(
+            vq.contains("\u{0275}\u{0275}queryAdvance();"),
+            "expected queryAdvance() in update block, got: {vq}"
+        );
+    }
+
+    /// `viewChildren()` (plural) sets both `descendants` (bit 0) and
+    /// `emitDistinctChangesOnly` (bit 2) for a flags integer of 5,
+    /// matching Angular's compiler emission for `QueryList`-style
+    /// multi-result queries.
+    #[test]
+    fn signal_view_children_sets_distinct_changes_flag() {
+        let q = SignalQuerySpec {
+            property_name: "children".into(),
+            kind: SignalQueryKind::ViewChildren,
+            predicate_source: "ChildCmp".into(),
+            read_source: None,
+            is_static: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[], &[q]);
+        let vq = r.view_query_prop.as_ref().expect("viewQuery");
+        assert!(
+            vq.contains("ɵɵviewQuerySignal(ctx.children, ChildCmp, 5)")
+                || vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.children, ChildCmp, 5)")
+        );
+    }
+
+    /// `contentChild()` defaults to `descendants: false` (bit 0 clear)
+    /// — only the direct children get matched unless the user opts
+    /// into descendants explicitly. `first: true` so distinct-changes
+    /// is also clear, leaving flags at 0.
+    #[test]
+    fn signal_content_child_defaults_no_descendants() {
+        let q = SignalQuerySpec {
+            property_name: "projected".into(),
+            kind: SignalQueryKind::ContentChild,
+            predicate_source: "SomeDir".into(),
+            read_source: None,
+            is_static: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[], &[q]);
+        let cq = r.content_queries_prop.as_ref().expect("contentQueries");
+        assert!(
+            cq.contains(
+                "\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.projected, SomeDir, 0)"
+            ),
+            "expected directiveIndex-leading content query call with flags=0, got: {cq}"
+        );
+    }
+
+    /// `viewChild('ref', { read: ElementRef })` propagates the read
+    /// token as a trailing arg so the runtime resolves the ElementRef
+    /// rather than the matched directive instance.
+    #[test]
+    fn signal_view_child_with_read_token() {
+        let q = SignalQuerySpec {
+            property_name: "el".into(),
+            kind: SignalQueryKind::ViewChild,
+            predicate_source: "['ref']".into(),
+            read_source: Some("ElementRef".into()),
+            is_static: false,
+        };
+        let r = compile_signal_members(&[], &[], &[], &[], &[q]);
+        let vq = r.view_query_prop.as_ref().expect("viewQuery");
+        assert!(vq.contains("\u{0275}\u{0275}viewQuerySignal(ctx.el, ['ref'], 1, ElementRef)"));
+    }
+
+    /// Mixing view + content signal queries on the same class produces
+    /// both functions, each with its own advance counts. View queries
+    /// must not leak into the content function (and vice versa) — they
+    /// share an LView slot pool but live in distinct create/refresh
+    /// blocks.
+    #[test]
+    fn mixed_view_and_content_queries_split_into_two_props() {
+        let queries = vec![
+            SignalQuerySpec {
+                property_name: "child".into(),
+                kind: SignalQueryKind::ViewChild,
+                predicate_source: "C".into(),
+                read_source: None,
+                is_static: false,
+            },
+            SignalQuerySpec {
+                property_name: "projected".into(),
+                kind: SignalQueryKind::ContentChild,
+                predicate_source: "P".into(),
+                read_source: None,
+                is_static: false,
+            },
+        ];
+        let r = compile_signal_members(&[], &[], &[], &[], &queries);
+        let vq = r.view_query_prop.expect("viewQuery");
+        let cq = r.content_queries_prop.expect("contentQueries");
+        assert!(vq.contains("ctx.child"));
+        assert!(!vq.contains("ctx.projected"));
+        assert!(cq.contains("ctx.projected"));
+        assert!(!cq.contains("ctx.child"));
+    }
+}

--- a/crates/template-compiler/tests/signal_apis_integration.rs
+++ b/crates/template-compiler/tests/signal_apis_integration.rs
@@ -44,7 +44,7 @@ function trimString(v: string): string {
 @Component({
   selector: 'app-x',
   standalone: true,
-  template: '<span>x</span>',
+  template: '<span>x</span><ng-content />',
 })
 export class XComponent {
   // Signal inputs — plain, required, aliased, transformed.
@@ -179,12 +179,28 @@ fn signal_apis_reach_runtime_with_correct_shape() {
         "expected ElementRef read token preserved:\n{out}"
     );
 
+    // The signals fixture uses `<ng-content />` (via the contentChild
+    // demo). That requires `ɵɵprojectionDef()` at the head of the
+    // create block AND `ngContentSelectors: ['*']` on the def —
+    // without both, the runtime throws
+    // `Cannot read properties of null (reading '0')` from
+    // `ɵɵprojection` because `tNode.projection` is never populated.
+    assert!(
+        out.contains("\u{0275}\u{0275}projectionDef();"),
+        "expected ɵɵprojectionDef() call at head of create block, got:\n{out}"
+    );
+    assert!(
+        out.contains("ngContentSelectors: [\"*\"]"),
+        "expected ngContentSelectors on the component def, got:\n{out}"
+    );
+
     // Symbols must be added to the @angular/core import set so the
     // bundler can resolve them and the runtime calls dispatch.
     for symbol in [
         "\u{0275}\u{0275}viewQuerySignal",
         "\u{0275}\u{0275}contentQuerySignal",
         "\u{0275}\u{0275}queryAdvance",
+        "\u{0275}\u{0275}projectionDef",
     ] {
         assert!(
             out.contains(symbol),

--- a/crates/template-compiler/tests/signal_apis_integration.rs
+++ b/crates/template-compiler/tests/signal_apis_integration.rs
@@ -1,0 +1,189 @@
+//! End-to-end integration test for signal-based authoring APIs (issue #55).
+//!
+//! Compiles a `@Component` whose class fields use Angular 17+'s signal
+//! authoring APIs — `input()`, `input.required()`, `input` with a
+//! transform, `output()`, `model()`, and the four query factories
+//! (`viewChild`, `viewChildren`, `contentChild`, `contentChildren`) —
+//! then verifies the rewritten source carries the matching Ivy runtime
+//! shapes:
+//!
+//! * `inputs: { foo: [<flags>, 'public', 'foo', transform?], ... }`
+//!   where bit 0 of `<flags>` is `InputFlags.SignalBased` and bit 1 is
+//!   `InputFlags.HasDecoratorInputTransform`.
+//! * `outputs: { changed: 'changed', ... }` — outputs are pure name
+//!   maps, no flags. `model()` adds a paired `<name>Change` entry.
+//! * `viewQuery: function(rf, ctx) { ... ɵɵviewQuerySignal(...) ... ɵɵqueryAdvance(); }`
+//! * `contentQueries: function(rf, ctx, directiveIndex) { ... ɵɵcontentQuerySignal(...) ... }`
+//!
+//! These are the exact shapes Angular's runtime reads — flipping bits,
+//! omitting the signal write-through path, or skipping `queryAdvance()`
+//! all silently break signal authoring at runtime, so the assertions
+//! pin every required piece.
+
+use std::path::PathBuf;
+
+use ngc_template_compiler::compile_component;
+
+const FIXTURE_SOURCE: &str = r#"
+import {
+  Component,
+  input,
+  output,
+  model,
+  viewChild,
+  viewChildren,
+  contentChild,
+  contentChildren,
+  ElementRef,
+} from '@angular/core';
+
+function trimString(v: string): string {
+  return v.trim();
+}
+
+@Component({
+  selector: 'app-x',
+  standalone: true,
+  template: '<span>x</span>',
+})
+export class XComponent {
+  // Signal inputs — plain, required, aliased, transformed.
+  name = input<string>('default');
+  required = input.required<number>();
+  aliased = input<string>('', { alias: 'pub' });
+  trimmed = input<string>('', { transform: trimString });
+
+  // Signal output.
+  changed = output<string>();
+
+  // Signal model — desugars to input + `valueChange` output.
+  value = model<string>('initial');
+
+  // Signal queries — view + content, single + plural.
+  v = viewChild<string>('ref');
+  vs = viewChildren(SomeCmp);
+  c = contentChild<SomeDir>(SomeDir, { read: ElementRef });
+  cs = contentChildren(SomeDir);
+}
+"#;
+
+#[test]
+fn signal_apis_reach_runtime_with_correct_shape() {
+    let compiled = compile_component(FIXTURE_SOURCE, &PathBuf::from("x.component.ts"))
+        .expect("component should compile");
+
+    assert!(
+        compiled.compiled,
+        "compile_component should rewrite signal-API source"
+    );
+    assert!(
+        !compiled.jit_fallback,
+        "signal-API components must not fall back to JIT"
+    );
+
+    let out = &compiled.source;
+
+    // Plain `input()` — SignalBased flag (bit 0) only.
+    assert!(
+        out.contains("name: [1, 'name', 'name']"),
+        "expected plain input to set SignalBased flag, got:\n{out}"
+    );
+
+    // `input.required()` keeps the same SignalBased flag — required is
+    // not a separate runtime flag.
+    assert!(
+        out.contains("required: [1, 'required', 'required']"),
+        "expected required input to set SignalBased flag, got:\n{out}"
+    );
+
+    // Alias surfaces in array position 1 (publicName), property name in
+    // position 2.
+    assert!(
+        out.contains("aliased: [1, 'pub', 'aliased']"),
+        "expected aliased input to keep public name in position 1, got:\n{out}"
+    );
+
+    // Transform sets BOTH SignalBased (bit 0) and
+    // HasDecoratorInputTransform (bit 1) → flags = 3 — and rides along
+    // as the 4th array element so the runtime can call it.
+    assert!(
+        out.contains("trimmed: [3, 'trimmed', 'trimmed', trimString]"),
+        "expected transform input to carry function ref + flag bit 1, got:\n{out}"
+    );
+
+    // Output → identity entry in the outputs map.
+    assert!(
+        out.contains("changed: 'changed'"),
+        "expected output to land in outputs map, got:\n{out}"
+    );
+
+    // Model emits a paired input + `<name>Change` output.
+    assert!(
+        out.contains("value: [1, 'value', 'value']"),
+        "expected model input entry, got:\n{out}"
+    );
+    assert!(
+        out.contains("valueChange: 'valueChange'"),
+        "expected model paired Change output, got:\n{out}"
+    );
+
+    // Signal queries dispatch to `ɵɵviewQuerySignal` / `ɵɵcontentQuerySignal`
+    // — never the legacy `ɵɵviewQuery` / `ɵɵcontentQuery` for these.
+    // The `ctx.<prop>` target in arg 1 (or arg 2 for content) is what
+    // lets the runtime write into the WritableSignal slot directly.
+    assert!(
+        out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.v"),
+        "expected viewQuerySignal create call for `v`, got:\n{out}"
+    );
+    assert!(
+        out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.vs"),
+        "expected viewQuerySignal create call for `vs`, got:\n{out}"
+    );
+    assert!(
+        out.contains("\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.c"),
+        "expected contentQuerySignal create call for `c`, got:\n{out}"
+    );
+    assert!(
+        out.contains("\u{0275}\u{0275}contentQuerySignal(directiveIndex, ctx.cs"),
+        "expected contentQuerySignal create call for `cs`, got:\n{out}"
+    );
+
+    // Each signal query needs a `ɵɵqueryAdvance()` in the update block
+    // so the next query reads from the right LView slot. Without these
+    // the second/third query would resolve against the first's slot.
+    assert!(
+        out.contains("\u{0275}\u{0275}queryAdvance();"),
+        "expected ɵɵqueryAdvance update calls, got:\n{out}"
+    );
+
+    // Read token must reach the runtime as the trailing argument so
+    // the runtime resolves an ElementRef rather than the matched
+    // directive instance.
+    assert!(
+        out.contains("ElementRef"),
+        "expected ElementRef read token preserved:\n{out}"
+    );
+
+    // Symbols must be added to the @angular/core import set so the
+    // bundler can resolve them and the runtime calls dispatch.
+    for symbol in [
+        "\u{0275}\u{0275}viewQuerySignal",
+        "\u{0275}\u{0275}contentQuerySignal",
+        "\u{0275}\u{0275}queryAdvance",
+    ] {
+        assert!(
+            out.contains(symbol),
+            "expected {symbol} to be imported, got:\n{out}"
+        );
+    }
+
+    // Rewritten source must lower cleanly through ts-transform — the
+    // pipeline that turns the rewritten TS into the .mjs the bundler
+    // consumes.
+    let js = ngc_ts_transform::transform_source(out, "x.component.ts")
+        .expect("compiled source should parse through ts-transform");
+    assert!(
+        js.contains("viewQuerySignal"),
+        "signal-query call must survive ts-transform:\n{js}"
+    );
+}

--- a/crates/template-compiler/tests/signal_apis_integration.rs
+++ b/crates/template-compiler/tests/signal_apis_integration.rs
@@ -131,9 +131,12 @@ fn signal_apis_reach_runtime_with_correct_shape() {
     // — never the legacy `ɵɵviewQuery` / `ɵɵcontentQuery` for these.
     // The `ctx.<prop>` target in arg 1 (or arg 2 for content) is what
     // lets the runtime write into the WritableSignal slot directly.
+    // `viewChild('ref')` wraps the bare-string predicate in an array
+    // — runtime treats `'ref'` (string) as a `ProviderToken` and
+    // `['ref']` (array) as a template-ref selector.
     assert!(
-        out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.v"),
-        "expected viewQuerySignal create call for `v`, got:\n{out}"
+        out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.v, ['ref']"),
+        "expected viewQuerySignal create call for `v` with wrapped predicate, got:\n{out}"
     );
     assert!(
         out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.vs"),

--- a/crates/template-compiler/tests/signal_apis_integration.rs
+++ b/crates/template-compiler/tests/signal_apis_integration.rs
@@ -83,32 +83,36 @@ fn signal_apis_reach_runtime_with_correct_shape() {
 
     let out = &compiled.source;
 
-    // Plain `input()` — SignalBased flag (bit 0) only.
+    // Plain `input()` — SignalBased flag (bit 0) only. Compact
+    // 2-element form `[flags, publicName]` because the public name
+    // matches the class property name.
     assert!(
-        out.contains("name: [1, 'name', 'name']"),
-        "expected plain input to set SignalBased flag, got:\n{out}"
+        out.contains("name: [1, 'name']"),
+        "expected plain input to set SignalBased flag (compact form), got:\n{out}"
     );
 
     // `input.required()` keeps the same SignalBased flag — required is
     // not a separate runtime flag.
     assert!(
-        out.contains("required: [1, 'required', 'required']"),
+        out.contains("required: [1, 'required']"),
         "expected required input to set SignalBased flag, got:\n{out}"
     );
 
-    // Alias surfaces in array position 1 (publicName), property name in
-    // position 2.
+    // Alias surfaces in array position 1 (publicName), property name
+    // in position 2 — this is the 3-element form because the names
+    // differ.
     assert!(
         out.contains("aliased: [1, 'pub', 'aliased']"),
         "expected aliased input to keep public name in position 1, got:\n{out}"
     );
 
-    // Transform sets BOTH SignalBased (bit 0) and
-    // HasDecoratorInputTransform (bit 1) → flags = 3 — and rides along
-    // as the 4th array element so the runtime can call it.
+    // Signal-based transforms stay on the SIGNAL (the field
+    // initializer carries the transform); they do NOT replicate into
+    // the inputs def. Flags stay at SignalBased (1) and the entry is
+    // the compact 2-element form. Angular's `ng build` does the same.
     assert!(
-        out.contains("trimmed: [3, 'trimmed', 'trimmed', trimString]"),
-        "expected transform input to carry function ref + flag bit 1, got:\n{out}"
+        out.contains("trimmed: [1, 'trimmed']"),
+        "expected signal input with transform to use compact form, got:\n{out}"
     );
 
     // Output → identity entry in the outputs map.
@@ -117,14 +121,20 @@ fn signal_apis_reach_runtime_with_correct_shape() {
         "expected output to land in outputs map, got:\n{out}"
     );
 
-    // Model emits a paired input + `<name>Change` output.
+    // Model emits a paired input + change output. The output map MUST
+    // be keyed by the class-property name (so the runtime finds the
+    // model signal at `instance.<field>` to subscribe to) and valued
+    // with the public event name (`<field>Change`). Keying by the
+    // public event name silently breaks two-way binding because the
+    // runtime then tries to read a non-existent
+    // `instance.<field>Change` field.
     assert!(
-        out.contains("value: [1, 'value', 'value']"),
-        "expected model input entry, got:\n{out}"
+        out.contains("value: [1, 'value']"),
+        "expected model input entry (compact form), got:\n{out}"
     );
     assert!(
-        out.contains("valueChange: 'valueChange'"),
-        "expected model paired Change output, got:\n{out}"
+        out.contains("value: 'valueChange'"),
+        "expected outputs entry keyed by class prop, valued with public event name, got:\n{out}"
     );
 
     // Signal queries dispatch to `ɵɵviewQuerySignal` / `ɵɵcontentQuerySignal`
@@ -133,10 +143,12 @@ fn signal_apis_reach_runtime_with_correct_shape() {
     // lets the runtime write into the WritableSignal slot directly.
     // `viewChild('ref')` wraps the bare-string predicate in an array
     // — runtime treats `'ref'` (string) as a `ProviderToken` and
-    // `['ref']` (array) as a template-ref selector.
+    // `['ref']` (array) as a template-ref selector. Flags = 5
+    // (descendants=true | emitDistinctChangesOnly=true), matching
+    // Angular's compiler emission for signal queries.
     assert!(
-        out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.v, ['ref']"),
-        "expected viewQuerySignal create call for `v` with wrapped predicate, got:\n{out}"
+        out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.v, ['ref'], 5)"),
+        "expected viewQuerySignal create call for `v` with flags=5, got:\n{out}"
     );
     assert!(
         out.contains("\u{0275}\u{0275}viewQuerySignal(ctx.vs"),

--- a/crates/template-compiler/tests/signal_apis_integration.rs
+++ b/crates/template-compiler/tests/signal_apis_integration.rs
@@ -44,7 +44,7 @@ function trimString(v: string): string {
 @Component({
   selector: 'app-x',
   standalone: true,
-  template: '<span>x</span><ng-content />',
+  template: '<span [(value)]="value">x</span><ng-content />',
 })
 export class XComponent {
   // Signal inputs — plain, required, aliased, transformed.
@@ -194,6 +194,25 @@ fn signal_apis_reach_runtime_with_correct_shape() {
         "expected ngContentSelectors on the component def, got:\n{out}"
     );
 
+    // Two-way binding `[(value)]="value"` to a model signal MUST
+    // dispatch to the signal-aware `ɵɵtwoWayProperty` /
+    // `ɵɵtwoWayListener` instructions plus `ɵɵtwoWayBindingSet` —
+    // emitting plain `ɵɵproperty` + assignment would replace the
+    // model signal with a raw value on every emission, and the next
+    // template `value()` read throws "is not a function".
+    assert!(
+        out.contains("\u{0275}\u{0275}twoWayProperty('value'"),
+        "expected ɵɵtwoWayProperty for two-way binding, got:\n{out}"
+    );
+    assert!(
+        out.contains("\u{0275}\u{0275}twoWayListener('valueChange'"),
+        "expected ɵɵtwoWayListener for two-way binding, got:\n{out}"
+    );
+    assert!(
+        out.contains("\u{0275}\u{0275}twoWayBindingSet(ctx.value, $event)"),
+        "expected ɵɵtwoWayBindingSet inside listener body, got:\n{out}"
+    );
+
     // Symbols must be added to the @angular/core import set so the
     // bundler can resolve them and the runtime calls dispatch.
     for symbol in [
@@ -201,6 +220,9 @@ fn signal_apis_reach_runtime_with_correct_shape() {
         "\u{0275}\u{0275}contentQuerySignal",
         "\u{0275}\u{0275}queryAdvance",
         "\u{0275}\u{0275}projectionDef",
+        "\u{0275}\u{0275}twoWayProperty",
+        "\u{0275}\u{0275}twoWayListener",
+        "\u{0275}\u{0275}twoWayBindingSet",
     ] {
         assert!(
             out.contains(symbol),


### PR DESCRIPTION
Closes #55.

## Summary

Adds AOT and linker support for Angular 17+'s signal-based authoring APIs:
`input()` / `input.required()` / `input` with transform, `output()`,
`model()`, and the four signal queries (`viewChild`, `viewChildren`,
`contentChild`, `contentChildren`).

## What changed

**Linker** — `crates/linker/src/{directive,component}.rs`
- Honour `isSignal` / `isRequired` / `transformFunction` on input
  descriptors in `ɵɵngDeclareDirective` / `ɵɵngDeclareComponent`. The
  runtime input array now carries the right `InputFlags` bits
  (`SignalBased = 1`, `HasDecoratorInputTransform = 2`) and the
  transform function reference rides along as the 4th element.
- Honour `isSignal` on query descriptors and dispatch to
  `ɵɵviewQuerySignal` / `ɵɵcontentQuerySignal` + `ɵɵqueryAdvance`.

**Template compiler (AOT)** — `crates/template-compiler/src/{extract,signal_codegen,codegen,directive_codegen}.rs`
- Detect class field initialisers calling the signal-API factories
  (bare and `.required` forms) and capture alias / transform / read /
  static metadata.
- Emit matching `inputs` / `outputs` map entries (with the right flag
  bits + transform refs preserved) and `viewQuery` / `contentQueries`
  functions (signal-aware dispatch) on the `defineComponent` /
  `defineDirective` call.
- `model()` desugars to a paired SignalBased input + \`<name>Change\` output.
- Bare-string predicates (`viewChild('ref')`) are wrapped to `['ref']`
  so the runtime treats them as template-ref selectors and not as
  provider tokens.

## Test plan

- [x] `cargo test --workspace` (unrelated SCSS preprocessor tests fail
  pre-existing — they need `sass`/`less`/`stylus` npm packages).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] New unit tests for each API (input, input.required, input with
  transform, input with alias, output, model, model with alias,
  viewChild, viewChildren, contentChild, contentChildren) on both the
  linker (`crates/linker/src/directive.rs`) and AOT
  (`crates/template-compiler/src/{extract,signal_codegen}.rs`) sides.
- [x] End-to-end integration test
  (`crates/template-compiler/tests/signal_apis_integration.rs`) compiles
  a component that exercises every API and asserts the rewritten Ivy
  shapes (flags, transform refs, `ɵɵviewQuerySignal` / `ɵɵcontentQuerySignal`,
  `ɵɵqueryAdvance`).