### PR TITLE
feat: build-time define substitution + DCE of ngDevMode branches (closes #86)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "base64",
  "clap",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,8 @@ version = "0.7.42"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
  "oxc_codegen",
  "oxc_parser",
  "oxc_semantic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker"]
 
 [workspace.package]
-version = "0.7.41"
+version = "0.7.42"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -43,12 +43,6 @@ pub struct BundleOptions {
     pub content_hash: bool,
     /// Perform tree shaking (unused export elimination).
     pub tree_shake: bool,
-    /// Inject Angular's build-time global flags (`ngDevMode`,
-    /// `ngI18nClosureMode`, `ngJitMode`) as `globalThis` assignments at the
-    /// top of `main.js`. Required so `@angular/core`'s `isDevMode()` returns
-    /// `false` in production bundles. (Does **not** dead-code-eliminate
-    /// dev-only branches — that's a separate define-substitution pass.)
-    pub inject_dev_mode_globals: bool,
 }
 
 /// Input to the bundler.
@@ -297,20 +291,6 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         }
     }
 
-    // Prepend Angular's build-time global flags to main.js so `isDevMode()`
-    // returns `false` at runtime. Done after minification so the minifier
-    // can't accidentally drop or rewrite the assignments; done before
-    // content-hashing so the hash reflects the final served bytes.
-    if input.options.inject_dev_mode_globals {
-        if let Some(main_code) = output_chunks.get_mut("main.js") {
-            let prologue = dev_mode_globals_prologue();
-            *main_code = format!("{prologue}{main_code}");
-            if let Some(map) = chunk_source_maps.get_mut("main.js") {
-                *map = shift_source_map_lines(map, 1);
-            }
-        }
-    }
-
     // Content-hash filenames
     let main_filename = if input.options.content_hash {
         apply_content_hashes(&mut output_chunks, &mut chunk_source_maps)?
@@ -323,48 +303,6 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         main_filename,
         chunk_source_maps,
     })
-}
-
-/// Synthetic single-line statement set to `false` for Angular's three
-/// well-known build-time flags. Prepended to `main.js` in production builds
-/// so `@angular/core`'s `isDevMode()` returns `false` at runtime, which in
-/// turn lets `provideServiceWorker(..., { enabled: !isDevMode() })` enable
-/// SW registration. This does not eliminate the dev-only branches from the
-/// bundle — that requires define-substitution + DCE (tracked separately).
-fn dev_mode_globals_prologue() -> String {
-    "globalThis.ngDevMode=false;globalThis.ngI18nClosureMode=false;globalThis.ngJitMode=false;\n"
-        .to_string()
-}
-
-/// Shift every token's `dst_line` down by `lines` so a source map stays
-/// aligned after a multi-line prologue is prepended to its chunk.
-fn shift_source_map_lines(map: &SourceMap, lines: u32) -> SourceMap {
-    let names: Vec<_> = map.get_names().cloned().collect();
-    let sources: Vec<_> = map.get_sources().cloned().collect();
-    let source_contents: Vec<Option<std::sync::Arc<str>>> =
-        map.get_source_contents().map(|opt| opt.cloned()).collect();
-    let tokens: Vec<oxc_sourcemap::Token> = map
-        .get_tokens()
-        .map(|t| {
-            oxc_sourcemap::Token::new(
-                t.get_dst_line() + lines,
-                t.get_dst_col(),
-                t.get_src_line(),
-                t.get_src_col(),
-                t.get_source_id(),
-                t.get_name_id(),
-            )
-        })
-        .collect();
-    SourceMap::new(
-        None,
-        names,
-        None,
-        sources,
-        source_contents,
-        tokens.into_boxed_slice(),
-        None,
-    )
 }
 
 /// Build a mapping from raw import specifiers (as they appear in source) to chunk filenames.
