### PR TITLE
fix(template-compiler): emit indexed runtime placeholder for ICU switch in i18n messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "base64",
  "clap",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.39"
+version = "0.7.40"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -4951,13 +4951,30 @@ mod tests {
             "<span i18n>{ count, plural, =0 {none} =1 {one} other {many} }</span>",
         );
         let dc = &output.static_fields[0];
+        // The runtime ICU parser (ICU_BLOCK_REGEXP in @angular/core) matches
+        // the switch position against `\uFFFD<idx>\uFFFD`, so the binding
+        // must round-trip through $localize as that marker; VAR_PLURAL is
+        // the translator-facing placeholder name carried as a `:NAME:` block
+        // label that $localize strips at runtime.
         assert!(
-            dc.contains("{count, plural, "),
-            "ICU body should be inlined into the localize message: {dc}"
+            dc.contains("{${\"\\u{FFFD}0\\u{FFFD}\"}:VAR_PLURAL:, plural, "),
+            "ICU switch must emit indexed runtime placeholder with VAR_PLURAL block label: {dc}"
         );
         assert!(
             dc.contains("=0 {none}") && dc.contains("other {many}"),
             "ICU case bodies should be preserved: {dc}"
+        );
+        assert!(
+            output.ivy_imports.contains("\u{0275}\u{0275}i18nExp"),
+            "ɵɵi18nExp should be imported: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nExp(ctx.count);"),
+            "update block should emit ɵɵi18nExp(ctx.count): {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nApply(1);"),
+            "update block should emit ɵɵi18nApply(slot): {dc}"
         );
     }
 

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -4979,6 +4979,42 @@ mod tests {
     }
 
     #[test]
