### PR TITLE
fix(bundler): preserve module-scope const referenced from class field initializer in production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "base64",
  "clap",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.38"
+version = "0.7.39"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -125,6 +125,10 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
 
     // Process main chunk first to get specifier→namespace mapping
     let main_chunk = &chunk_graph.chunks[0];
+    let subpath_ctx = Some(shake::SubpathImportContext {
+        root_dir: &input.root_dir,
+        export_conditions: &condition_refs,
+    });
     let main_unused = if input.options.tree_shake {
         // Lazy chunks consume symbols from main cross-chunk; those consumptions
         // are invisible to the per-chunk shake analysis below. Precompute them
@@ -138,6 +142,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
             &main_chunk.modules,
             &input.modules,
             &prefix_refs,
+            subpath_ctx,
         )?;
 
         shake::analyze_unused_exports(
@@ -146,6 +151,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
             &main_chunk.entry,
             &prefix_refs,
             Some(&externally_used),
+            subpath_ctx,
         )?
     } else {
         HashMap::new()
@@ -191,6 +197,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
                     &chunk.entry,
                     &prefix_refs,
                     None,
+                    subpath_ctx,
                 )?
             } else {
                 HashMap::new()

--- a/crates/bundler/src/shake.rs
+++ b/crates/bundler/src/shake.rs
@@ -17,6 +17,16 @@ use oxc_span::SourceType;
 use rayon::prelude::*;
 use tracing::debug;
 
+/// Context for resolving `#`-prefixed subpath imports against the project's
+/// `package.json` `imports` field. When `None`, `#`-aliased specifiers are
+/// not resolvable and their use-edges are ignored (matching the pre-#92
+/// behavior — used by tests that don't construct a real project).
+#[derive(Clone, Copy)]
+pub struct SubpathImportContext<'a> {
+    pub root_dir: &'a Path,
+    pub export_conditions: &'a [&'a str],
+}
+
 /// Information about a module's exports and imports for tree shaking analysis.
 struct ModuleInfo {
     /// Names exported by this module.
@@ -47,6 +57,7 @@ pub fn analyze_unused_exports(
     entry: &PathBuf,
     local_prefixes: &[&str],
     externally_used: Option<&HashSet<String>>,
+    subpath_ctx: Option<SubpathImportContext<'_>>,
 ) -> NgcResult<HashMap<PathBuf, HashSet<String>>> {
     // Step 1: Parse each module in parallel and collect export/import info.
     // `analyze_module` only reads its inputs, so per-module work is independent.
@@ -74,9 +85,13 @@ pub fn analyze_unused_exports(
     for (importer_path, info) in &module_infos {
         for (specifier, imported_names) in &info.local_imports {
             // Resolve specifier to a module path
-            if let Some(target_path) =
-                resolve_local_specifier(specifier, importer_path, module_paths, local_prefixes)
-            {
+            if let Some(target_path) = resolve_local_specifier(
+                specifier,
+                importer_path,
+                module_paths,
+                local_prefixes,
+                subpath_ctx,
+            ) {
                 debug!(
                     importer = %importer_path.display(),
                     specifier = specifier,
@@ -242,13 +257,32 @@ fn collect_declaration_names(decl: &oxc_ast::ast::Declaration, names: &mut HashS
 /// Try to resolve a local import specifier to a module path.
 ///
 /// This is a best-effort resolution — it checks if the specifier starts with
-/// a local prefix and tries to find a matching module path.
+/// a local prefix and tries to find a matching module path. When `subpath_ctx`
+/// is provided, `#`-prefixed specifiers are also resolved through the
+/// project's `package.json` `imports` field — without this, a class field
+/// initializer reading a value from a `#`-aliased module (issue #92) is not
+/// recognized as a use of the target's export, the declaration gets shaken
+/// out, and the class throws `ReferenceError` at instance construction.
 fn resolve_local_specifier(
     specifier: &str,
     importer: &Path,
     module_paths: &[PathBuf],
     local_prefixes: &[&str],
+    subpath_ctx: Option<SubpathImportContext<'_>>,
 ) -> Option<PathBuf> {
+    if specifier.starts_with('#') {
+        let ctx = subpath_ctx?;
+        let resolved = ngc_npm_resolver::resolve::resolve_subpath_import(
+            specifier,
+            Some(importer),
+            ctx.root_dir,
+            ctx.export_conditions,
+        )
+        .ok()?;
+        let canonical = resolved.canonicalize().unwrap_or(resolved);
+        return module_paths.iter().find(|p| **p == canonical).cloned();
+    }
+
     let is_local = local_prefixes.iter().any(|p| specifier.starts_with(p));
     if !is_local {
         return None;
@@ -322,6 +356,7 @@ pub fn collect_cross_chunk_used_names(
     provider_modules: &[PathBuf],
     all_code: &HashMap<PathBuf, String>,
     local_prefixes: &[&str],
+    subpath_ctx: Option<SubpathImportContext<'_>>,
 ) -> NgcResult<HashSet<String>> {
     let provider_set: HashSet<&PathBuf> = provider_modules.iter().collect();
 
@@ -344,6 +379,7 @@ pub fn collect_cross_chunk_used_names(
                     consumer_path,
                     provider_modules,
                     local_prefixes,
+                    subpath_ctx,
                 ) else {
                     continue;
                 };
@@ -385,12 +421,14 @@ pub fn collect_cross_chunk_used_names(
             all_code,
             &mut provider_exports,
             &mut used,
+            subpath_ctx,
         )?;
     }
 
     Ok(used)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn expand_namespace_imports(
     code: &str,
     consumer_path: &Path,
@@ -399,6 +437,7 @@ fn expand_namespace_imports(
     all_code: &HashMap<PathBuf, String>,
     provider_exports: &mut HashMap<PathBuf, HashSet<String>>,
     used: &mut HashSet<String>,
+    subpath_ctx: Option<SubpathImportContext<'_>>,
 ) -> NgcResult<()> {
     let allocator = Allocator::new();
     let parsed = Parser::new(&allocator, code, SourceType::mjs()).parse();
@@ -421,9 +460,13 @@ fn expand_namespace_imports(
             continue;
         }
         let source = import.source.value.to_string();
-        let Some(target) =
-            resolve_local_specifier(&source, consumer_path, provider_modules, local_prefixes)
-        else {
+        let Some(target) = resolve_local_specifier(
+            &source,
+            consumer_path,
+            provider_modules,
+            local_prefixes,
+            subpath_ctx,
+        ) else {
             continue;
         };
         let exports = match provider_exports.get(&target) {
@@ -471,6 +514,7 @@ mod tests {
             &PathBuf::from("/root/main.js"),
             &["."],
             None,
+            None,
         )
         .expect("should analyze");
 
@@ -501,6 +545,7 @@ mod tests {
             &modules,
             &PathBuf::from("/root/main.ts"),
             &["."],
+            None,
             None,
         )
         .expect("should analyze");
@@ -533,6 +578,7 @@ mod tests {
             &modules,
             &PathBuf::from("/root/main.ts"),
             &["."],
+            None,
             None,
         )
         .expect("should analyze");
@@ -572,6 +618,7 @@ mod tests {
             &PathBuf::from("/root/main.js"),
             &["."],
             Some(&externally_used),
+            None,
         )
         .expect("should analyze");
 
@@ -612,8 +659,9 @@ mod tests {
                 .into(),
         );
 
-        let used = collect_cross_chunk_used_names(&[canon_comp], &[canon_svc], &modules, &["."])
-            .expect("should collect");
+        let used =
+            collect_cross_chunk_used_names(&[canon_comp], &[canon_svc], &modules, &["."], None)
+                .expect("should collect");
         assert!(
             used.contains("AnalyticsService"),
             "import of ./foo.service must resolve to foo.service.ts"
@@ -650,8 +698,9 @@ mod tests {
             "import { AnalyticsService } from '../svc';\nnew AnalyticsService();\n".into(),
         );
 
-        let used = collect_cross_chunk_used_names(&[canon_comp], &[canon_svc], &modules, &["."])
-            .expect("should collect");
+        let used =
+            collect_cross_chunk_used_names(&[canon_comp], &[canon_svc], &modules, &["."], None)
+                .expect("should collect");
         assert!(used.contains("AnalyticsService"));
     }
 }

--- a/crates/bundler/tests/subpath_imports_integration.rs
+++ b/crates/bundler/tests/subpath_imports_integration.rs
@@ -301,3 +301,248 @@ fn subpath_import_in_lazy_chunk_does_not_leak_to_main_import() {
         "lazy chunk must not pull APP_ENV from ./main.js: {lazy_code}"
     );
 }
+
+/// Regression for issue #92: a `#`-aliased const referenced from a class field
+/// initializer must survive tree-shaking. Before the fix, shake's
+/// `resolve_local_specifier` returned `None` for `#`-prefixed specifiers, so
+/// the consumer's import edge was never recorded as a use of the target's
+/// export. The const declaration was then dropped by the rewriter, and the
+/// runtime threw `ReferenceError: APP_ENV is not defined` from the class
+/// field initializer.
+#[test]
+fn subpath_import_const_referenced_from_class_field_survives_tree_shake() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.ts"], "exclude": [] }"#,
+    )
+    .expect("write tsconfig");
+
+    fs::write(
+        root.join("package.json"),
+        r##"{
+          "name": "class-field-fixture",
+          "imports": { "#env/*": "./src/env/*.js" }
+        }"##,
+    )
+    .expect("write package.json");
+
+    let src = root.join("src");
+    fs::create_dir_all(src.join("env")).expect("create src/env");
+
+    fs::write(
+        src.join("main.ts"),
+        "import { Comp } from './comp';\nnew Comp();\n",
+    )
+    .expect("write main.ts");
+
+    // The shape from the issue: a class field initializer reads an imported
+    // const. The import target is a `#`-aliased file under the project's
+    // `imports` map.
+    fs::write(
+        src.join("comp.ts"),
+        "import { APP_ENV } from '#env/config';\n\
+         export class Comp {\n  \
+           env = APP_ENV;\n\
+         }\n",
+    )
+    .expect("write comp.ts");
+
+    fs::write(
+        src.join("env/config.js"),
+        "export const APP_ENV = { name: 'env-fixture' };\n",
+    )
+    .expect("write config.js");
+
+    fs::create_dir_all(root.join("node_modules")).expect("create node_modules");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let bare_specs: Vec<String> = file_graph.npm_import_sites.keys().cloned().collect();
+    let npm = resolve_npm_dependencies(&bare_specs, root, DEVELOPMENT_BROWSER_CONDITIONS)
+        .expect("npm resolution");
+
+    let mut graph = file_graph.graph;
+    let mut path_index = file_graph.path_index;
+    for path in npm.modules.keys() {
+        if !path_index.contains_key(path) {
+            let idx = graph.add_node(path.clone());
+            path_index.insert(path.clone(), idx);
+        }
+    }
+
+    let config_path = npm
+        .modules
+        .keys()
+        .find(|p| p.ends_with("src/env/config.js"))
+        .cloned()
+        .expect("config.js should be in npm resolution");
+    for (spec, sites) in &file_graph.npm_import_sites {
+        if spec == "#env/config" {
+            let to_idx = path_index[&config_path];
+            for (from_file, kind) in sites {
+                if let Some(&from_idx) = path_index.get(from_file) {
+                    graph.add_edge(from_idx, to_idx, *kind);
+                }
+            }
+        }
+    }
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in graph.node_indices() {
+        let path = &graph[idx];
+        let source = npm
+            .modules
+            .get(path)
+            .cloned()
+            .or_else(|| fs::read_to_string(path).ok())
+            .unwrap_or_else(|| panic!("source missing for {}", path.display()));
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions {
+            tree_shake: true,
+            ..BundleOptions::default()
+        },
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: npm.resolved_specifiers.clone(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+
+    // The const declaration must survive — that's the bug under repair.
+    assert!(
+        main_code.contains("APP_ENV"),
+        "main chunk should retain the APP_ENV const declaration after tree-shaking; got:\n{main_code}"
+    );
+    assert!(
+        main_code.contains("name: 'env-fixture'") || main_code.contains("name:'env-fixture'"),
+        "main chunk should retain the APP_ENV literal value: {main_code}"
+    );
+}
+
+/// Same shape as the `#`-aliased test above but using a plain relative
+/// specifier — locks in that the same code path keeps working for
+/// non-aliased imports (the existing common case).
+#[test]
+fn relative_import_const_referenced_from_class_field_survives_tree_shake() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.ts"], "exclude": [] }"#,
+    )
+    .expect("write tsconfig");
+
+    fs::write(
+        root.join("package.json"),
+        r##"{ "name": "relative-class-field-fixture" }"##,
+    )
+    .expect("write package.json");
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+
+    fs::write(
+        src.join("main.ts"),
+        "import { Comp } from './comp';\nnew Comp();\n",
+    )
+    .expect("write main.ts");
+
+    fs::write(
+        src.join("config.ts"),
+        "export const APP_ENV = { name: 'relative-fixture' };\n",
+    )
+    .expect("write config.ts");
+
+    fs::write(
+        src.join("comp.ts"),
+        "import { APP_ENV } from './config';\n\
+         export class Comp {\n  \
+           env = APP_ENV;\n\
+         }\n",
+    )
+    .expect("write comp.ts");
+
+    fs::create_dir_all(root.join("node_modules")).expect("create node_modules");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let bare_specs: Vec<String> = file_graph.npm_import_sites.keys().cloned().collect();
+    let npm = resolve_npm_dependencies(&bare_specs, root, DEVELOPMENT_BROWSER_CONDITIONS)
+        .expect("npm resolution");
+
+    let graph = file_graph.graph;
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in graph.node_indices() {
+        let path = &graph[idx];
+        let source = npm
+            .modules
+            .get(path)
+            .cloned()
+            .or_else(|| fs::read_to_string(path).ok())
+            .unwrap_or_else(|| panic!("source missing for {}", path.display()));
+        modules.insert(path.clone(), source);
+    }
+
+    let input = BundleInput {
+        modules,
+        graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions {
+            tree_shake: true,
+            ..BundleOptions::default()
+        },
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: npm.resolved_specifiers.clone(),
+        export_conditions: Vec::new(),
+    };
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    let main_code = output
+        .chunks
+        .get(&output.main_filename)
+        .expect("main chunk present");
+
+    assert!(
+        main_code.contains("APP_ENV"),
+        "main chunk should retain the APP_ENV const declaration after tree-shaking; got:\n{main_code}"
+    );
+    assert!(
+        main_code.contains("name: 'relative-fixture'")
+            || main_code.contains("name:'relative-fixture'"),
+        "main chunk should retain APP_ENV's literal: {main_code}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #92. In `--configuration production` builds, a class field initializer reading a `#`-aliased const threw `ReferenceError` at instance construction because the const declaration was tree-shaken away.

Root cause: `crates/bundler/src/shake.rs::resolve_local_specifier` only resolved relative (`./…`) specifiers. For `#`-prefixed subpath imports (resolved via the project's `package.json` `imports` field, e.g. `import { APP_ENV } from '#env/config'`), the resolver returned `None`, so the import edge was never recorded as a use of the target's export. `analyze_unused_exports` then flagged `APP_ENV` unused and the rewriter dropped `export const APP_ENV = …` entirely. The class still referenced `APP_ENV` from its field initializer → `ReferenceError`.

The fix routes `#`-prefixed specifiers through `ngc_npm_resolver::resolve::resolve_subpath_import` (the same resolver `concat.rs` already uses for lazy-chunk classification). A new `SubpathImportContext` carries `root_dir` + `export_conditions` into shake's analyzer; the bundler wires it through to both `analyze_unused_exports` and `collect_cross_chunk_used_names`.

## Test plan

- [x] Regression: `subpath_import_const_referenced_from_class_field_survives_tree_shake` — bundles a `#env/config` -> `APP_ENV` chain with `tree_shake: true` and a `class Comp { env = APP_ENV; }` consumer; asserts the const literal survives in the main chunk.
- [x] Companion: `relative_import_const_referenced_from_class_field_survives_tree_shake` — same shape with a plain `./config` specifier, locking in that the non-aliased path keeps working.
- [x] `cargo test --workspace` (existing 600+ tests still pass; the previously-failing new test now passes).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`