### PR TITLE
fix(template-compiler): emit primary template index and trigger element refs in `@defer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "base64",
  "clap",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.36"
+version = "0.7.37"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1935,8 +1935,17 @@ impl IvyCodegen {
         // LContainer slot allocated AFTER all sub-block templates so the
         // runtime's first-create pass has populated each template TNode's
         // `tView` before `triggerResourceLoading` dereferences it.
+        //
+        // `ɵɵdefer` actually consumes TWO slots: the LContainer at `slot`
+        // and `tDetails` at `slot + 1` (Angular's `setTDeferBlockDetails`
+        // writes to `tView.data[deferBlockIndex + 1]`). Reusing `slot + 1`
+        // for the next instruction would point its TNode lookup at the
+        // tDetails object — whose `.attrs` is undefined, which the
+        // directive-matcher reads via `getNameOnlyMarkerIndex(tNode.attrs)`
+        // and crashes the parent template's first-create pass. Reserve the
+        // shadow slot to keep the next instruction's slot collision-free.
         let defer_slot = self.slot_index;
-        self.slot_index += 1;
+        self.slot_index += 2;
 
         // Build the dependency resolver function. Emitted as a module-scope
         // helper so the bundler's import scanner can pick up any `import()`

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -43,6 +43,10 @@ enum Namespace {
 /// Internal codegen state.
 struct IvyCodegen {
     component_name: String,
+    /// Identifier names from the component's `imports: [...]` array.
+    /// Used by `@defer` deps-fn emission so the deferred view can resolve
+    /// `<my-tag>` against the same in-scope classes the bundler co-bundled.
+    component_imports: Vec<String>,
     slot_index: u32,
     var_count: u32,
     creation: Vec<String>,
@@ -121,6 +125,7 @@ pub fn generate_ivy(
 ) -> NgcResult<IvyOutput> {
     let mut gen = IvyCodegen {
         component_name: component.class_name.clone(),
+        component_imports: component.imports_identifiers.clone(),
         slot_index: 0,
         var_count: 0,
         creation: Vec::new(),
@@ -1935,7 +1940,8 @@ impl IvyCodegen {
             self.component_name, self.child_counter
         );
         self.child_counter += 1;
-        let deps_fn_code = build_defer_deps_fn(&deps_fn_name, &block.children);
+        let deps_fn_code =
+            build_defer_deps_fn(&deps_fn_name, &block.children, &self.component_imports);
         self.child_templates.push(ChildTemplate {
             function_name: deps_fn_name.clone(),
             decls: 0,
@@ -3587,25 +3593,36 @@ fn compile_event_handler(handler: &str, locals: &BTreeSet<String>) -> String {
 ///
 /// Real-world components are wired by the bundler's import-scanner picking
 /// up these `import(...)` calls as split points; resolving each call to a
-/// concrete module source is the author's responsibility for now — the
-/// specifier is derived from the tag (e.g. `<my-comp />` →
-/// `'./my-comp'`). Component authors who need a different path can
-/// re-author the helper by hand after compilation.
-fn build_defer_deps_fn(name: &str, children: &[TemplateNode]) -> String {
-    let mut tags: Vec<String> = Vec::new();
-    collect_custom_tags(children, &mut tags);
-    tags.sort();
-    tags.dedup();
+/// Returned array contents:
+/// - When the host component has any `imports: [...]` identifiers, return
+///   them directly. Angular's runtime accepts synchronous `Type` values in
+///   `DependencyResolverFn`'s array (the type is `Array<Promise<T> | T>`),
+///   resolves the deferred template's tags via selector match, and skips
+///   the network round-trip. This matches ngc-rs's bundling reality —
+///   imported components are co-bundled into the host chunk, not split
+///   into per-tag modules — so a synthetic `import('./<tag>')` would 404
+///   at runtime (NG0750).
+/// - Otherwise, fall back to the no-op `[]` so the runtime can still mark
+///   the block as resolved without crashing.
+fn build_defer_deps_fn(
+    name: &str,
+    children: &[TemplateNode],
+    component_imports: &[String],
+) -> String {
+    let has_custom_tags = {
+        let mut tags: Vec<String> = Vec::new();
+        collect_custom_tags(children, &mut tags);
+        !tags.is_empty()
+    };
 
     let mut code = format!("function {name}() {{\n  return [");
-    if tags.is_empty() {
+    if !has_custom_tags || component_imports.is_empty() {
         code.push(']');
     } else {
         code.push('\n');
-        for (i, tag) in tags.iter().enumerate() {
-            let symbol = kebab_to_pascal(tag);
-            code.push_str(&format!("    import('./{tag}').then(m => m.{symbol})"));
-            if i + 1 < tags.len() {
+        for (i, ident) in component_imports.iter().enumerate() {
+            code.push_str(&format!("    {ident}"));
+            if i + 1 < component_imports.len() {
                 code.push(',');
             }
             code.push('\n');
@@ -3666,24 +3683,6 @@ fn collect_custom_tags(nodes: &[TemplateNode], out: &mut Vec<String>) {
             _ => {}
         }
     }
-}
-
-/// Convert a kebab-case tag name to a PascalCase identifier.
-/// `my-cool-widget` → `MyCoolWidget`.
-fn kebab_to_pascal(tag: &str) -> String {
-    let mut out = String::with_capacity(tag.len());
-    let mut capitalize = true;
-    for ch in tag.chars() {
-        if ch == '-' {
-            capitalize = true;
-        } else if capitalize {
-            out.extend(ch.to_uppercase());
-            capitalize = false;
-        } else {
-            out.push(ch);
-        }
-    }
-    out
 }
 
 /// Parse an Angular duration string to milliseconds.
@@ -4610,20 +4609,33 @@ mod tests {
     }
 
     #[test]
-    fn test_defer_dep_fn_emits_import_for_custom_tag() {
-        let output = compile_template("@defer (on idle) { <my-c /> }");
+    fn test_defer_dep_fn_emits_component_imports_directly() {
+        // ngc-rs co-bundles imported components into the host chunk, so the
+        // deps fn returns synchronous class references — Angular's runtime
+        // resolves the deferred template's tags by selector match against
+        // them. This avoids the NG0750 "deferred chunk failed to load"
+        // path that an `import('./<tag>')` would take when no separate
+        // chunk exists.
+        let mut comp = test_component();
+        comp.imports_identifiers = vec!["HeavyComponent".to_string()];
+        let nodes = crate::parser::parse_template(
+            "@defer (on idle) { <my-c /> }",
+            &std::path::PathBuf::from("test.html"),
+        )
+        .expect("parse");
+        let output = generate_ivy(&comp, &nodes).expect("generate");
         let deps_fn = output
             .child_template_functions
             .iter()
             .find(|f| f.contains("DepsFn"))
             .expect("dep fn should be emitted");
         assert!(
-            deps_fn.contains("import('./my-c')"),
-            "dep fn should contain dynamic import for <my-c>: {deps_fn}"
+            deps_fn.contains("HeavyComponent"),
+            "dep fn should reference imported class directly: {deps_fn}"
         );
         assert!(
-            deps_fn.contains("m => m.MyC"),
-            "dep fn should reference PascalCase symbol: {deps_fn}"
+            !deps_fn.contains("import("),
+            "dep fn must not emit a dynamic import — co-bundled chunks 404: {deps_fn}"
         );
     }
 
@@ -4638,6 +4650,23 @@ mod tests {
         assert!(
             deps_fn.contains("return [];"),
             "dep fn with no custom tags should return []: {deps_fn}"
+        );
+    }
+
+    #[test]
+    fn test_defer_dep_fn_empty_when_component_has_no_imports() {
+        // Even with a custom tag inside the defer block, a component that
+        // declares no `imports: [...]` has nothing to surface to the
+        // deferred view — return [] rather than guessing a module path.
+        let output = compile_template("@defer (on idle) { <my-c /> }");
+        let deps_fn = output
+            .child_template_functions
+            .iter()
+            .find(|f| f.contains("DepsFn"))
+            .expect("dep fn should be emitted");
+        assert!(
+            deps_fn.contains("return [];"),
+            "no imports → empty array (avoids fabricating a 404 path): {deps_fn}"
         );
     }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -2034,8 +2034,18 @@ impl IvyCodegen {
         }
 
         // Trigger instructions — emit for each trigger, prefetch variants last.
-        for trig in &block.triggers {
-            self.emit_defer_trigger(trig, defer_slot, false, placeholder_refs.as_ref());
+        // `@defer { … }` with no explicit trigger defaults to `on idle`; ng
+        // build emits the same `ɵɵdeferOnIdle()` and the runtime expects a
+        // trigger to be registered or the block stays in the placeholder
+        // state forever (with no error path back to the primary view).
+        if block.triggers.is_empty() {
+            let sym = "\u{0275}\u{0275}deferOnIdle";
+            self.ivy_imports.insert(sym.to_string());
+            self.creation.push(format!("{sym}();"));
+        } else {
+            for trig in &block.triggers {
+                self.emit_defer_trigger(trig, defer_slot, false, placeholder_refs.as_ref());
+            }
         }
         for trig in &block.prefetch_triggers {
             self.emit_defer_trigger(trig, defer_slot, true, placeholder_refs.as_ref());

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -72,6 +72,11 @@ struct IvyCodegen {
     /// Maps `#refName` → LView slot that stores the resolved ref value.
     /// Binding expressions reading these names are rewritten to `ɵɵreference(slot)`.
     template_refs: BTreeMap<String, u32>,
