### PR TITLE
feat(serve): http dev server with live reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -486,6 +498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +710,16 @@ dependencies = [
  "regex",
  "sha2",
  "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "ngc-dev-server"
+version = "0.8.1"
+dependencies = [
+ "ngc-diagnostics",
+ "tempfile",
+ "tiny_http",
  "tracing",
 ]
 
@@ -1755,6 +1783,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "clap",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch"]
+members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
 version = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/dev-server/Cargo.toml
+++ b/crates/dev-server/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ngc-dev-server"
+description = "HTTP dev server with live reload for ngc-rs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+ngc-diagnostics = { path = "../diagnostics" }
+tiny_http = "0.12"
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -28,7 +28,7 @@
 use std::io::Write;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
@@ -231,11 +231,7 @@ fn serve_loop(server: Arc<Server>, root: PathBuf, clients: SseClients) {
     }
 }
 
-fn handle_request(
-    request: tiny_http::Request,
-    root: &Path,
-    clients: &SseClients,
-) -> NgcResult<()> {
+fn handle_request(request: tiny_http::Request, root: &Path, clients: &SseClients) -> NgcResult<()> {
     if !matches!(request.method(), Method::Get | Method::Head) {
         let resp = Response::from_string("method not allowed").with_status_code(StatusCode(405));
         return request.respond(resp).map_err(io_err);

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -1,0 +1,568 @@
+//! HTTP dev server with live reload for ngc-rs.
+//!
+//! This crate provides a lightweight, synchronous HTTP server that serves a
+//! built `dist/` directory and notifies connected browsers when a rebuild has
+//! completed. Live reload is delivered over Server-Sent Events (SSE), which is
+//! significantly simpler to implement on top of plain blocking HTTP than a
+//! full WebSocket handshake — no framing, no upgrade negotiation, just a
+//! long-lived `text/event-stream` response.
+//!
+//! # Design notes
+//!
+//! * **Sync IO only.** The server uses `tiny_http`, which dispatches requests
+//!   on a worker pool of OS threads. No tokio, in keeping with the rayon-only
+//!   rule for the rest of the workspace.
+//! * **Decoupled from the watcher.** The server consumes a generic
+//!   [`std::sync::mpsc::Receiver`] of [`ReloadEvent`]s. The producer side is
+//!   left to the caller — the file watcher (issue #24) will become one such
+//!   producer, but tests and other tooling can drive reloads with the same
+//!   API.
+//! * **SPA fallback.** Any unmatched `GET` whose path does not resolve to a
+//!   real file under `dist/` returns the contents of `index.html`. This
+//!   matches the behavior of `ng serve` for client-side routed apps.
+//! * **Live reload injection.** When `index.html` is served, a tiny client
+//!   script is injected just before the closing `</body>` tag. It opens an
+//!   `EventSource` to `/__ngc_reload` and triggers `location.reload()` when a
+//!   `reload` event arrives.
+
+use std::io::Write;
+use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use ngc_diagnostics::{NgcError, NgcResult};
+use tiny_http::{Header, Method, Response, Server, StatusCode};
+
+/// A signal that connected browsers should reload the page.
+///
+/// The struct is intentionally empty for now — future revisions may carry
+/// metadata such as the changed file list to enable hot-module replacement.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReloadEvent;
+
+/// Configuration for [`DevServer`].
+#[derive(Debug, Clone)]
+pub struct DevServerConfig {
+    /// Path to the built `dist/` directory that will be served.
+    pub root: PathBuf,
+    /// Host to bind on. Defaults to `127.0.0.1`.
+    pub host: String,
+    /// Port to bind on. Defaults to `4200`. A value of `0` will let the OS
+    /// pick an ephemeral port — useful for tests.
+    pub port: u16,
+}
+
+impl DevServerConfig {
+    /// Construct a config with default host (`127.0.0.1`) and port (`4200`)
+    /// for the given `dist/` directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            host: "127.0.0.1".to_string(),
+            port: 4200,
+        }
+    }
+
+    /// Override the bind host.
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+
+    /// Override the bind port. Use `0` to let the OS pick.
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+}
+
+/// Handle to a running dev server.
+///
+/// Dropping the handle stops the server and closes any open SSE connections.
+pub struct DevServer {
+    addr: SocketAddr,
+    reload_tx: Sender<ReloadEvent>,
+    server: Arc<Server>,
+    accept_join: Option<JoinHandle<()>>,
+}
+
+impl DevServer {
+    /// Bind a new dev server on the configured address and start serving.
+    ///
+    /// The server runs on a background thread pool managed by `tiny_http`.
+    /// Reload events are forwarded from `reload_rx` to all connected SSE
+    /// clients. Pass [`ReloadEvent`]s to the matching sender returned by
+    /// [`channel`](std::sync::mpsc::channel) elsewhere — typically from a file
+    /// watcher.
+    pub fn start(config: DevServerConfig, reload_rx: Receiver<ReloadEvent>) -> NgcResult<Self> {
+        let bind = (config.host.as_str(), config.port);
+        let addr = bind
+            .to_socket_addrs()
+            .map_err(|e| NgcError::ServeError {
+                message: format!(
+                    "could not resolve bind address {}:{}: {e}",
+                    config.host, config.port
+                ),
+            })?
+            .next()
+            .ok_or_else(|| NgcError::ServeError {
+                message: format!("no addresses resolved for {}:{}", config.host, config.port),
+            })?;
+
+        let listener = TcpListener::bind(addr).map_err(|e| NgcError::ServeError {
+            message: format!("could not bind to {addr}: {e}"),
+        })?;
+        let actual_addr = listener.local_addr().map_err(|e| NgcError::ServeError {
+            message: format!("could not read local address: {e}"),
+        })?;
+
+        let server = Server::from_listener(listener, None).map_err(|e| NgcError::ServeError {
+            message: format!("tiny_http server init failed: {e}"),
+        })?;
+        let server = Arc::new(server);
+
+        let clients: SseClients = Arc::new(Mutex::new(Vec::new()));
+        let (internal_tx, internal_rx) = channel::<ReloadEvent>();
+
+        spawn_bridge(reload_rx, internal_tx.clone())?;
+        spawn_fanout(internal_rx, Arc::clone(&clients))?;
+
+        let request_server = Arc::clone(&server);
+        let root = config.root.clone();
+        let request_clients = Arc::clone(&clients);
+        let join = thread::Builder::new()
+            .name("ngc-dev-server-accept".into())
+            .spawn(move || serve_loop(request_server, root, request_clients))
+            .map_err(|e| NgcError::ServeError {
+                message: format!("could not spawn accept thread: {e}"),
+            })?;
+
+        tracing::info!(addr = %actual_addr, "ngc-rs dev server listening");
+
+        Ok(Self {
+            addr: actual_addr,
+            reload_tx: internal_tx,
+            server,
+            accept_join: Some(join),
+        })
+    }
+
+    /// Address the server is actually bound to. When the configured port was
+    /// `0` this reflects the ephemeral port chosen by the OS.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Send a reload event to all connected browsers without going through
+    /// an external channel. Convenient for tests and ad-hoc tooling.
+    pub fn trigger_reload(&self) -> NgcResult<()> {
+        self.reload_tx
+            .send(ReloadEvent)
+            .map_err(|e| NgcError::ServeError {
+                message: format!("could not enqueue reload event: {e}"),
+            })
+    }
+}
+
+impl Drop for DevServer {
+    fn drop(&mut self) {
+        self.server.unblock();
+        if let Some(handle) = self.accept_join.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+type SseWriter = Box<dyn Write + Send>;
+type SseClients = Arc<Mutex<Vec<SseWriter>>>;
+
+fn spawn_bridge(rx: Receiver<ReloadEvent>, tx: Sender<ReloadEvent>) -> NgcResult<()> {
+    thread::Builder::new()
+        .name("ngc-dev-server-bridge".into())
+        .spawn(move || {
+            while let Ok(ev) = rx.recv() {
+                if tx.send(ev).is_err() {
+                    break;
+                }
+            }
+        })
+        .map(|_| ())
+        .map_err(|e| NgcError::ServeError {
+            message: format!("could not spawn bridge thread: {e}"),
+        })
+}
+
+fn spawn_fanout(rx: Receiver<ReloadEvent>, clients: SseClients) -> NgcResult<()> {
+    thread::Builder::new()
+        .name("ngc-dev-server-fanout".into())
+        .spawn(move || fanout_loop(rx, clients))
+        .map(|_| ())
+        .map_err(|e| NgcError::ServeError {
+            message: format!("could not spawn fanout thread: {e}"),
+        })
+}
+
+fn fanout_loop(rx: Receiver<ReloadEvent>, clients: SseClients) {
+    while rx.recv().is_ok() {
+        let mut guard = match clients.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.retain_mut(|stream| {
+            stream
+                .write_all(b"event: reload\ndata: rebuild\n\n")
+                .and_then(|_| stream.flush())
+                .is_ok()
+        });
+    }
+}
+
+fn serve_loop(server: Arc<Server>, root: PathBuf, clients: SseClients) {
+    for request in server.incoming_requests() {
+        let root = root.clone();
+        let clients = Arc::clone(&clients);
+        thread::spawn(move || {
+            if let Err(e) = handle_request(request, &root, &clients) {
+                tracing::warn!(error = %e, "dev server request failed");
+            }
+        });
+    }
+}
+
+fn handle_request(
+    request: tiny_http::Request,
+    root: &Path,
+    clients: &SseClients,
+) -> NgcResult<()> {
+    if !matches!(request.method(), Method::Get | Method::Head) {
+        let resp = Response::from_string("method not allowed").with_status_code(StatusCode(405));
+        return request.respond(resp).map_err(io_err);
+    }
+
+    let url = request.url().to_string();
+    let path = url.split('?').next().unwrap_or("/");
+
+    if path == "/__ngc_reload" {
+        return handle_sse(request, clients);
+    }
+
+    serve_static(request, root, path)
+}
+
+fn handle_sse(request: tiny_http::Request, clients: &SseClients) -> NgcResult<()> {
+    let response_head = b"HTTP/1.1 200 OK\r\n\
+Content-Type: text/event-stream\r\n\
+Cache-Control: no-cache\r\n\
+Connection: keep-alive\r\n\
+Access-Control-Allow-Origin: *\r\n\
+\r\n\
+: connected\n\n";
+
+    let mut writer = request.into_writer();
+    writer
+        .write_all(response_head)
+        .and_then(|_| writer.flush())
+        .map_err(|e| NgcError::ServeError {
+            message: format!("could not start SSE stream: {e}"),
+        })?;
+
+    let mut guard = clients.lock().map_err(|_| NgcError::ServeError {
+        message: "SSE client list mutex was poisoned".into(),
+    })?;
+    guard.push(writer);
+    Ok(())
+}
+
+fn serve_static(request: tiny_http::Request, root: &Path, url_path: &str) -> NgcResult<()> {
+    let decoded = decode_path(url_path);
+    let candidate = match resolve_under_root(root, &decoded) {
+        Some(p) => p,
+        None => {
+            let resp = Response::from_string("forbidden").with_status_code(StatusCode(403));
+            return request.respond(resp).map_err(io_err);
+        }
+    };
+
+    match pick_file(&candidate) {
+        Some(file_path) => respond_with_file(request, &file_path),
+        None => spa_fallback(request, root),
+    }
+}
+
+fn pick_file(candidate: &Path) -> Option<PathBuf> {
+    if candidate.is_file() {
+        return Some(candidate.to_path_buf());
+    }
+    if candidate.is_dir() {
+        let index = candidate.join("index.html");
+        if index.is_file() {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn spa_fallback(request: tiny_http::Request, root: &Path) -> NgcResult<()> {
+    let index = root.join("index.html");
+    if index.is_file() {
+        respond_with_file(request, &index)
+    } else {
+        let resp = Response::from_string("not found").with_status_code(StatusCode(404));
+        request.respond(resp).map_err(io_err)
+    }
+}
+
+fn respond_with_file(request: tiny_http::Request, path: &Path) -> NgcResult<()> {
+    let bytes = std::fs::read(path).map_err(|e| NgcError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let mime = mime_for(path);
+
+    let body = if is_index_html(path) {
+        inject_live_reload_client(&bytes)
+    } else {
+        bytes
+    };
+
+    let mut resp = Response::from_data(body);
+    resp.add_header(header("Content-Type", mime)?);
+    resp.add_header(header("Cache-Control", "no-cache")?);
+    request.respond(resp).map_err(io_err)
+}
+
+fn is_index_html(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.eq_ignore_ascii_case("index.html"))
+        .unwrap_or(false)
+}
+
+fn header(name: &str, value: &str) -> NgcResult<Header> {
+    Header::from_bytes(name.as_bytes(), value.as_bytes()).map_err(|_| NgcError::ServeError {
+        message: format!("invalid HTTP header value for {name}: {value}"),
+    })
+}
+
+fn io_err(e: std::io::Error) -> NgcError {
+    NgcError::ServeError {
+        message: format!("response write failed: {e}"),
+    }
+}
+
+fn decode_path(url_path: &str) -> String {
+    let mut out = String::with_capacity(url_path.len());
+    let bytes = url_path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push(((hi << 4) | lo) as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn resolve_under_root(root: &Path, url_path: &str) -> Option<PathBuf> {
+    let trimmed = url_path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return Some(root.to_path_buf());
+    }
+    let mut joined = root.to_path_buf();
+    for segment in trimmed.split('/') {
+        match segment {
+            "" | "." => continue,
+            ".." => return None,
+            other => joined.push(other),
+        }
+    }
+    Some(joined)
+}
+
+/// MIME type lookup for a given path's extension. Falls back to
+/// `application/octet-stream` for unknown extensions.
+pub fn mime_for(path: &Path) -> &'static str {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("html" | "htm") => "text/html; charset=utf-8",
+        Some("js" | "mjs" | "cjs") => "application/javascript; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("json") => "application/json; charset=utf-8",
+        Some("map") => "application/json; charset=utf-8",
+        Some("svg") => "image/svg+xml",
+        Some("png") => "image/png",
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("ico") => "image/x-icon",
+        Some("avif") => "image/avif",
+        Some("woff") => "font/woff",
+        Some("woff2") => "font/woff2",
+        Some("ttf") => "font/ttf",
+        Some("otf") => "font/otf",
+        Some("eot") => "application/vnd.ms-fontobject",
+        Some("wasm") => "application/wasm",
+        Some("txt") => "text/plain; charset=utf-8",
+        Some("xml") => "application/xml; charset=utf-8",
+        _ => "application/octet-stream",
+    }
+}
+
+/// The live-reload client script that gets injected into served `index.html`.
+///
+/// Subscribes to `/__ngc_reload` via `EventSource`, listens for `reload`
+/// events, and triggers a full page refresh. Wrapped in a script tag so it
+/// can be inserted directly into HTML.
+pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){location.reload();});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+
+/// Insert the live-reload client script into an HTML byte buffer.
+///
+/// Inserts immediately before the closing `</body>` tag (case-insensitive).
+/// If no `</body>` is present, appends to the end.
+pub fn inject_live_reload_client(html: &[u8]) -> Vec<u8> {
+    let s = match std::str::from_utf8(html) {
+        Ok(s) => s,
+        Err(_) => {
+            let mut out = Vec::with_capacity(html.len() + LIVE_RELOAD_SCRIPT.len());
+            out.extend_from_slice(html);
+            out.extend_from_slice(LIVE_RELOAD_SCRIPT.as_bytes());
+            return out;
+        }
+    };
+    let lower = s.to_ascii_lowercase();
+    if let Some(idx) = lower.rfind("</body>") {
+        let mut out = String::with_capacity(s.len() + LIVE_RELOAD_SCRIPT.len());
+        out.push_str(&s[..idx]);
+        out.push_str(LIVE_RELOAD_SCRIPT);
+        out.push_str(&s[idx..]);
+        return out.into_bytes();
+    }
+    let mut out = String::with_capacity(s.len() + LIVE_RELOAD_SCRIPT.len());
+    out.push_str(s);
+    out.push_str(LIVE_RELOAD_SCRIPT);
+    out.into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mime_for_known_extensions() {
+        assert!(mime_for(Path::new("a.js")).starts_with("application/javascript"));
+        assert!(mime_for(Path::new("a.mjs")).starts_with("application/javascript"));
+        assert!(mime_for(Path::new("a.css")).starts_with("text/css"));
+        assert!(mime_for(Path::new("a.html")).starts_with("text/html"));
+        assert_eq!(
+            mime_for(Path::new("a.map")),
+            "application/json; charset=utf-8"
+        );
+        assert_eq!(mime_for(Path::new("a.woff2")), "font/woff2");
+        assert_eq!(mime_for(Path::new("a.svg")), "image/svg+xml");
+        assert_eq!(mime_for(Path::new("a.wasm")), "application/wasm");
+    }
+
+    #[test]
+    fn mime_for_unknown_extension() {
+        assert_eq!(
+            mime_for(Path::new("nope.unknownext")),
+            "application/octet-stream"
+        );
+        assert_eq!(mime_for(Path::new("noext")), "application/octet-stream");
+    }
+
+    #[test]
+    fn inject_live_reload_client_inserts_before_body_close() {
+        let html = b"<html><body><h1>hi</h1></body></html>";
+        let injected = inject_live_reload_client(html);
+        let s = std::str::from_utf8(&injected).expect("utf8");
+        assert!(s.contains(LIVE_RELOAD_SCRIPT));
+        let script_idx = s.find(LIVE_RELOAD_SCRIPT).expect("script present");
+        let body_close = s.find("</body>").expect("body close present");
+        assert!(script_idx < body_close);
+    }
+
+    #[test]
+    fn inject_live_reload_client_appends_when_no_body() {
+        let html = b"<html><h1>hi</h1></html>";
+        let injected = inject_live_reload_client(html);
+        let s = std::str::from_utf8(&injected).expect("utf8");
+        assert!(s.ends_with(LIVE_RELOAD_SCRIPT));
+    }
+
+    #[test]
+    fn inject_live_reload_client_handles_uppercase_body() {
+        let html = b"<HTML><BODY><h1>hi</h1></BODY></HTML>";
+        let injected = inject_live_reload_client(html);
+        let s = std::str::from_utf8(&injected).expect("utf8");
+        let script_idx = s.find(LIVE_RELOAD_SCRIPT).expect("script present");
+        let body_close = s.find("</BODY>").expect("body close present");
+        assert!(script_idx < body_close);
+    }
+
+    #[test]
+    fn resolve_under_root_rejects_traversal() {
+        let root = Path::new("/tmp/dist");
+        assert!(resolve_under_root(root, "/../etc/passwd").is_none());
+        assert!(resolve_under_root(root, "/foo/../../etc").is_none());
+    }
+
+    #[test]
+    fn resolve_under_root_accepts_normal() {
+        let root = Path::new("/tmp/dist");
+        let p = resolve_under_root(root, "/main.js").expect("ok");
+        assert_eq!(p, Path::new("/tmp/dist/main.js"));
+        let p = resolve_under_root(root, "/").expect("ok");
+        assert_eq!(p, Path::new("/tmp/dist"));
+    }
+
+    #[test]
+    fn decode_path_handles_percent_encoding() {
+        assert_eq!(decode_path("/a%20b.js"), "/a b.js");
+        assert_eq!(decode_path("/plain.js"), "/plain.js");
+        assert_eq!(decode_path("/%2F"), "//");
+    }
+
+    #[test]
+    fn devserver_config_defaults() {
+        let c = DevServerConfig::new("/tmp/dist");
+        assert_eq!(c.host, "127.0.0.1");
+        assert_eq!(c.port, 4200);
+        assert_eq!(c.root, PathBuf::from("/tmp/dist"));
+    }
+
+    #[test]
+    fn devserver_config_with_overrides() {
+        let c = DevServerConfig::new("/tmp/dist")
+            .with_host("0.0.0.0")
+            .with_port(0);
+        assert_eq!(c.host, "0.0.0.0");
+        assert_eq!(c.port, 0);
+    }
+
+    #[test]
+    fn is_index_html_recognizes_variants() {
+        assert!(is_index_html(Path::new("/x/index.html")));
+        assert!(is_index_html(Path::new("/x/INDEX.HTML")));
+        assert!(!is_index_html(Path::new("/x/main.js")));
+    }
+}

--- a/crates/dev-server/tests/integration.rs
+++ b/crates/dev-server/tests/integration.rs
@@ -1,0 +1,260 @@
+//! Integration tests for the dev server.
+//!
+//! Each test binds an ephemeral port, drives requests through a minimal raw
+//! HTTP/1.1 client (no extra crate dependency), and asserts the server's
+//! behavior end to end.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+use ngc_dev_server::{DevServer, DevServerConfig, LIVE_RELOAD_SCRIPT, ReloadEvent};
+use tempfile::TempDir;
+
+struct Fixture {
+    server: DevServer,
+    _root: TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = TempDir::new().expect("tempdir");
+        write_file(
+            root.path(),
+            "index.html",
+            b"<html><body><h1>hi</h1></body></html>",
+        );
+        write_file(root.path(), "main.js", b"console.log('hello');");
+        write_file(root.path(), "main.js.map", b"{\"version\":3}");
+        write_file(root.path(), "styles.css", b"body{color:red}");
+        write_file(root.path(), "assets/logo.svg", b"<svg/>");
+
+        let cfg = DevServerConfig::new(root.path()).with_port(0);
+        let (_tx, rx) = channel::<ReloadEvent>();
+        let server = DevServer::start(cfg, rx).expect("start dev server");
+        Self {
+            server,
+            _root: root,
+        }
+    }
+}
+
+fn write_file(root: &std::path::Path, rel: &str, bytes: &[u8]) {
+    let path: PathBuf = root.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir");
+    }
+    std::fs::write(&path, bytes).expect("write");
+}
+
+struct HttpResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+impl HttpResponse {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+fn http_get(addr: std::net::SocketAddr, path: &str) -> HttpResponse {
+    let mut stream = TcpStream::connect(addr).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+    let req = format!(
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(req.as_bytes()).expect("write");
+    stream.flush().expect("flush");
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line).expect("status line");
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .expect("status code");
+
+    let mut headers = Vec::new();
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("header line");
+        if line == "\r\n" || line.is_empty() {
+            break;
+        }
+        if let Some((k, v)) = line.trim_end_matches("\r\n").split_once(':') {
+            headers.push((k.trim().to_string(), v.trim().to_string()));
+        }
+    }
+
+    let mut body = Vec::new();
+    reader.read_to_end(&mut body).expect("body");
+    HttpResponse {
+        status,
+        headers,
+        body,
+    }
+}
+
+#[test]
+fn get_root_returns_index_html_with_injected_client() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/");
+    assert_eq!(resp.status, 200);
+    let ct = resp.header("Content-Type").expect("content-type");
+    assert!(ct.starts_with("text/html"), "got {ct}");
+    let body = std::str::from_utf8(&resp.body).expect("utf8 body");
+    assert!(
+        body.contains(LIVE_RELOAD_SCRIPT),
+        "live-reload script not injected: {body}"
+    );
+    assert!(body.contains("<h1>hi</h1>"));
+}
+
+#[test]
+fn get_index_html_directly_also_injects_client() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/index.html");
+    assert_eq!(resp.status, 200);
+    let body = std::str::from_utf8(&resp.body).expect("utf8 body");
+    assert!(body.contains(LIVE_RELOAD_SCRIPT));
+}
+
+#[test]
+fn get_existing_js_file_returns_correct_mime() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/main.js");
+    assert_eq!(resp.status, 200);
+    let ct = resp.header("Content-Type").expect("content-type");
+    assert!(ct.starts_with("application/javascript"), "got {ct}");
+    assert_eq!(resp.body, b"console.log('hello');");
+}
+
+#[test]
+fn get_source_map_returns_json_mime() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/main.js.map");
+    assert_eq!(resp.status, 200);
+    let ct = resp.header("Content-Type").expect("content-type");
+    assert!(ct.starts_with("application/json"), "got {ct}");
+    assert_eq!(resp.body, b"{\"version\":3}");
+}
+
+#[test]
+fn get_css_returns_css_mime() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/styles.css");
+    assert_eq!(resp.status, 200);
+    let ct = resp.header("Content-Type").expect("content-type");
+    assert!(ct.starts_with("text/css"), "got {ct}");
+}
+
+#[test]
+fn get_nested_asset_resolves_under_root() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/assets/logo.svg");
+    assert_eq!(resp.status, 200);
+    let ct = resp.header("Content-Type").expect("content-type");
+    assert_eq!(ct, "image/svg+xml");
+    assert_eq!(resp.body, b"<svg/>");
+}
+
+#[test]
+fn unknown_path_falls_back_to_index_html() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/some/spa/route");
+    assert_eq!(resp.status, 200);
+    let ct = resp.header("Content-Type").expect("content-type");
+    assert!(ct.starts_with("text/html"), "got {ct}");
+    let body = std::str::from_utf8(&resp.body).expect("utf8 body");
+    assert!(body.contains("<h1>hi</h1>"));
+    assert!(body.contains(LIVE_RELOAD_SCRIPT));
+}
+
+#[test]
+fn path_traversal_is_refused() {
+    let fx = Fixture::new();
+    let resp = http_get(fx.server.addr(), "/../etc/passwd");
+    assert_eq!(resp.status, 403);
+}
+
+#[test]
+fn trigger_reload_pushes_event_to_sse_client() {
+    let fx = Fixture::new();
+    let mut stream = TcpStream::connect(fx.server.addr()).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+    let req = "GET /__ngc_reload HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: text/event-stream\r\n\r\n";
+    stream.write_all(req.as_bytes()).expect("write");
+    stream.flush().expect("flush");
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line).expect("status line");
+    assert!(status_line.contains("200"), "status was {status_line}");
+
+    let mut saw_event_stream = false;
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).expect("header");
+        if n == 0 {
+            break;
+        }
+        if line.to_ascii_lowercase().contains("text/event-stream") {
+            saw_event_stream = true;
+        }
+        if line == "\r\n" {
+            break;
+        }
+    }
+    assert!(saw_event_stream, "missing event-stream content type");
+
+    let mut got_connected = String::new();
+    reader.read_line(&mut got_connected).expect("connected");
+    assert!(
+        got_connected.starts_with(": connected"),
+        "got {got_connected:?}"
+    );
+    let mut blank = String::new();
+    reader.read_line(&mut blank).expect("blank");
+
+    std::thread::sleep(Duration::from_millis(100));
+    fx.server.trigger_reload().expect("trigger reload");
+
+    let mut event = String::new();
+    reader.read_line(&mut event).expect("event line");
+    assert_eq!(event, "event: reload\n");
+    let mut data = String::new();
+    reader.read_line(&mut data).expect("data line");
+    assert_eq!(data, "data: rebuild\n");
+}
+
+#[test]
+fn unknown_extension_serves_octet_stream() {
+    let root = TempDir::new().expect("tempdir");
+    write_file(
+        root.path(),
+        "index.html",
+        b"<html><body></body></html>",
+    );
+    write_file(root.path(), "blob.weird", b"\x00\x01\x02blob");
+    let cfg = DevServerConfig::new(root.path()).with_port(0);
+    let (_tx, rx) = channel::<ReloadEvent>();
+    let server = DevServer::start(cfg, rx).expect("start");
+    let resp = http_get(server.addr(), "/blob.weird");
+    assert_eq!(resp.status, 200);
+    assert_eq!(
+        resp.header("Content-Type").unwrap_or_default(),
+        "application/octet-stream"
+    );
+}

