### PR TITLE
fix(template-compiler): substitute `#` and `{{...}}` inside ICU plural case bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "base64",
  "clap",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.40"
+version = "0.7.41"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -5015,6 +5015,72 @@ mod tests {
     }
 
     #[test]
+    fn test_icu_plural_case_body_hash_emits_switch_placeholder() {
+        // `#` inside a `plural` case body references the switch binding —
+        // it should round-trip through `$localize` as the same indexed
+        // marker the switch position uses, so the runtime substitutes the
+        // count value where `#` appears. Reusing the switch's interpolation
+        // index also means no extra `ɵɵi18nExp` call: the existing one for
+        // the switch already feeds the case-body substitution.
+        let output = compile_template(
+            "<span i18n>{ count, plural, =0 {none} =1 {one} other {# items} }</span>",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("other {${\"\\u{FFFD}0\\u{FFFD}\"}:INTERPOLATION: items}"),
+            "`#` in plural case body should emit \\uFFFD0\\uFFFD INTERPOLATION marker: {dc}"
+        );
+        assert_eq!(
+            dc.matches("\u{0275}\u{0275}i18nExp(ctx.count);").count(),
+            1,
+            "should emit exactly one ɵɵi18nExp(ctx.count) — the switch's call covers the `#` substitution: {dc}"
+        );
+    }
+
+    #[test]
+    fn test_icu_plural_case_body_interpolation_emits_new_placeholder() {
+        // `{{name}}` inside a plural case body is its own binding — it must
+        // allocate a fresh interpolation index and emit a matching
+        // `ɵɵi18nExp(ctx.name)` in the update block alongside the switch's
+        // call.
+        let output = compile_template(
+            "<span i18n>{ count, plural, =0 {none} other {{{name}} items} }</span>",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("other {${\"\\u{FFFD}1\\u{FFFD}\"}:INTERPOLATION: items}"),
+            "`{{{{name}}}}` in case body should emit a new \\uFFFD1\\uFFFD INTERPOLATION marker: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nExp(ctx.count);"),
+            "switch's ɵɵi18nExp(ctx.count) should still be present: {dc}"
+        );
+        assert!(
+            dc.contains("\u{0275}\u{0275}i18nExp(ctx.name);"),
+            "nested interpolation should add ɵɵi18nExp(ctx.name): {dc}"
+        );
+    }
+
+    #[test]
+    fn test_icu_select_case_body_hash_stays_literal() {
+        // `select` cases do not interpret `#` — it must reach the runtime as
+        // literal text, not a placeholder. Regression guard for the
+        // category check inside `compile_message`'s ICU arm.
+        let output = compile_template(
+            "<span i18n>{ gender, select, male {he #1} female {she} other {they} }</span>",
+        );
+        let dc = &output.static_fields[0];
+        assert!(
+            dc.contains("male {he #1}"),
+            "`#` inside a `select` case body must remain literal: {dc}"
+        );
+        assert!(
+            !dc.contains("male {he ${\"\\u{FFFD}0\\u{FFFD}\"}:INTERPOLATION:"),
+            "`select` case body must not emit a `#` substitution placeholder: {dc}"
+        );
+    }
+
+    #[test]
     fn test_scope_component_styles_single_element_array() {
         let scoped = scope_component_styles("[`.a { color: red; }`]");
         assert_eq!(scoped, "[`.a[_ngcontent-%COMP%]{ color: red; }`]");

--- a/crates/template-compiler/src/i18n.rs
+++ b/crates/template-compiler/src/i18n.rs
@@ -157,7 +157,7 @@ fn walk_children(children: &[TemplateNode], body: &mut String, interpolations: &
                 // switch expression into `interpolations` makes the caller
                 // emit the matching `ɵɵi18nExp(ctx.<expr>)` in the update
                 // block.
-                let idx = interpolations.len();
+                let switch_idx = interpolations.len();
                 interpolations.push(icu.switch_expression.clone());
                 let (placeholder_name, category_kw) = match icu.category {
                     crate::ast::IcuCategory::Plural => ("VAR_PLURAL", "plural"),
@@ -166,9 +166,16 @@ fn walk_children(children: &[TemplateNode], body: &mut String, interpolations: &
                         ("VAR_SELECTORDINAL", "selectordinal")
                     }
                 };
+                // `#` is the canonical reference to the switch binding inside
+                // a `plural` / `selectordinal` case body — `select` leaves it
+                // as literal text.
+                let substitute_hash = matches!(
+                    icu.category,
+                    crate::ast::IcuCategory::Plural | crate::ast::IcuCategory::SelectOrdinal
+                );
                 body.push('{');
                 body.push_str(&format!(
-                    "${{\"\\u{{FFFD}}{idx}\\u{{FFFD}}\"}}:{placeholder_name}:"
+                    "${{\"\\u{{FFFD}}{switch_idx}\\u{{FFFD}}\"}}:{placeholder_name}:"
                 ));
                 body.push_str(", ");
                 body.push_str(category_kw);
@@ -176,7 +183,13 @@ fn walk_children(children: &[TemplateNode], body: &mut String, interpolations: &
                 for case in &icu.cases {
                     append_template_text(body, &case.key);
                     body.push_str(" {");
-                    append_template_text(body, &case.body);
+                    append_icu_case_body(
+                        body,
+                        interpolations,
+                        &case.body,
+                        switch_idx,
+                        substitute_hash,
+                    );
                     body.push_str("} ");
                 }
                 body.push('}');
@@ -187,6 +200,50 @@ fn walk_children(children: &[TemplateNode], body: &mut String, interpolations: &
                 // /`@for` children into their own sub-messages.
             }
         }
+    }
+}
+
+/// Walk an ICU case body, expanding `{{expr}}` interpolations and (for
+/// `plural` / `selectordinal`) the `#` token into runtime placeholders.
+///
+/// Each `{{expr}}` becomes a fresh `${"\u{FFFD}<idx>\u{FFFD}"}:INTERPOLATION:`
+/// marker and pushes its expression into `interpolations`. `#` reuses the
+/// switch expression's placeholder index so the existing `ɵɵi18nExp` for the
+/// switch also feeds the case-body substitution — Angular's runtime ICU
+/// model treats the case body and the switch as a single binding.
+fn append_icu_case_body(
+    body: &mut String,
+    interpolations: &mut Vec<String>,
+    case_body: &str,
+    switch_idx: usize,
+    substitute_hash: bool,
+) {
+    let mut rest = case_body;
+    while !rest.is_empty() {
+        if let Some(after_open) = rest.strip_prefix("{{") {
+            if let Some(end) = after_open.find("}}") {
+                let expr = after_open[..end].trim();
+                let new_idx = interpolations.len();
+                interpolations.push(expr.to_string());
+                body.push_str(&format!(
+                    "${{\"\\u{{FFFD}}{new_idx}\\u{{FFFD}}\"}}:INTERPOLATION:"
+                ));
+                rest = &after_open[end + 2..];
+                continue;
+            }
+        }
+        if substitute_hash {
+            if let Some(after_hash) = rest.strip_prefix('#') {
+                body.push_str(&format!(
+                    "${{\"\\u{{FFFD}}{switch_idx}\\u{{FFFD}}\"}}:INTERPOLATION:"
+                ));
+                rest = after_hash;
+                continue;
+            }
+        }
+        let ch = rest.chars().next().unwrap();
+        escape_template_char(ch, body);
+        rest = &rest[ch.len_utf8()..];
     }
 }
 