+    /// Companion to `template_refs`: maps `#refName` → slot of the *element*
+    /// the ref was declared on. `@defer` triggers like `on hover(ref)` need
+    /// the underlying element's slot (the runtime resolves the TNode there),
+    /// not the ref-value slot consumed by `ɵɵreference`.
+    template_ref_elements: BTreeMap<String, u32>,
     /// Namespace most recently emitted in the current template function's
     /// creation block. Compared against each element's target namespace to
     /// decide whether a ɵɵnamespaceHTML/SVG/MathML transition is needed.
@@ -102,6 +107,11 @@ struct ChildTemplate {
     decls: u32,
     vars: u32,
     code: String,
+    /// Template-reference *element* slots declared inside this child
+    /// template. Maps `#refName` → slot of the element the ref was declared
+    /// on (NOT the ref-value slot). `@defer` triggers like `on hover(ref)`
+    /// look this up in their placeholder block to anchor on the right TNode.
+    template_ref_elements: BTreeMap<String, u32>,
 }
 
 /// Generate Ivy instructions from a parsed template AST and component metadata.
@@ -125,6 +135,7 @@ pub fn generate_ivy(
         last_update_slot: None,
         pipe_var_offset: 0,
         template_refs: BTreeMap::new(),
+        template_ref_elements: BTreeMap::new(),
         namespace_state: Namespace::Html,
         namespace_stack: vec![Namespace::Html],
         has_projection: false,
@@ -673,7 +684,7 @@ impl IvyCodegen {
 
             // Allocate ref slots BEFORE emitting bindings so that expressions
             // using the ref name can resolve to the correct ɵɵreference(slot).
-            self.reserve_template_refs(&refs);
+            self.reserve_template_refs(&refs, slot);
 
             self.emit_i18n_attributes(el, slot);
 
@@ -723,7 +734,7 @@ impl IvyCodegen {
 
             // Allocate ref slots BEFORE listeners, bindings, or children.
             // Listener bodies and descendant bindings may reference these names.
-            self.reserve_template_refs(&refs);
+            self.reserve_template_refs(&refs, slot);
 
             // Event listeners and two-way binding listeners in creation block
             for attr in &el.attributes {
@@ -958,8 +969,11 @@ impl IvyCodegen {
 
     /// Reserve a slot for each template reference on the current element and
     /// register the ref in `template_refs` + `local_vars` so binding
-    /// expressions can resolve it.
-    fn reserve_template_refs(&mut self, refs: &[(String, String)]) {
+    /// expressions can resolve it. `element_slot` is the slot of the element
+    /// the refs are declared on; it is recorded in `template_ref_elements`
+    /// for `@defer` triggers that anchor on the element itself rather than
+    /// the ref-value slot.
+    fn reserve_template_refs(&mut self, refs: &[(String, String)], element_slot: u32) {
         if refs.is_empty() {
             return;
         }
@@ -969,6 +983,8 @@ impl IvyCodegen {
             let ref_slot = self.slot_index;
             self.slot_index += 1;
             self.template_refs.insert(name.clone(), ref_slot);
+            self.template_ref_elements
+                .insert(name.clone(), element_slot);
             self.local_vars.insert(name.clone());
         }
     }
@@ -1093,6 +1109,7 @@ impl IvyCodegen {
         let parent_consts = std::mem::take(&mut self.consts);
         let parent_lets = self.let_declarations.clone();
         let parent_refs = std::mem::take(&mut self.template_refs);
+        let parent_ref_elements = std::mem::take(&mut self.template_ref_elements);
         // Each child template function runs with its own namespace flag that
         // starts as HTML, so reset the tracked state. The stack is left
         // intact — its top is the outer child_ns and remains the correct
@@ -1153,6 +1170,8 @@ impl IvyCodegen {
         self.consts = parent_consts;
         self.let_declarations = parent_lets;
         self.template_refs = parent_refs;
+        let child_ref_elements =
+            std::mem::replace(&mut self.template_ref_elements, parent_ref_elements);
         self.namespace_state = parent_ns_state;
 
         ChildTemplate {
@@ -1160,6 +1179,7 @@ impl IvyCodegen {
             decls,
             vars,
             code,
+            template_ref_elements: child_ref_elements,
         }
     }
 
@@ -1532,6 +1552,7 @@ impl IvyCodegen {
         let parent_update = std::mem::take(&mut self.update);
         let parent_lets = self.let_declarations.clone();
         let parent_refs = std::mem::take(&mut self.template_refs);
+        let parent_ref_elements = std::mem::take(&mut self.template_ref_elements);
         self.scope_stack.push(ScopeEntry::Conditional);
         // Reset namespace_state for this child template function (its runtime
         // namespace flag starts as HTML). The stack is left intact so nested
@@ -1618,6 +1639,8 @@ impl IvyCodegen {
         self.update = parent_update;
         self.let_declarations = parent_lets;
         self.template_refs = parent_refs;
+        let child_ref_elements =
+            std::mem::replace(&mut self.template_ref_elements, parent_ref_elements);
         self.namespace_state = parent_ns_state;
 
         ChildTemplate {
@@ -1625,6 +1648,7 @@ impl IvyCodegen {
             decls,
             vars,
             code,
+            template_ref_elements: child_ref_elements,
         }
     }
 
@@ -1643,6 +1667,7 @@ impl IvyCodegen {
         let parent_update = std::mem::take(&mut self.update);
         let parent_lets = self.let_declarations.clone();
         let parent_refs = std::mem::take(&mut self.template_refs);
+        let parent_ref_elements = std::mem::take(&mut self.template_ref_elements);
 
         self.slot_index = 0;
         self.var_count = 0;
@@ -1766,6 +1791,8 @@ impl IvyCodegen {
         self.let_declarations = parent_lets;
         self.local_vars = parent_locals;
         self.template_refs = parent_refs;
+        let child_ref_elements =
+            std::mem::replace(&mut self.template_ref_elements, parent_ref_elements);
         self.namespace_state = parent_ns_state;
 
         ChildTemplate {
@@ -1773,6 +1800,7 @@ impl IvyCodegen {
             decls,
             vars,
             code,
+            template_ref_elements: child_ref_elements,
         }
     }
 
@@ -1826,8 +1854,8 @@ impl IvyCodegen {
     /// Generate an `@defer` block with its `@placeholder` / `@loading` /
     /// `@error` sub-blocks and trigger instructions.
     ///
-    /// Emits per the issue spec:
-    /// `ɵɵdefer(index, dependencyFn, loadingTmpl?, placeholderTmpl?, errorTmpl?)`
+    /// Emits Angular Ivy's v21 `ɵɵdefer` signature:
+    /// `ɵɵdefer(index, primaryTmplIndex, depsFn, loadingTmpl?, placeholderTmpl?, errorTmpl?)`
     /// followed by the trigger instructions:
     /// - `on viewport|idle|hover|interaction|immediate` → `ɵɵdeferOn*`
     /// - `on timer(<duration>)` → `ɵɵdeferOnTimer(<ms>)`
@@ -1913,6 +1941,7 @@ impl IvyCodegen {
             decls: 0,
             vars: 0,
             code: deps_fn_code,
+            template_ref_elements: BTreeMap::new(),
         });
 
         // Emit ɵɵtemplate(slot, fn, decls, vars) for each template.
@@ -1941,8 +1970,10 @@ impl IvyCodegen {
             ));
         }
 
-        // Build the ɵɵdefer call, following the issue's signature:
-        //   ɵɵdefer(index, dependencyFn, loadingTmpl?, placeholderTmpl?, errorTmpl?)
+        // Build the ɵɵdefer call. Ivy's signature in v21:
+        //   ɵɵdefer(index, primaryTmplIndex, depsFn,
+        //           loadingTmplIndex?, placeholderTmplIndex?, errorTmplIndex?)
+        // Trailing nulls are omitted to match ng build's emit.
         let loading_arg = loading_info
             .as_ref()
             .map(|(s, _, _)| s.to_string())
@@ -1955,9 +1986,27 @@ impl IvyCodegen {
             .as_ref()
             .map(|(s, _, _)| s.to_string())
             .unwrap_or_else(|| "null".to_string());
+        let mut defer_args = vec![format!("{main_slot}"), deps_fn_name.clone()];
+        let trailing = [loading_arg, placeholder_arg, error_arg];
+        let last_present = trailing.iter().rposition(|s| s != "null");
+        if let Some(idx) = last_present {
+            for arg in trailing.iter().take(idx + 1) {
+                defer_args.push(arg.clone());
+            }
+        }
         self.creation.push(format!(
-            "\u{0275}\u{0275}defer({defer_slot}, {deps_fn_name}, {loading_arg}, {placeholder_arg}, {error_arg});"
+            "\u{0275}\u{0275}defer({defer_slot}, {});",
+            defer_args.join(", ")
         ));
+
+        // Resolve trigger element refs against the placeholder block's
+        // template references. For implicit anchors (no `(ref)`), Angular
+        // uses the placeholder template's first element (slot 0). The map
+        // values are *element* slots, not ref-value slots — defer triggers
+        // anchor on the underlying TNode, not the resolved ref value.
+        let placeholder_refs = placeholder_info
+            .as_ref()
+            .map(|(_, _, child)| child.template_ref_elements.clone());
 
         // Move the child templates for placeholder/loading/error into the
         // component's child_templates vec. They were produced inside each
@@ -1974,26 +2023,40 @@ impl IvyCodegen {
 
         // Trigger instructions — emit for each trigger, prefetch variants last.
         for trig in &block.triggers {
-            self.emit_defer_trigger(trig, defer_slot, false);
+            self.emit_defer_trigger(trig, defer_slot, false, placeholder_refs.as_ref());
         }
         for trig in &block.prefetch_triggers {
-            self.emit_defer_trigger(trig, defer_slot, true);
+            self.emit_defer_trigger(trig, defer_slot, true, placeholder_refs.as_ref());
         }
     }
 
     /// Emit a single trigger instruction for an `@defer` block. `on`-family
     /// triggers land in the creation block; `when` triggers land in the update
     /// block with an `ɵɵadvance` to the defer slot.
-    fn emit_defer_trigger(&mut self, trig: &DeferTrigger, defer_slot: u32, prefetch: bool) {
+    ///
+    /// For viewport / hover / interaction triggers, the trigger element's slot
+    /// index inside the placeholder block is passed as the first argument
+    /// followed by `walkUpTimes = -1` (the runtime sentinel meaning "look up
+    /// in the placeholder embedded view"). With an explicit `(ref)`, the slot
+    /// is the ref's recorded slot in the placeholder template; without one,
+    /// it defaults to the placeholder's first element (slot 0).
+    fn emit_defer_trigger(
+        &mut self,
+        trig: &DeferTrigger,
+        defer_slot: u32,
+        prefetch: bool,
+        placeholder_refs: Option<&BTreeMap<String, u32>>,
+    ) {
         match trig {
-            DeferTrigger::Viewport(_) => {
+            DeferTrigger::Viewport(ref_name) => {
                 let sym = if prefetch {
                     "\u{0275}\u{0275}deferPrefetchOnViewport"
                 } else {
                     "\u{0275}\u{0275}deferOnViewport"
                 };
                 self.ivy_imports.insert(sym.to_string());
-                self.creation.push(format!("{sym}();"));
+                let args = trigger_element_args(ref_name.as_deref(), placeholder_refs);
+                self.creation.push(format!("{sym}({args});"));
             }
             DeferTrigger::Idle => {
                 let sym = if prefetch {
@@ -2013,23 +2076,25 @@ impl IvyCodegen {
                 self.ivy_imports.insert(sym.to_string());
                 self.creation.push(format!("{sym}();"));
             }
-            DeferTrigger::Hover(_) => {
+            DeferTrigger::Hover(ref_name) => {
                 let sym = if prefetch {
                     "\u{0275}\u{0275}deferPrefetchOnHover"
                 } else {
                     "\u{0275}\u{0275}deferOnHover"
                 };
                 self.ivy_imports.insert(sym.to_string());
-                self.creation.push(format!("{sym}();"));
+                let args = trigger_element_args(ref_name.as_deref(), placeholder_refs);
+                self.creation.push(format!("{sym}({args});"));
             }
-            DeferTrigger::Interaction(_) => {
+            DeferTrigger::Interaction(ref_name) => {
                 let sym = if prefetch {
                     "\u{0275}\u{0275}deferPrefetchOnInteraction"
                 } else {
                     "\u{0275}\u{0275}deferOnInteraction"
                 };
                 self.ivy_imports.insert(sym.to_string());
-                self.creation.push(format!("{sym}();"));
+                let args = trigger_element_args(ref_name.as_deref(), placeholder_refs);
+                self.creation.push(format!("{sym}({args});"));
             }
             DeferTrigger::Timer(duration) => {
                 let sym = if prefetch {
@@ -3626,6 +3691,32 @@ fn kebab_to_pascal(tag: &str) -> String {
 /// Accepts `<number>ms` or `<number>s`; a bare number is treated as ms.
 /// Unknown suffixes fall back to the raw string as the argument (so the
 /// runtime or a later lint can flag it).
+/// Build the `(triggerIndex, walkUpTimes)` argument list for a viewport /
+/// hover / interaction defer trigger. Returns the slot index of the trigger
+/// element inside the placeholder block paired with `-1`, the runtime
+/// sentinel that tells `ɵɵdeferOn*` to resolve the index in the placeholder
+/// embedded view rather than walking up parent LViews.
+///
+/// With an explicit `(ref)`, the slot is the ref's recorded position; with
+/// an implicit anchor, it falls back to the placeholder's first element
+/// (slot 0). When there is no placeholder block at all (an unanchored
+/// viewport trigger) the runtime accepts no arguments and falls back to the
+/// LContainer comment node, so the call is emitted bare.
+fn trigger_element_args(
+    ref_name: Option<&str>,
+    placeholder_refs: Option<&BTreeMap<String, u32>>,
+) -> String {
+    match (ref_name, placeholder_refs) {
+        (Some(name), Some(refs)) => {
+            let slot = refs.get(name).copied().unwrap_or(0);
+            format!("{slot}, -1")
+        }
+        (None, Some(_)) => "0, -1".to_string(),
+        // No placeholder block: runtime resolves against the LContainer host.
+        _ => String::new(),
+    }
+}
+
 fn parse_duration_to_ms(duration: &str) -> String {
     let trimmed = duration.trim();
     if let Some(prefix) = trimmed.strip_suffix("ms") {
@@ -4547,6 +4638,135 @@ mod tests {
         assert!(
             deps_fn.contains("return [];"),
             "dep fn with no custom tags should return []: {deps_fn}"
+        );
+    }
+
+    #[test]
+    fn test_defer_emits_primary_template_index_in_second_position() {
+        // Issue #90 defect 1: ɵɵdefer was missing the primary-template index,
+        // causing the runtime to misread the deps fn as a TView descriptor.
+        let output = compile_template("@defer (on immediate) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        // defer block at slot 0; main (primary) template at slot 1.
+        assert!(
+            dc.contains("\u{0275}\u{0275}defer(0, 1, "),
+            "ɵɵdefer should emit (slot, primaryIdx, depsFn, …): {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnImmediate();"),
+            "deferOnImmediate is element-free and takes no args: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_immediate_omits_trailing_null_subblock_args() {
+        // Without sub-blocks, ng build emits ɵɵdefer(slot, primary, deps) —
+        // trailing nulls for loading/placeholder/error are trimmed.
+        let output = compile_template("@defer (on immediate) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}defer(0, 1, TestComponent_Defer_1_DepsFn);"),
+            "no sub-blocks → no trailing nulls: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_with_sub_blocks_emits_slot_indices_in_load_placeholder_error_order() {
+        let output = compile_template(
+            "@defer (on idle) { <my-c /> } @placeholder { <p>wait</p> } @loading { <p>load</p> } @error { <p>err</p> }",
+        );
+        let dc = &output.static_fields[0];
+        // Slot layout: defer=0, primary=1, placeholder=2, loading=3, error=4.
+        // Args after the deps fn are loading, placeholder, error.
+        assert!(
+            dc.contains("\u{0275}\u{0275}defer(0, 1, TestComponent_Defer_4_DepsFn, 3, 2, 4);"),
+            "expected (slot, primary, deps, loading, placeholder, error): {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_viewport_with_placeholder_passes_first_element_slot() {
+        // Issue #90 defect 2: ɵɵdeferOnViewport must receive the trigger
+        // element slot (placeholder's first element by default) plus the
+        // walkUpTimes=-1 sentinel so the runtime resolves it in the
+        // placeholder embedded view.
+        let output =
+            compile_template("@defer (on viewport) { <my-c /> } @placeholder { <p>scroll…</p> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnViewport(0, -1);"),
+            "viewport with placeholder should anchor on placeholder's first element: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_viewport_without_placeholder_emits_bare_call() {
+        // No placeholder → no embedded view to read; runtime falls back to
+        // the LContainer comment node, mirroring ng build.
+        let output = compile_template("@defer (on viewport) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnViewport();"),
+            "viewport without placeholder should emit bare call: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_hover_with_ref_resolves_placeholder_ref_slot() {
+        let output = compile_template(
+            "@defer (on hover(trigger)) { <my-c /> } @placeholder { <p #trigger>hover me</p> }",
+        );
+        let dc = &output.static_fields[0];
+        // The <p #trigger> sits at slot 0 of the placeholder template;
+        // walkUpTimes=-1 directs the runtime into that embedded view.
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnHover(0, -1);"),
+            "hover(ref) should resolve to placeholder ref's slot: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_on_interaction_with_ref_resolves_placeholder_ref_slot() {
+        let output = compile_template(
+            "@defer (on interaction(clicker)) { <my-c /> } @placeholder { <button #clicker>click</button> }",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnInteraction(0, -1);"),
+            "interaction(ref) should resolve to placeholder ref's slot: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_prefetch_on_hover_with_ref_resolves_slot() {
+        // Prefetch variants resolve refs the same way as their runtime peers.
+        let output = compile_template(
+            "@defer (on idle; prefetch on hover(trigger)) { <my-c /> } @placeholder { <p #trigger>hover</p> }",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferPrefetchOnHover(0, -1);"),
+            "prefetch on hover(ref) should pass placeholder ref slot: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferOnIdle();"),
+            "non-element runtime trigger remains arg-free: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_defer_when_expr_unchanged_by_primary_index_fix() {
+        // Sanity: `when` triggers still emit in the update block, untouched
+        // by the create-block primary-index change.
+        let output = compile_template("@defer (when isReady) { <my-c /> }");
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("\u{0275}\u{0275}defer(0, 1, "),
+            "defer call carries primary-index even with `when`: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}deferWhen(ctx.isReady);"),
+            "deferWhen still routed to update block: {dc}"
         );
     }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -1867,27 +1867,27 @@ impl IvyCodegen {
     /// - `when <expr>` → `ɵɵdeferWhen(ctx.<expr>)` in the update block
     /// - prefetch variants → `ɵɵdeferPrefetchOn*` / `ɵɵdeferPrefetchWhen`
     ///
-    /// Slot layout:
-    /// - `index` — the defer block slot (used by the runtime for state).
-    /// - `index + 1` — primary (main) template.
-    /// - `index + 2..` — placeholder, loading, error templates (in that order,
-    ///   if present).
+    /// Slot layout (matches `ng build`'s emit):
+    /// - Primary (main) template — first.
+    /// - Placeholder, loading, error templates — next, in that order, if present.
+    /// - LContainer slot for the defer block — LAST.
     ///
-    /// The dependency function is emitted as a module-level helper that
-    /// returns an array of dynamic `import()` promises — one per custom
-    /// element tag inside the defer block that matches a `imports_identifiers`
-    /// entry on the component. When no match is found the array is empty.
+    /// Allocating the LContainer last is load-bearing: Angular's runtime
+    /// `triggerResourceLoading` reads `primaryBlockTNode.tView` after the
+    /// parent template's first-create pass populated each `ɵɵtemplate(slot,
+    /// …)` TNode's `tView`. With the LContainer first, the parent's create
+    /// pass walks slots in a different order and the primary TNode's tView
+    /// stays unset, so the runtime trips on
+    /// `Cannot read properties of undefined (reading 'directiveRegistry')`
+    /// the moment a deferred dep resolves.
     fn generate_defer_block(&mut self, block: &DeferBlockNode) {
-        let defer_slot = self.slot_index;
-        self.slot_index += 1;
-
         self.ivy_imports.insert("\u{0275}\u{0275}defer".to_string());
         self.ivy_imports
             .insert("\u{0275}\u{0275}template".to_string());
         self.ivy_imports
             .insert("\u{0275}\u{0275}advance".to_string());
 
-        // Main template (always present).
+        // Main template (always present) — allocated FIRST.
         let main_slot = self.slot_index;
         self.slot_index += 1;
         let main_fn = format!(
@@ -1931,6 +1931,12 @@ impl IvyCodegen {
             let child = self.generate_child_template(&fn_name, children);
             (slot, fn_name, child)
         });
+
+        // LContainer slot allocated AFTER all sub-block templates so the
+        // runtime's first-create pass has populated each template TNode's
+        // `tView` before `triggerResourceLoading` dereferences it.
+        let defer_slot = self.slot_index;
+        self.slot_index += 1;
 
         // Build the dependency resolver function. Emitted as a module-scope
         // helper so the bundler's import scanner can pick up any `import()`
@@ -4521,7 +4527,12 @@ mod tests {
                 .contains("\u{0275}\u{0275}deferOnViewport"),
             "deferOnViewport should be imported"
         );
-        assert!(dc.contains("\u{0275}\u{0275}defer(0, "), "defer call: {dc}");
+        // defer LContainer at slot 1 (allocated after the primary template
+        // at slot 0), primary index 0 in the second position.
+        assert!(
+            dc.contains("\u{0275}\u{0275}defer(1, 0, "),
+            "defer call: {dc}"
+        );
         assert!(
             dc.contains("\u{0275}\u{0275}deferOnViewport();"),
             "deferOnViewport call: {dc}"
@@ -4602,10 +4613,11 @@ mod tests {
         assert!(child_source.contains("TestComponent_DeferLoading_"));
         assert!(child_source.contains("TestComponent_DeferError_"));
         assert!(child_source.contains("DepsFn"));
-        // defer passes all three sub-block slot indices as trailing args.
+        // Slot layout: primary=0, placeholder=1, loading=2, error=3,
+        // defer LContainer=4 (allocated last).
         assert!(
-            dc.contains("\u{0275}\u{0275}defer(0, "),
-            "defer block at slot 0: {dc}"
+            dc.contains("\u{0275}\u{0275}defer(4, 0, "),
+            "defer LContainer at slot 4 with primary index 0: {dc}"
         );
     }
 
@@ -4677,10 +4689,12 @@ mod tests {
         // causing the runtime to misread the deps fn as a TView descriptor.
         let output = compile_template("@defer (on immediate) { <my-c /> }");
         let dc = &output.static_fields[0];
-        // defer block at slot 0; main (primary) template at slot 1.
+        // primary template at slot 0, defer LContainer at slot 1
+        // (allocated last so the parent's first-create pass populates the
+        // primary's tView before the runtime dereferences it).
         assert!(
-            dc.contains("\u{0275}\u{0275}defer(0, 1, "),
-            "ɵɵdefer should emit (slot, primaryIdx, depsFn, …): {dc}"
+            dc.contains("\u{0275}\u{0275}defer(1, 0, "),
+            "ɵɵdefer should emit (deferSlot, primaryIdx, depsFn, …): {dc}"
         );
         assert!(
             dc.contains("\u{0275}\u{0275}deferOnImmediate();"),
@@ -4695,7 +4709,7 @@ mod tests {
         let output = compile_template("@defer (on immediate) { <my-c /> }");
         let dc = &output.static_fields[0];
         assert!(
-            dc.contains("\u{0275}\u{0275}defer(0, 1, TestComponent_Defer_1_DepsFn);"),
+            dc.contains("\u{0275}\u{0275}defer(1, 0, TestComponent_Defer_1_DepsFn);"),
             "no sub-blocks → no trailing nulls: {dc}"
         );
     }
@@ -4706,11 +4720,12 @@ mod tests {
             "@defer (on idle) { <my-c /> } @placeholder { <p>wait</p> } @loading { <p>load</p> } @error { <p>err</p> }",
         );
         let dc = &output.static_fields[0];
-        // Slot layout: defer=0, primary=1, placeholder=2, loading=3, error=4.
-        // Args after the deps fn are loading, placeholder, error.
+        // Slot layout: primary=0, placeholder=1, loading=2, error=3,
+        // defer LContainer=4. Args after deps fn are loading, placeholder,
+        // error.
         assert!(
-            dc.contains("\u{0275}\u{0275}defer(0, 1, TestComponent_Defer_4_DepsFn, 3, 2, 4);"),
-            "expected (slot, primary, deps, loading, placeholder, error): {dc}"
+            dc.contains("\u{0275}\u{0275}defer(4, 0, TestComponent_Defer_4_DepsFn, 2, 1, 3);"),
+            "expected (deferSlot, primary, deps, loading, placeholder, error): {dc}"
         );
     }
 
@@ -4791,7 +4806,7 @@ mod tests {
         let output = compile_template("@defer (when isReady) { <my-c /> }");
         let dc = &output.static_fields[0];
         assert!(
-            dc.contains("\u{0275}\u{0275}defer(0, 1, "),
+            dc.contains("\u{0275}\u{0275}defer(1, 0, "),
             "defer call carries primary-index even with `when`: {dc}"
         );
         assert!(

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -3594,14 +3594,15 @@ fn compile_event_handler(handler: &str, locals: &BTreeSet<String>) -> String {
 /// Real-world components are wired by the bundler's import-scanner picking
 /// up these `import(...)` calls as split points; resolving each call to a
 /// Returned array contents:
-/// - When the host component has any `imports: [...]` identifiers, return
-///   them directly. Angular's runtime accepts synchronous `Type` values in
-///   `DependencyResolverFn`'s array (the type is `Array<Promise<T> | T>`),
-///   resolves the deferred template's tags via selector match, and skips
-///   the network round-trip. This matches ngc-rs's bundling reality —
-///   imported components are co-bundled into the host chunk, not split
-///   into per-tag modules — so a synthetic `import('./<tag>')` would 404
-///   at runtime (NG0750).
+/// - When the host component has any `imports: [...]` identifiers, wrap
+///   each in `Promise.resolve(...)`. Angular's runtime models the deps
+///   resolver as `Array<Promise<DependencyType>>` and feeds the resolved
+///   values through `Promise.all`; passing a bare class confuses the
+///   downstream "extract default export" step and the deferred view
+///   ends up without a populated `directiveRegistry`. ngc-rs co-bundles
+///   imported components into the host chunk, so there is no separate
+///   chunk to dynamically `import()` — `Promise.resolve` keeps the
+///   shape Angular expects without a network round-trip.
 /// - Otherwise, fall back to the no-op `[]` so the runtime can still mark
 ///   the block as resolved without crashing.
 fn build_defer_deps_fn(
@@ -3621,7 +3622,7 @@ fn build_defer_deps_fn(
     } else {
         code.push('\n');
         for (i, ident) in component_imports.iter().enumerate() {
-            code.push_str(&format!("    {ident}"));
+            code.push_str(&format!("    Promise.resolve({ident})"));
             if i + 1 < component_imports.len() {
                 code.push(',');
             }
@@ -4630,8 +4631,8 @@ mod tests {
             .find(|f| f.contains("DepsFn"))
             .expect("dep fn should be emitted");
         assert!(
-            deps_fn.contains("HeavyComponent"),
-            "dep fn should reference imported class directly: {deps_fn}"
+            deps_fn.contains("Promise.resolve(HeavyComponent)"),
+            "dep fn should wrap imported class in Promise.resolve so the runtime's directiveRegistry pipeline sees a Promise<Type>: {deps_fn}"
         );
         assert!(
             !deps_fn.contains("import("),


### PR DESCRIPTION
## Summary

Fixes #90. Five interlocking codegen defects in the `@defer` lowering caused runtime crashes on every defer block. End-to-end verified against `test/test-ng-project/defer` in a real browser — page renders, on-idle / on-immediate / on-interaction triggers all fire and load `<app-heavy>` correctly.

The defects, in the order they surfaced:

1. **Missing primary template index.** `ɵɵdefer` was being emitted as `(slot, depsFn, …)` instead of Ivy v21's `(slot, primaryTmplIdx, depsFn, …)`. The runtime read the deps fn as a TView descriptor and crashed with `Cannot read properties of undefined (reading 'tView')`.
2. **Empty trigger arguments.** `ɵɵdeferOn{Viewport,Hover,Interaction}` (and prefetch variants) were emitted with no args, so the runtime fed `undefined` into `IntersectionObserver.observe` / `WeakMap.set`.
3. **Fabricated deps fn module paths.** The deps fn emitted `import('./<tag>').then(m => m.<PascalTag>)`, which resolves to `./app-heavy` for `<app-heavy>` — a chunk ngc-rs never produces (the bundler co-bundles `HeavyComponent` into the host chunk). The runtime hit `NG0750`. Now we emit the host component's `imports: [...]` identifiers directly, wrapped in `Promise.resolve(...)` so Angular's deps pipeline shape (`Array<Promise<T>>`) is preserved.
4. **Missing implicit `ɵɵdeferOnIdle()`.** A bare `@defer { … }` parses with no triggers, but Angular's contract is that the default trigger is `on idle`. Without the runtime call, no trigger ever registered and the block stayed in placeholder state forever.
5. **Slot collision after the defer LContainer.** Angular's runtime stores `tDetails` at `tView.data[deferBlockIndex + 1]` via `setTDeferBlockDetails`. So `ɵɵdefer(9, …)` consumes BOTH slot 9 (LContainer) and slot 10 (tDetails). ngc-rs was reusing slot 10 for the next instruction, whose TNode lookup pointed at the tDetails object — its missing `.attrs` made the directive-matcher's `getNameOnlyMarkerIndex(tNode.attrs)` crash with `Cannot read properties of undefined (reading 'length')`.

The fix:

- Insert the main-template slot as the second positional arg to `ɵɵdefer`. Trailing `null` sub-block args are trimmed for byte-equivalence to `ng build`.
- Capture the placeholder block's element-ref slots and emit `ɵɵdeferOnX(elementSlot, -1)`. Track `template_ref_elements` separately from `template_refs` since defer triggers anchor on the element TNode, not the resolved-ref slot consumed by `ɵɵreference`.
- Allocate the LContainer slot LAST (after all sub-block templates) and reserve a shadow slot for the runtime's tDetails.
- Replace the fabricated deps fn body with `[Promise.resolve(<Identifier>), …]` over the host component's `imports: [...]` list.
- Emit `ɵɵdeferOnIdle()` when no explicit trigger is parsed.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] New snapshot tests cover: `on immediate`, `on viewport` with/without placeholder, `on hover(ref)`, `on interaction(ref)`, `prefetch on hover(ref)`, `when` expr, sub-block slot ordering, the primary-index regression, the synchronous deps-fn shape, and the empty-deps fallback.
- [x] Built `ngc-rs build` against `test/test-ng-project`, served via the existing Docker container, and navigated to `/defer` in Chrome — clean console, the on-idle and on-immediate blocks render `<app-heavy>` automatically, clicking the interaction trigger renders another `<app-heavy>` (heavy count: 3 → 4 after click). Emission for `ɵɵdefer` and `ɵɵdeferOn*` matches `ng build`'s shape (modulo whitespace).