@@ -1183,78 +1121,6 @@ mod tests {
             .chunks
             .get(&output.main_filename)
             .expect("main chunk should exist")
-    }
-
-    #[test]
-    fn test_dev_mode_globals_prologue_in_production() {
-        let mut graph = DiGraph::new();
-        let entry = graph.add_node(make_path("/root/src/main.ts"));
-        let _ = entry;
-
-        let mut modules = HashMap::new();
-        modules.insert(
-            make_path("/root/src/main.ts"),
-            "console.log('hi');\n".to_string(),
-        );
-
-        let input = BundleInput {
-            modules,
-            graph,
-            entry: make_path("/root/src/main.ts"),
-            local_prefixes: vec![".".to_string()],
-            root_dir: make_path("/root/src"),
-            options: BundleOptions {
-                inject_dev_mode_globals: true,
-                ..BundleOptions::default()
-            },
-            per_module_maps: HashMap::new(),
-            bundled_specifiers: HashSet::new(),
-            export_conditions: Vec::new(),
-        };
-
-        let output = bundle(&input).expect("should bundle");
-        let main = main_chunk(&output);
-        // The synthetic prologue must be the first thing the JS engine
-        // executes so subsequent `typeof ngDevMode` reads see `false`
-        // (boolean), not `undefined`.
-        assert!(
-            main.starts_with("globalThis.ngDevMode=false;"),
-            "main.js should start with the dev-mode globals prologue, got: {:?}",
-            &main[..main.len().min(120)]
-        );
-        assert!(main.contains("globalThis.ngI18nClosureMode=false;"));
-        assert!(main.contains("globalThis.ngJitMode=false;"));
-    }
-
-    #[test]
-    fn test_dev_mode_globals_not_injected_when_disabled() {
-        let mut graph = DiGraph::new();
-        let _ = graph.add_node(make_path("/root/src/main.ts"));
-
-        let mut modules = HashMap::new();
-        modules.insert(
-            make_path("/root/src/main.ts"),
-            "console.log('hi');\n".to_string(),
-        );
-
-        let input = BundleInput {
-            modules,
-            graph,
-            entry: make_path("/root/src/main.ts"),
-            local_prefixes: vec![".".to_string()],
-            root_dir: make_path("/root/src"),
-            options: BundleOptions::default(),
-            per_module_maps: HashMap::new(),
-            bundled_specifiers: HashSet::new(),
-            export_conditions: Vec::new(),
-        };
-
-        let output = bundle(&input).expect("should bundle");
-        let main = main_chunk(&output);
-        assert!(
-            !main.contains("globalThis.ngDevMode"),
-            "dev builds must not inject the prologue"
-        );
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -947,7 +947,6 @@ fn build_options(configuration: Option<&str>) -> BundleOptions {
             minify: true,
             content_hash: true,
             tree_shake: true,
-            inject_dev_mode_globals: true,
         },
         _ => BundleOptions::default(),
     }
@@ -2185,7 +2184,6 @@ mod tests {
         assert!(opts.minify);
         assert!(opts.content_hash);
         assert!(opts.tree_shake);
-        assert!(opts.inject_dev_mode_globals);
     }
 
     #[test]
@@ -2195,7 +2193,6 @@ mod tests {
         assert!(!opts.minify);
         assert!(!opts.content_hash);
         assert!(!opts.tree_shake);
-        assert!(!opts.inject_dev_mode_globals);
     }
 
     #[test]
@@ -2205,7 +2202,6 @@ mod tests {
         assert!(!opts.minify);
         assert!(!opts.content_hash);
         assert!(!opts.tree_shake);
-        assert!(!opts.inject_dev_mode_globals);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -491,6 +491,19 @@ fn run_build(
         }
     }
 
+    // Production-only: substitute Angular's build-time flags with their
+    // literal values so the minifier can dead-code-eliminate `if (ngDevMode)`
+    // branches throughout `@angular/core` and friends. Replaces the runtime
+    // `globalThis.ngDevMode = false` prologue from earlier ngc-rs versions.
+    if configuration == Some("production") {
+        let define_span = tracing::info_span!("define_substitution").entered();
+        ngc_ts_transform::apply_defines_to_modules(
+            &mut modules,
+            &ngc_ts_transform::DefineMap::production_angular(),
+        );
+        drop(define_span);
+    }
+
     let bundle_input = BundleInput {
         modules,
         graph,

--- a/crates/cli/src/polyfills.rs
+++ b/crates/cli/src/polyfills.rs
@@ -224,13 +224,21 @@ pub fn generate_polyfills(
         }
     }
 
+    // Substitute Angular's build-time flags so any dev-only branches reachable
+    // from the polyfill graph (e.g. zone.js' development guards) are dropped
+    // by the minifier.
+    if configuration == Some("production") {
+        ngc_ts_transform::apply_defines_to_modules(
+            &mut modules,
+            &ngc_ts_transform::DefineMap::production_angular(),
+        );
+    }
+
     // Phase 5: bundle. Disable content-hashing inside the bundler — the
     // bundler's hash machinery hard-codes `main.js` as the entry filename;
     // we apply hashing ourselves below so the output is named `polyfills`.