### PR DESCRIPTION
Closes #100.

## Summary

Walks `plural` / `selectordinal` case bodies in `compile_message`'s `IcuExpression` arm and rewrites the two placeholder forms Angular's runtime expects:

- `#` is replaced with `${"\uFFFD<switch_idx>\uFFFD"}:INTERPOLATION:`, reusing the index already pushed for the switch expression. The `ɵɵi18nExp(ctx.<switch_expr>)` the existing arm emits also feeds the case-body substitution — no duplicate update-block call.
- `{{expr}}` runs allocate a fresh interpolation index, push the trimmed expression, and emit the same `${"\uFFFD<idx>\uFFFD"}:INTERPOLATION:` shape the rest of `walk_children` already uses for plain text interpolations.

`select` cases skip the `#` substitution — `#` is only meaningful for plural / selectordinal, so it stays literal.

## Tests

- `test_icu_plural_case_body_hash_emits_switch_placeholder`: `# items` → `\uFFFD0\uFFFD` INTERPOLATION marker, exactly one `ɵɵi18nExp(ctx.count)`.
- `test_icu_plural_case_body_interpolation_emits_new_placeholder`: `{{name}} items` → fresh `\uFFFD1\uFFFD` marker plus a matching `ɵɵi18nExp(ctx.name)`.
- `test_icu_select_case_body_hash_stays_literal`: `select` regression guard — `#` stays as text.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Browser verification on `test-ng-project` `/i18n` route: cart count renders `3 items` instead of `# items`.