+    fn test_icu_select_inside_i18n_uses_var_select_placeholder() {
+        let output = compile_template(
+            "<span i18n>{ gender, select, male {he} female {she} other {they} }</span>",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("{${\"\\u{FFFD}0\\u{FFFD}\"}:VAR_SELECT:, select, "),
+            "ICU switch must emit indexed runtime placeholder with VAR_SELECT block label: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nExp(ctx.gender);"),
+            "update block should emit ɵɵi18nExp(ctx.gender): {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nApply(1);"),
+            "update block should emit ɵɵi18nApply(slot): {dc}"
+        );
+    }
+
+    #[test]
+    fn test_icu_selectordinal_inside_i18n_uses_var_selectordinal_placeholder() {
+        let output = compile_template(
+            "<span i18n>{ rank, selectordinal, =1 {1st} =2 {2nd} other {#th} }</span>",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("{${\"\\u{FFFD}0\\u{FFFD}\"}:VAR_SELECTORDINAL:, selectordinal, "),
+            "ICU switch must emit indexed runtime placeholder with VAR_SELECTORDINAL block label: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nExp(ctx.rank);"),
+            "update block should emit ɵɵi18nExp(ctx.rank): {dc}"
+        );
+    }
+
+    #[test]
     fn test_scope_component_styles_single_element_array() {
         let scoped = scope_component_styles("[`.a { color: red; }`]");
         assert_eq!(scoped, "[`.a[_ngcontent-%COMP%]{ color: red; }`]");

--- a/crates/template-compiler/src/i18n.rs
+++ b/crates/template-compiler/src/i18n.rs
@@ -146,17 +146,32 @@ fn walk_children(children: &[TemplateNode], body: &mut String, interpolations: &
                 ));
             }
             TemplateNode::IcuExpression(icu) => {
-                // Inline the raw ICU message — Angular's translator pipeline
-                // understands the `{expr, plural, ...}` shape verbatim inside
-                // a `$localize` literal.
+                // Angular's runtime ICU parser (`ICU_BLOCK_REGEXP` in
+                // `@angular/core`'s `i18n_parse`) matches the switch position
+                // against `\uFFFD<idx>:?\d*\uFFFD` — the same indexed
+                // placeholder marker used for regular interpolations. The
+                // translator-facing placeholder name (`VAR_PLURAL`,
+                // `VAR_SELECT`, `VAR_SELECTORDINAL`) is carried as the
+                // `${...}:NAME:` block label, which `$localize` strips when
+                // building the runtime message. Pushing the user-authored
+                // switch expression into `interpolations` makes the caller
+                // emit the matching `ɵɵi18nExp(ctx.<expr>)` in the update
+                // block.
+                let idx = interpolations.len();
+                interpolations.push(icu.switch_expression.clone());
+                let (placeholder_name, category_kw) = match icu.category {
+                    crate::ast::IcuCategory::Plural => ("VAR_PLURAL", "plural"),
+                    crate::ast::IcuCategory::Select => ("VAR_SELECT", "select"),
+                    crate::ast::IcuCategory::SelectOrdinal => {
+                        ("VAR_SELECTORDINAL", "selectordinal")
+                    }
+                };
                 body.push('{');
-                append_template_text(body, &icu.switch_expression);
+                body.push_str(&format!(
+                    "${{\"\\u{{FFFD}}{idx}\\u{{FFFD}}\"}}:{placeholder_name}:"
+                ));
                 body.push_str(", ");
-                body.push_str(match icu.category {
-                    crate::ast::IcuCategory::Plural => "plural",
-                    crate::ast::IcuCategory::Select => "select",
-                    crate::ast::IcuCategory::SelectOrdinal => "selectordinal",
-                });
+                body.push_str(category_kw);
                 body.push_str(", ");
                 for case in &icu.cases {
                     append_template_text(body, &case.key);


### PR DESCRIPTION
## Summary

- Fix `Unable to parse ICU expression` runtime crash on any `i18n` block containing an ICU `plural` / `select` / `selectordinal` expression.
- The compiler was emitting the user-authored switch expression verbatim into the `$localize` body (`{count, plural, ...}`); Angular's runtime ICU parser (`ICU_BLOCK_REGEXP` in `@angular/core`'s `i18n_parse`) requires an indexed `\uFFFD<idx>\uFFFD` placeholder marker in the switch position, with the actual binding fed in separately via `ɵɵi18nExp`.
- The ICU switch is now emitted as `${"\uFFFD<idx>\uFFFD"}:VAR_PLURAL:` (or `:VAR_SELECT:` / `:VAR_SELECTORDINAL:`) inside the message body. After `$localize` strips the `:NAME:` block label at runtime, the message becomes `{\uFFFD<idx>\uFFFD, plural, ...}` — matches the regex. The user-authored expression is pushed into the message's `interpolations` so the existing `generate_i18n_element` codegen path emits the matching `ɵɵi18nExp(ctx.<expr>)` in the update block. `VAR_PLURAL` / `VAR_SELECT` / `VAR_SELECTORDINAL` is preserved as the translator-facing placeholder name for extraction.

Closes #99.

## Verification

- Browser-verified against `test-ng-project` running in Docker on :8080 with the new release binary: the crash is gone, `app-i18n` renders, and the `=0` / `=1` / `other` plural cases switch correctly as the bound count changes.
- `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` passes.
- A separate, narrower bug — `#` in plural case bodies and nested `{{...}}` interpolations inside case bodies inline as raw text instead of placeholders — is filed as #100. That's cosmetic (no crash) and outside #99's scope.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Existing `test_icu_plural_inside_i18n_is_inlined` flipped to assert the new shape (indexed placeholder + `ɵɵi18nExp(ctx.count)` + `ɵɵi18nApply(slot)`).
- [x] New `test_icu_select_inside_i18n_uses_var_select_placeholder`.
- [x] New `test_icu_selectordinal_inside_i18n_uses_var_selectordinal_placeholder`.
- [x] Browser smoke test: navigate to `/i18n` on the test bed — page renders, no `Unable to parse ICU expression` console error, plural switching works.