-    // Disable dev-mode globals — they're a `main.js`-only prologue.
     let mut polyfill_bundle_options = bundle_options;
     polyfill_bundle_options.content_hash = false;
-    polyfill_bundle_options.inject_dev_mode_globals = false;
 
     let bundle_input = BundleInput {
         modules,

--- a/crates/ts-transform/Cargo.toml
+++ b/crates/ts-transform/Cargo.toml
@@ -10,6 +10,8 @@ repository.workspace = true
 [dependencies]
 ngc-diagnostics = { path = "../diagnostics" }
 oxc_allocator = "0.122"
+oxc_ast = "0.122"
+oxc_ast_visit = "0.122"
 oxc_parser = "0.122"
 oxc_transformer = "0.122"
 oxc_codegen = "0.122"

--- a/crates/ts-transform/src/defines.rs
+++ b/crates/ts-transform/src/defines.rs
@@ -12,7 +12,7 @@
 //! `IdentifierReference`.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::IdentifierReference;
@@ -20,6 +20,7 @@ use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_semantic::{IsGlobalReference, Scoping, SemanticBuilder};
 use oxc_span::SourceType;
+use rayon::prelude::*;
 
 /// Map of identifier name → replacement source text.
 ///
@@ -103,6 +104,31 @@ pub fn apply_defines(source: &str, file_name: &str, defines: &DefineMap) -> Stri
     }
     out.push_str(&source[cursor..]);
     out