--- a/crates/dev-server/tests/integration.rs
+++ b/crates/dev-server/tests/integration.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
-use ngc_dev_server::{DevServer, DevServerConfig, LIVE_RELOAD_SCRIPT, ReloadEvent};
+use ngc_dev_server::{DevServer, DevServerConfig, ReloadEvent, LIVE_RELOAD_SCRIPT};
 use tempfile::TempDir;
 
 struct Fixture {
@@ -69,9 +69,7 @@ fn http_get(addr: std::net::SocketAddr, path: &str) -> HttpResponse {
     stream
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("read timeout");
-    let req = format!(
-        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
-    );
+    let req = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
     stream.write_all(req.as_bytes()).expect("write");
     stream.flush().expect("flush");
 
@@ -242,11 +240,7 @@ fn trigger_reload_pushes_event_to_sse_client() {
 #[test]
 fn unknown_extension_serves_octet_stream() {
     let root = TempDir::new().expect("tempdir");
-    write_file(
-        root.path(),
-        "index.html",
-        b"<html><body></body></html>",
-    );
+    write_file(root.path(), "index.html", b"<html><body></body></html>");
     write_file(root.path(), "blob.weird", b"\x00\x01\x02blob");
     let cfg = DevServerConfig::new(root.path()).with_port(0);
     let (_tx, rx) = channel::<ReloadEvent>();

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -202,6 +202,13 @@ pub enum NgcError {
         /// Description of what went wrong while watching files.
         message: String,
     },
+
+    /// The dev server failed to start, bind, or otherwise serve requests.
+    #[error("dev server error: {message}")]
+    ServeError {
+        /// Description of what went wrong.
+        message: String,
+    },
 }
 
 /// A type alias for Results using NgcError.


### PR DESCRIPTION
Closes #25

## Summary

New `ngc-dev-server` crate that serves a built `dist/` over HTTP with live-reload notifications. Designed as a self-contained library — the `ngc-rs serve` CLI command and the watcher hookup land in follow-up work.

## What's in this branch

- New crate `crates/dev-server` exposing `DevServer`, `DevServerConfig`, and `ReloadEvent`.
- Sync HTTP server on `tiny_http` (no tokio — rayon-only rule preserved).
- **Live reload over Server-Sent Events** at `/__ngc_reload`. SSE chosen over WebSocket because plain `text/event-stream` works trivially on top of blocking IO; no upgrade handshake or framing layer needed.
- Live-reload client script auto-injected before `</body>` whenever `index.html` is served (case-insensitive match; appends if no body tag).
- SPA fallback: any unmatched GET that does not resolve to a real file under the dist root returns `index.html`.
- MIME types for `.js` / `.mjs` / `.cjs`, `.css`, `.html`, `.json`, `.map` (source maps → `application/json`), `.svg` / `.png` / `.jpg` / `.gif` / `.webp` / `.avif` / `.ico`, `.woff` / `.woff2` / `.ttf` / `.otf` / `.eot`, `.wasm`, `.txt`, `.xml`. Unknown extensions fall back to `application/octet-stream`.
- Path traversal (`..`) refused with 403.
- Configurable host (default `127.0.0.1`) and port (default `4200`, `0` for ephemeral).
- New `NgcError::ServeError` variant — all errors go through `crates/diagnostics` as required.
- Decoupled from the watcher (issue #24): the server takes a `mpsc::Receiver<ReloadEvent>` and forwards events to all connected SSE clients. `DevServer::trigger_reload()` is the test/tooling entry point.

## Test coverage

- 11 unit tests in the crate covering MIME lookup, live-reload script injection (with/without/uppercase body tag), URL decode, path-traversal rejection, and config builders.
- 10 integration tests in `crates/dev-server/tests/integration.rs` driving a real `tiny_http` instance on an ephemeral port through a hand-rolled HTTP/1.1 client. Covers GET `/`, GET `/index.html`, GET `/main.js`, GET `/main.js.map`, GET `/styles.css`, GET nested asset, SPA fallback for unknown route, 403 for `..`, end-to-end SSE round-trip (`trigger_reload` → `event: reload` line on the wire), and unknown-extension → `application/octet-stream`.

## Deferred to issue #26

- `ngc-rs serve` CLI subcommand and flag parsing (`--host`, `--port`, `--open`).
- "Open browser on first build" behavior.
- Wiring the watcher (issue #24) `mpsc::Sender<RebuildEvent>` into the dev server's `mpsc::Receiver<ReloadEvent>`.
- End-to-end DoD against treasr-frontend (browser refresh < 1s).

## Verification

`cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` all clean locally.

## Test plan

- [ ] CI: `cargo test --workspace` green
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI: `cargo fmt --check` clean
