### PR TITLE
fix(bundler): rewrite `new Worker(new URL(...))` call site and de-double worker chunk filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "base64",
  "clap",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.37"
+version = "0.7.38"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -534,33 +534,25 @@ fn scc_emit_deps_first(
 
 /// Derive a worker chunk filename from a worker entry's file path.
 ///
-/// Strips a trailing `.worker` segment so `foo.worker.ts` produces
-/// `worker-foo.js` rather than the redundant `worker-foo-worker.js`.
-/// Example: `/root/src/app/compute.worker.ts` → `"worker-compute.js"`
-fn worker_chunk_filename_from_path(path: &Path, root_dir: &Path) -> String {
-    let relative = path.strip_prefix(root_dir).unwrap_or(path);
-    let stem = relative.with_extension("");
-    let stem_str = stem.to_string_lossy();
-
-    let name = stem_str
-        .replace(['/', '\\'], "-")
-        .replace('.', "-")
-        .to_lowercase();
-
-    let mut parts: Vec<&str> = name.split('-').filter(|s| !s.is_empty()).collect();
-    if parts.last().is_some_and(|s| *s == "worker") {
-        parts.pop();
-    }
-    let short_name = if parts.len() > 2 {
-        parts[parts.len() - 2..].join("-")
-    } else {
-        parts.join("-")
+/// Uses just the basename so a parent directory containing the word `worker`
+/// (e.g. `web-worker/`) doesn't get folded into the output name. Strips the
+/// final extension and a trailing `.worker` segment so `hash.worker.ts`
+/// produces `worker-hash.js` rather than `worker-worker-hash.js`.
+fn worker_chunk_filename_from_path(path: &Path, _root_dir: &Path) -> String {
+    let basename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let stem = match basename.rsplit_once('.') {
+        Some((stem, _ext)) => stem,
+        None => basename,
     };
-
-    if short_name.is_empty() {
+    let trimmed = stem.strip_suffix(".worker").unwrap_or(stem);
+    let name = trimmed.replace('.', "-").to_lowercase();
+    if name.is_empty() {
         "worker.js".to_string()
     } else {
-        format!("worker-{short_name}.js")
+        format!("worker-{name}.js")
     }
 }
 
@@ -822,14 +814,30 @@ mod tests {
             worker_chunk_filename_from_path(Path::new("/root/src/compute.worker.ts"), root),
             "worker-compute.js"
         );
+        // The parent dir is dropped — only the basename contributes.
         assert_eq!(
             worker_chunk_filename_from_path(Path::new("/root/src/workers/compute.worker.ts"), root),
-            "worker-workers-compute.js"
+            "worker-compute.js"
         );
         // No trailing .worker segment — no strip.
         assert_eq!(
             worker_chunk_filename_from_path(Path::new("/root/src/foo.ts"), root),
             "worker-foo.js"
+        );
+    }
+
+    /// Regression for issue #93: a parent directory whose name contains
+    /// `worker` (e.g. `web-worker/`) used to get folded into the output
+    /// name, producing `worker-worker-hash.js` for `hash.worker.ts`.
+    #[test]
+    fn test_worker_chunk_filename_does_not_double_worker_prefix() {
+        let root = Path::new("/root/src");
+        assert_eq!(
+            worker_chunk_filename_from_path(
+                Path::new("/root/src/app/features/web-worker/hash.worker.ts"),
+                root,
+            ),
+            "worker-hash.js"
         );
     }
 

--- a/crates/bundler/src/rewrite.rs
+++ b/crates/bundler/src/rewrite.rs
@@ -339,7 +339,8 @@ fn collect_module_decl_edits(
     }
 }
 
-/// Walk a statement recursively to find dynamic `import()` expressions.
+/// Walk a statement recursively to find dynamic `import()` expressions and
+/// `new Worker(new URL(...))` constructions.
 fn collect_dynamic_import_edits(
     stmt: &Statement,
     rewrites: &HashMap<String, String>,
@@ -368,15 +369,23 @@ fn collect_dynamic_import_edits(
                 collect_dynamic_import_edits_from_decl(decl, rewrites, edits, dynamic_imports);
             }
         }
-        Statement::ExportDefaultDeclaration(export) => {
-            if let ExportDefaultDeclarationKind::FunctionDeclaration(f) = &export.declaration {
+        Statement::ExportDefaultDeclaration(export) => match &export.declaration {
+            ExportDefaultDeclarationKind::FunctionDeclaration(f) => {
                 if let Some(body) = &f.body {
                     for s in &body.statements {
                         collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
                     }
                 }
             }
-        }
+            ExportDefaultDeclarationKind::ClassDeclaration(c) => {
+                walk_class_for_dynamic_imports(c, rewrites, edits, dynamic_imports);
+            }
+            other => {
+                if let Some(expr) = other.as_expression() {
+                    walk_expr_for_dynamic_imports(expr, rewrites, edits, dynamic_imports);
+                }
+            }
+        },
         // Top-level `function foo() { ... return import('./x'); }` — e.g. the
         // dependency-resolver helpers emitted by the template-compiler for
         // `@defer` blocks. Without this arm, `import()` calls inside the body
@@ -388,6 +397,81 @@ fn collect_dynamic_import_edits(
                     collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
                 }
             }
+        }
+        // Top-level class declarations: Angular components/services live here.
+        // Their constructors and method bodies hold the `new Worker(new URL(...))`
+        // call sites that need rewriting (issue #93).
+        Statement::ClassDeclaration(class) => {
+            walk_class_for_dynamic_imports(class, rewrites, edits, dynamic_imports);
+        }
+        Statement::BlockStatement(block) => {
+            for s in &block.body {
+                collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+            }
+        }
+        Statement::IfStatement(if_stmt) => {
+            walk_expr_for_dynamic_imports(&if_stmt.test, rewrites, edits, dynamic_imports);
+            collect_dynamic_import_edits(&if_stmt.consequent, rewrites, edits, dynamic_imports);
+            if let Some(alt) = &if_stmt.alternate {
+                collect_dynamic_import_edits(alt, rewrites, edits, dynamic_imports);
+            }
+        }
+        Statement::ForStatement(for_stmt) => {
+            if let Some(test) = &for_stmt.test {
+                walk_expr_for_dynamic_imports(test, rewrites, edits, dynamic_imports);
+            }
+            if let Some(update) = &for_stmt.update {
+                walk_expr_for_dynamic_imports(update, rewrites, edits, dynamic_imports);
+            }
+            collect_dynamic_import_edits(&for_stmt.body, rewrites, edits, dynamic_imports);
+        }
+        Statement::ForInStatement(stmt) => {
+            walk_expr_for_dynamic_imports(&stmt.right, rewrites, edits, dynamic_imports);
+            collect_dynamic_import_edits(&stmt.body, rewrites, edits, dynamic_imports);
+        }
+        Statement::ForOfStatement(stmt) => {
+            walk_expr_for_dynamic_imports(&stmt.right, rewrites, edits, dynamic_imports);
+            collect_dynamic_import_edits(&stmt.body, rewrites, edits, dynamic_imports);
+        }
+        Statement::WhileStatement(stmt) => {
+            walk_expr_for_dynamic_imports(&stmt.test, rewrites, edits, dynamic_imports);
+            collect_dynamic_import_edits(&stmt.body, rewrites, edits, dynamic_imports);
+        }
+        Statement::DoWhileStatement(stmt) => {
+            walk_expr_for_dynamic_imports(&stmt.test, rewrites, edits, dynamic_imports);
+            collect_dynamic_import_edits(&stmt.body, rewrites, edits, dynamic_imports);
+        }
+        Statement::TryStatement(stmt) => {
+            for s in &stmt.block.body {
+                collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+            }
+            if let Some(handler) = &stmt.handler {
+                for s in &handler.body.body {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+            if let Some(finalizer) = &stmt.finalizer {
+                for s in &finalizer.body {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        Statement::SwitchStatement(stmt) => {
+            walk_expr_for_dynamic_imports(&stmt.discriminant, rewrites, edits, dynamic_imports);
+            for case in &stmt.cases {
+                if let Some(test) = &case.test {
+                    walk_expr_for_dynamic_imports(test, rewrites, edits, dynamic_imports);
+                }
+                for s in &case.consequent {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        Statement::ThrowStatement(stmt) => {
+            walk_expr_for_dynamic_imports(&stmt.argument, rewrites, edits, dynamic_imports);
+        }
+        Statement::LabeledStatement(stmt) => {
+            collect_dynamic_import_edits(&stmt.body, rewrites, edits, dynamic_imports);
         }
         _ => {}
     }
@@ -415,7 +499,47 @@ fn collect_dynamic_import_edits_from_decl(
                 }
             }
         }
+        oxc_ast::ast::Declaration::ClassDeclaration(class) => {
+            walk_class_for_dynamic_imports(class, rewrites, edits, dynamic_imports);
+        }
         _ => {}
+    }
+}
+
+/// Walk a class body — constructors, methods, property initializers, and
+/// static blocks — for dynamic imports and worker URL constructions.
+fn walk_class_for_dynamic_imports(
+    class: &oxc_ast::ast::Class,
+    rewrites: &HashMap<String, String>,
+    edits: &mut Vec<TextEdit>,
+    dynamic_imports: &mut Vec<DynamicImportInfo>,
+) {
+    for element in &class.body.body {
+        match element {
+            oxc_ast::ast::ClassElement::MethodDefinition(method) => {
+                if let Some(body) = &method.value.body {
+                    for s in &body.statements {
+                        collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                    }
+                }
+            }
+            oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
+                if let Some(value) = &prop.value {
+                    walk_expr_for_dynamic_imports(value, rewrites, edits, dynamic_imports);
+                }
+            }
+            oxc_ast::ast::ClassElement::AccessorProperty(prop) => {
+                if let Some(value) = &prop.value {
+                    walk_expr_for_dynamic_imports(value, rewrites, edits, dynamic_imports);
+                }
+            }
+            oxc_ast::ast::ClassElement::StaticBlock(block) => {
+                for s in &block.body {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -513,6 +637,16 @@ fn walk_expr_for_dynamic_imports(
                     collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
                 }
             }
+        }
+        Expression::FunctionExpression(func) => {
+            if let Some(body) = &func.body {
+                for s in &body.statements {
+                    collect_dynamic_import_edits(s, rewrites, edits, dynamic_imports);
+                }
+            }
+        }
+        Expression::ClassExpression(class) => {
+            walk_class_for_dynamic_imports(class, rewrites, edits, dynamic_imports);
         }
         // Handle member expressions (StaticMember, ComputedMember, PrivateField)
         _ if expr.as_member_expression().is_some() => {
@@ -883,6 +1017,44 @@ mod tests {
         let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
         assert!(result.code.contains("'./worker-shared.js'"));
         assert!(!result.code.contains("./shared.worker"));
+    }
+
+    #[test]
+    fn test_worker_url_in_class_constructor_rewritten() {
+        // Repro for issue #93: Angular components are classes, and the
+        // `new Worker(new URL(...))` call lives inside the constructor body.
+        // The walker must descend through class declarations and method
+        // bodies for the rewrite to land.
+        let code = "class WebWorkerComponent {\n\
+                    constructor() {\n\
+                      this.worker = new Worker(new URL('./hash.worker', import.meta.url), { type: 'module' });\n\
+                    }\n\
+                  }\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./hash.worker".to_string(), "worker-hash.js".to_string());
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(
+            result.code.contains("'./worker-hash.js'"),
+            "expected the URL specifier to be rewritten in a class constructor; got:\n{}",
+            result.code
+        );
+        assert!(!result.code.contains("./hash.worker"));
+    }
+
+    #[test]
+    fn test_dynamic_import_in_class_method_rewritten() {
+        let code = "class Loader {\n\
+                    load() { return import('./lazy').then(m => m.X); }\n\
+                  }\n";
+        let mut rewrites = HashMap::new();
+        rewrites.insert("./lazy".to_string(), "chunk-lazy.js".to_string());
+        let result = rewrite_module(code, "test.js", &["."], &rewrites).expect("should rewrite");
+        assert!(
+            result.code.contains("'./chunk-lazy.js'"),
+            "expected the import() specifier to be rewritten inside a class method; got:\n{}",
+            result.code
+        );
+        assert!(!result.code.contains("import('./lazy')"));
     }
 
     #[test]

--- a/crates/bundler/tests/worker_integration.rs
+++ b/crates/bundler/tests/worker_integration.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use ngc_bundler::{bundle, BundleInput, BundleOptions};
+use ngc_bundler::{bundle, BundleInput, BundleOptions, BundleOutput};
 use ngc_project_resolver::resolve_project;
 use tempfile::tempdir;
 
@@ -140,4 +140,195 @@ fn worker_new_url_is_bundled_as_separate_chunk_and_rewritten() {
     // The `new Worker(new URL(..., import.meta.url), ...)` shell stays intact.
     assert!(main_code.contains("new Worker(new URL("));
     assert!(main_code.contains("import.meta.url"));
+}
+
+/// Repro for issue #93: the `new Worker(new URL(...))` site is inside a class
+/// constructor (Angular component shape) and the worker file lives in a parent
+/// directory whose name contains `worker`. Both the rewrite and the chunk
+/// filename used to break in that combination.
+#[test]
+fn worker_url_in_class_constructor_under_web_worker_dir_is_rewritten() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    let tsconfig = r#"{
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+
+    let feature_dir = root.join("src/app/features/web-worker");
+    fs::create_dir_all(&feature_dir).expect("create feature dir");
+    fs::write(
+        root.join("src/main.ts"),
+        "import './app/features/web-worker/web-worker.component';\n",
+    )
+    .expect("write main.ts");
+
+    fs::write(
+        feature_dir.join("web-worker.component.ts"),
+        "export class WebWorkerComponent {\n\
+           worker;\n\
+           constructor() {\n\
+             this.worker = new Worker(new URL('./hash.worker', import.meta.url), { type: 'module' });\n\
+           }\n\
+         }\n",
+    )
+    .expect("write component");
+
+    fs::write(
+        feature_dir.join("hash.worker.ts"),
+        "self.onmessage = (e) => self.postMessage(e.data);\n",
+    )
+    .expect("write worker");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in file_graph.graph.node_indices() {
+        let path = &file_graph.graph[idx];
+        let source = fs::read_to_string(path).expect("read project file");
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph: file_graph.graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions::default(),
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: Default::default(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    // Worker chunk filename must be `worker-hash.js`, not `worker-worker-hash.js`.
+    let (worker_filename, worker_code) = output
+        .chunks
+        .iter()
+        .find(|(k, _)| k.starts_with("worker-"))
+        .expect("a worker-*.js chunk should have been emitted");
+    assert_eq!(
+        worker_filename, "worker-hash.js",
+        "expected `worker-hash.js`, got `{worker_filename}` (parent dir bled into the name)",
+    );
+    assert!(worker_code.contains("onmessage"));
+
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+    // The worker URL is inside the component class constructor — the rewriter
+    // must descend into class bodies for this to land.
+    assert!(
+        main_code.contains("'./worker-hash.js'"),
+        "main chunk should reference the worker chunk filename; got:\n{main_code}",
+    );
+    assert!(
+        !main_code.contains("./hash.worker"),
+        "main chunk must no longer reference the source-form worker specifier; got:\n{main_code}",
+    );
+}
+
+/// When content hashing is on, the rewritten URL must point at the same hashed
+/// filename the bundler wrote to disk — otherwise the browser fetches a 404.
+#[test]
+fn worker_url_rewrite_uses_content_hashed_filename() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    let tsconfig = r#"{
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+
+    fs::write(
+        src.join("main.ts"),
+        "class App {\n\
+           start() {\n\
+             return new Worker(new URL('./compute.worker', import.meta.url), { type: 'module' });\n\
+           }\n\
+         }\n\
+         new App().start();\n",
+    )
+    .expect("write main.ts");
+
+    fs::write(
+        src.join("compute.worker.ts"),
+        "self.onmessage = (e) => self.postMessage(e.data * 2);\n",
+    )
+    .expect("write worker");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in file_graph.graph.node_indices() {
+        let path = &file_graph.graph[idx];
+        let source = fs::read_to_string(path).expect("read project file");
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph: file_graph.graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions {
+            content_hash: true,
+            ..BundleOptions::default()
+        },
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: Default::default(),
+        export_conditions: Vec::new(),
+    };
+
+    let output: BundleOutput = bundle(&input).expect("bundle succeeds");
+
+    let worker_filename = output
+        .chunks
+        .keys()
+        .find(|k| k.starts_with("worker-"))
+        .cloned()
+        .expect("worker chunk should exist");
+
+    // Hashed filename has the form `worker-compute.<8-hex>.js`.
+    assert!(
+        worker_filename.starts_with("worker-compute.") && worker_filename.ends_with(".js"),
+        "worker chunk filename `{worker_filename}` should look like `worker-compute.<hash>.js`",
+    );
+
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+    assert!(
+        main_code.contains(&format!("'./{worker_filename}'")),
+        "main chunk should reference the hashed worker filename `{worker_filename}`; got:\n{main_code}",
+    );
+    assert!(
+        !main_code.contains("./compute.worker"),
+        "main chunk must not contain the source-form specifier",
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #93. Two bugs in the web-worker bundling pass added in #66:

- **Filename:** `worker_chunk_filename_from_path` joined the entire relative path with `-` and then took the last two segments, so a worker file under `web-worker/` (whose dir name itself contains `worker`) emitted `worker-worker-hash.js` for `hash.worker.ts`. Switched to using just the basename, stripping the trailing extension and a trailing `.worker` segment, matching the convention in #66 (`worker-<basename>.js`).
- **Rewrite:** the dynamic-import / worker-URL walker only descended into a handful of statement types — variable declarations, returns, exports, top-level functions and arrow bodies. It never entered class bodies. Angular components are classes whose constructor holds the `new Worker(new URL(...))` call site, so the lazy chunk for `web-worker.component` shipped the source-form `'./hash.worker'` specifier, the browser fetched the SPA fallback HTML, and the worker never ran. The walker now also visits class bodies (constructors, methods, property initialisers, static blocks), function expressions, class expressions, and the common control-flow statements (block / if / for / while / do-while / for-in / for-of / try / switch / throw / labeled).

The `new Worker(new URL(...))` shell stays intact — only the inner string literal is rewritten — so source-map columns and the original semantics are preserved.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] New rewriter unit tests: worker URL inside a class constructor, `import()` inside a class method
- [x] New chunk-filename regression test for the doubled-prefix case (`web-worker/hash.worker.ts` → `worker-hash.js`)
- [x] New end-to-end integration tests: class-constructor call site under a `web-worker/` parent dir, and content-hashed filename round-trip