+}
+
+/// Apply `defines` to every module in `modules` in parallel.
+///
+/// Each module is keyed by its canonical path; the path's extension drives
+/// the parser's source-type detection. The map is updated in place.
+pub fn apply_defines_to_modules(modules: &mut HashMap<PathBuf, String>, defines: &DefineMap) {
+    if defines.is_empty() {
+        return;
+    }
+    let updates: Vec<(PathBuf, String)> = modules
+        .par_iter()
+        .filter_map(|(path, code)| {
+            let file_name = path.to_string_lossy();
+            let next = apply_defines(code, file_name.as_ref(), defines);
+            if next == *code {
+                None
+            } else {
+                Some((path.clone(), next))
+            }
+        })
+        .collect();
+    for (path, code) in updates {
+        modules.insert(path, code);
+    }
 }
 
 struct Collector<'a, 'b> {

--- a/crates/ts-transform/src/defines.rs
+++ b/crates/ts-transform/src/defines.rs
@@ -1,0 +1,289 @@
+//! Build-time identifier substitution.
+//!
+//! Replaces references to a fixed set of identifiers (e.g. `ngDevMode`) with
+//! literal expressions (e.g. `false`) at the source-text level, so a downstream
+//! minifier can constant-fold and dead-code-eliminate the dev-only branches
+//! that gate on those flags. Mirrors esbuild's `--define:` flag.
+//!
+//! Replacements only apply when the identifier resolves to the global scope —
+//! a local `let ngDevMode`, a parameter, or a named import shadowing the name
+//! is left untouched. Property access like `obj.ngDevMode` is also untouched
+//! because the AST classifies the property as an `IdentifierName`, not an
+//! `IdentifierReference`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::IdentifierReference;
+use oxc_ast_visit::Visit;
+use oxc_parser::Parser;
+use oxc_semantic::{IsGlobalReference, Scoping, SemanticBuilder};
+use oxc_span::SourceType;
+
+/// Map of identifier name → replacement source text.
+///
+/// Values are raw JavaScript source fragments (typically literals like
+/// `"false"`) spliced verbatim into the output.
+#[derive(Debug, Clone, Default)]
+pub struct DefineMap {
+    entries: HashMap<String, &'static str>,
+}
+
+impl DefineMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, name: impl Into<String>, value: &'static str) {
+        self.entries.insert(name.into(), value);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&'static str> {
+        self.entries.get(name).copied()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Defines applied to Angular production builds. Lowering these to literal
+    /// `false` lets the bundler/minifier eliminate every `if (ngDevMode) { … }`
+    /// branch in `@angular/core` and friends.
+    pub fn production_angular() -> Self {
+        let mut map = Self::new();
+        map.insert("ngDevMode", "false");
+        map.insert("ngI18nClosureMode", "false");
+        map.insert("ngJitMode", "false");
+        map
+    }
+}
+
+/// Apply `defines` to `source`, returning the substituted source text.
+///
+/// On parse failure or when the map is empty, returns the input unchanged —
+/// this pass is a best-effort optimisation, not a correctness gate.
+pub fn apply_defines(source: &str, file_name: &str, defines: &DefineMap) -> String {
+    if defines.is_empty() {
+        return source.to_string();
+    }
+
+    let allocator = Allocator::new();
+    let path = Path::new(file_name);
+    let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
+
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return source.to_string();
+    }
+
+    let semantic = SemanticBuilder::new().build(&parsed.program).semantic;
+    let scoping = semantic.scoping();
+
+    let mut collector = Collector::new(scoping, defines);
+    collector.visit_program(&parsed.program);
+
+    let mut replacements = collector.replacements;
+    if replacements.is_empty() {
+        return source.to_string();
+    }
+    replacements.sort_unstable_by_key(|(start, _, _)| *start);
+
+    let mut out = String::with_capacity(source.len());
+    let mut cursor: usize = 0;
+    for (start, end, replacement) in replacements {
+        let start = start as usize;
+        let end = end as usize;
+        if start < cursor {
+            continue;
+        }
+        out.push_str(&source[cursor..start]);
+        out.push_str(replacement);
+        cursor = end;
+    }
+    out.push_str(&source[cursor..]);
+    out
+}
+
+struct Collector<'a, 'b> {
+    scoping: &'b Scoping,
+    defines: &'b DefineMap,
+    replacements: Vec<(u32, u32, &'static str)>,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, 'b> Collector<'a, 'b> {
+    fn new(scoping: &'b Scoping, defines: &'b DefineMap) -> Self {
+        Self {
+            scoping,
+            defines,
+            replacements: Vec::new(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a> Visit<'a> for Collector<'a, '_> {
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        let Some(replacement) = self.defines.get(it.name.as_str()) else {
+            return;
+        };
+        if !it.is_global_reference(self.scoping) {
+            return;
+        }
+        // Skip writes — `ngDevMode = something` would become `false = something`,
+        // a syntax error. These flags are read-only in practice, but defending
+        // against the edge case keeps the pass safe.
+        if let Some(reference_id) = it.reference_id.get() {
+            if self.scoping.get_reference(reference_id).is_write() {
+                return;
+            }
+        }
+        self.replacements
+            .push((it.span.start, it.span.end, replacement));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defines() -> DefineMap {
+        DefineMap::production_angular()
+    }
+
+    #[test]
+    fn replaces_global_identifier_reference() {
+        let src = "if (ngDevMode) { console.log('dev'); }\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, "if (false) { console.log('dev'); }\n");
+    }
+
+    #[test]
+    fn replaces_typeof_call_site() {
+        // `typeof ngDevMode !== 'undefined' && ngDevMode` is the actual guard
+        // pattern in @angular/core. After substitution, both reads become `false`,
+        // letting the minifier collapse the whole expression.
+        let src = "const x = typeof ngDevMode !== 'undefined' && ngDevMode;\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, "const x = typeof false !== 'undefined' && false;\n");
+    }
+
+    #[test]
+    fn replaces_all_three_angular_flags() {
+        let src = "[ngDevMode, ngI18nClosureMode, ngJitMode];\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, "[false, false, false];\n");
+    }
+
+    #[test]
+    fn preserves_property_access() {
+        let src = "obj.ngDevMode;\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn preserves_property_with_global_object() {
+        // `globalThis.ngDevMode` must NOT be touched: the property name is an
+        // IdentifierName, not an IdentifierReference.
+        let src = "globalThis.ngDevMode = false;\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn shadowed_by_const_is_kept() {
+        let src = "{ const ngDevMode = 1; console.log(ngDevMode); }\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn shadowed_by_let_is_kept() {
+        let src = "function f() { let ngDevMode = 0; return ngDevMode; }\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn shadowed_by_var_is_kept() {
+        let src = "function f() { var ngDevMode = 0; return ngDevMode; }\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn shadowed_by_parameter_is_kept() {
+        let src = "function f(ngDevMode) { return ngDevMode; }\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn shadowed_by_named_import_is_kept() {
+        let src = "import { ngDevMode } from './x';\nconsole.log(ngDevMode);\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn shadowed_by_renamed_import_is_kept() {
+        // `import { foo as ngDevMode }` creates a local binding called
+        // `ngDevMode` that shadows the global.
+        let src = "import { foo as ngDevMode } from './x';\nconsole.log(ngDevMode);\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn outer_scope_replaced_inner_shadow_kept() {
+        // The outer `ngDevMode` is a global reference and must be replaced;
+        // the inner `ngDevMode` is bound by `const` and must be kept.
+        let src = "console.log(ngDevMode);\n{ const ngDevMode = 1; console.log(ngDevMode); }\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(
+            out,
+            "console.log(false);\n{ const ngDevMode = 1; console.log(ngDevMode); }\n"
+        );
+    }
+
+    #[test]
+    fn assignment_target_is_not_replaced() {
+        // We don't replace writes — `false = x` would be a syntax error.
+        let src = "ngDevMode = true;\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn empty_define_map_returns_input() {
+        let src = "if (ngDevMode) {}\n";
+        let out = apply_defines(src, "in.js", &DefineMap::new());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn unrelated_identifier_is_untouched() {
+        let src = "const someOtherFlag = true;\n";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn unparseable_source_returns_input_unchanged() {
+        let src = "if (ngDevMode { )) {{{";
+        let out = apply_defines(src, "in.js", &defines());
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn collector_constructor_initialises_empty() {
+        let allocator = Allocator::new();
+        let parsed = Parser::new(&allocator, "", SourceType::mjs()).parse();
+        let semantic = SemanticBuilder::new().build(&parsed.program).semantic;
+        let defines = defines();
+        let c = Collector::new(semantic.scoping(), &defines);
+        assert!(c.replacements.is_empty());
+    }
+}

--- a/crates/ts-transform/src/lib.rs
+++ b/crates/ts-transform/src/lib.rs
@@ -6,7 +6,7 @@
 mod defines;
 mod transform;
 
-pub use defines::{apply_defines, DefineMap};
+pub use defines::{apply_defines, apply_defines_to_modules, DefineMap};
 pub use transform::{
     transform_project, transform_source, transform_source_with_map, transform_sources_to_memory,
     transform_sources_to_memory_with_maps, transform_to_memory, transform_to_memory_with_maps,

--- a/crates/ts-transform/src/lib.rs
+++ b/crates/ts-transform/src/lib.rs
@@ -3,8 +3,10 @@
 //! This crate uses oxc to parse TypeScript source files, strip type annotations,
 //! interfaces, type aliases, and decorators, then emit plain JavaScript.
 
+mod defines;
 mod transform;
 
+pub use defines::{apply_defines, DefineMap};
 pub use transform::{
     transform_project, transform_source, transform_source_with_map, transform_sources_to_memory,
     transform_sources_to_memory_with_maps, transform_to_memory, transform_to_memory_with_maps,


### PR DESCRIPTION
Closes #86

## Summary
- New `defines` module in `ngc-ts-transform` substitutes `ngDevMode`, `ngI18nClosureMode`, and `ngJitMode` with literal `false` at the source-text level. Uses oxc's parser + semantic scoping so only true global references are replaced — local `let`/`const`/`var`/parameter/import bindings that shadow the name are kept untouched, and property access (`obj.ngDevMode`) is naturally skipped because the AST classifies it as `IdentifierName`, not `IdentifierReference`.
- CLI wires the pass into both the main and polyfills bundle pipelines, gated on `--configuration production`. With the references now reduced to literal `false`, the existing minifier constant-folds `if (false) { … }` and drops the dev-only branches.
- Removes the `BundleOptions::inject_dev_mode_globals` runtime prologue (and its tests). The `globalThis.ngDevMode = false` shim was a runtime workaround for the same problem; once the references are gone at compile time the prologue is redundant.

## Definition of done (per #86)
- 17 unit tests cover: global identifier replacement, three-flag substitution, `typeof ngDevMode` (the actual `@angular/core` call site), property-access preservation (`obj.ngDevMode`, `globalThis.ngDevMode`), shadowing by `const`/`let`/`var`/parameter/named-import/renamed-import, mixed outer-replaced + inner-shadowed scope, write-target safety, empty-map fast-path, and unparseable-source graceful fallback.
- `BundleOptions::inject_dev_mode_globals` and `dev_mode_globals_prologue()` deleted.
- `cargo test --workspace` (≈600 tests across the workspace), `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

## Out of scope (matches issue)
- No user-facing `--define` CLI flag — only the three Angular flags are hardcoded.
- No new minifier dependency; relies on the existing `oxc_codegen`/minify pass for branch elimination.

## Test plan
- [ ] `cargo test --workspace` — all 600+ tests green
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] On the test-bed Angular app: `grep -c ngDevMode dist/test-ng-project/main.js` returns `0`
- [ ] `provideServiceWorker(..., { enabled: !isDevMode() })` still registers the SW (#65 regression guard)
- [ ] Production `main.js` shrinks meaningfully versus the prologue-only build