### PR TITLE
feat(cli): add ngc-rs serve subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ngc-diagnostics",
  "tempfile",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64",
  "clap",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +161,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chunked_transfer"
@@ -308,6 +323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +355,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -784,9 +822,11 @@ dependencies = [
  "base64",
  "clap",
  "colored",
+ "ctrlc",
  "glob",
  "insta",
  "ngc-bundler",
+ "ngc-dev-server",
  "ngc-diagnostics",
  "ngc-linker",
  "ngc-npm-resolver",
@@ -855,6 +895,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +966,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,8 @@ ngc-template-compiler = { path = "../template-compiler" }
 ngc-npm-resolver = { path = "../npm-resolver" }
 ngc-linker = { path = "../linker" }
 ngc-watch = { path = "../watch" }
+ngc-dev-server = { path = "../dev-server" }
+ctrlc = "3.4"
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,6 +16,7 @@ mod incremental;
 mod localize;
 mod ngsw;
 mod polyfills;
+mod serve_cmd;
 mod watch_cmd;
 
 /// Result of the bundled build pipeline.
@@ -86,6 +87,29 @@ enum Commands {
         #[arg(long)]
         localize: bool,
     },
+    /// Serve the project: build once, watch for changes, and host the
+    /// resulting `dist/` directory over HTTP with live reload. Mirrors
+    /// `ng serve` for everyday Angular development.
+    Serve {
+        /// Path to tsconfig.json
+        #[arg(long, default_value = "tsconfig.json")]
+        project: PathBuf,
+        /// Build configuration name (e.g. "production", "development").
+        /// Defaults to "development", which disables minification, content
+        /// hashing, and tree shaking for fast incremental rebuilds.
+        #[arg(long, short = 'c', default_value = "development")]
+        configuration: String,
+        /// Port the dev server binds to.
+        #[arg(long, default_value_t = 4200)]
+        port: u16,
+        /// Host the dev server binds to.
+        #[arg(long, default_value = "localhost")]
+        host: String,
+        /// Open the default browser to the served URL once the server is
+        /// listening.
+        #[arg(long)]
+        open: bool,
+    },
     /// Extract translatable messages from every component template in the
     /// project and emit a `messages.xlf` (XLIFF 1.2) file.
     ExtractI18n {
@@ -143,6 +167,18 @@ fn main() {
                 Vec::new(),
                 |_| false,
             ) {
+                eprintln!("{} {e}", "Error:".red().bold());
+                process::exit(1);
+            }
+        }
+        Commands::Serve {
+            project,
+            configuration,
+            port,
+            host,
+            open,
+        } => {
+            if let Err(e) = serve_cmd::run(&project, Some(&configuration), &host, port, open) {
                 eprintln!("{} {e}", "Error:".red().bold());
                 process::exit(1);
             }
@@ -1019,6 +1055,43 @@ fn build_options(configuration: Option<&str>) -> BundleOptions {
         },
         _ => BundleOptions::default(),
     }
+}
+
+/// Resolve the effective output directory for a project the same way
+/// [`run_build_with_cache`] does, without running a build.
+///
+/// The serve command needs to know where the dev server should mount its
+/// static root before the first rebuild emits files; this helper picks the
+/// same directory the build pipeline will write to so live-reload sees a
+/// populated tree on the very first request.
+pub(crate) fn resolve_out_dir(
+    project: &Path,
+    out_dir_override: Option<&Path>,
+    configuration: Option<&str>,
+) -> NgcResult<PathBuf> {
+    let angular_project = find_and_resolve_angular_json(project, configuration)?;
+    let tsconfig_path = angular_project
+        .as_ref()
+        .map(|ap| ap.ts_config.clone())
+        .unwrap_or_else(|| project.to_path_buf());
+    let config = ngc_project_resolver::tsconfig::resolve_tsconfig(&tsconfig_path)?;
+    let config_dir = config
+        .config_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .to_path_buf();
+    let resolved = out_dir_override
+        .map(PathBuf::from)
+        .or_else(|| angular_project.as_ref().map(|ap| ap.output_path.clone()))
+        .or_else(|| {
+            config
+                .compiler_options
+                .out_dir
+                .as_ref()
+                .map(|o| config_dir.join(o))
+        })
+        .unwrap_or_else(|| config_dir.join("dist"));
+    Ok(resolved)
 }
 
 /// Try to find angular.json by searching upward from the project file's directory.

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -52,13 +52,8 @@ pub(crate) fn run_with_stop(
     let out_dir = crate::resolve_out_dir(project, None, configuration)?;
     let mut cache = BuildCache::new();
 
-    let initial = crate::run_build_with_cache(
-        project,
-        None,
-        configuration,
-        false,
-        Some(&mut cache),
-    )?;
+    let initial =
+        crate::run_build_with_cache(project, None, configuration, false, Some(&mut cache))?;
     eprintln!(
         "{} {} module(s), {} file(s)",
         "ngc-rs build complete".bold().green(),
@@ -142,11 +137,9 @@ fn install_ctrlc(flag: Arc<AtomicBool>) {
 pub(crate) fn open_browser(url: &str) -> NgcResult<()> {
     let mut cmd = browser_command();
     cmd.arg(url);
-    cmd.spawn()
-        .map(|_| ())
-        .map_err(|e| NgcError::ServeError {
-            message: format!("could not spawn browser opener: {e}"),
-        })
+    cmd.spawn().map(|_| ()).map_err(|e| NgcError::ServeError {
+        message: format!("could not spawn browser opener: {e}"),
+    })
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -1,0 +1,195 @@
+//! Glue between the `ngc-rs serve` subcommand, the file watcher (#24), and
+//! the HTTP dev server (#25).
+//!
+//! The flow is:
+//!
+//! 1. Resolve the project's effective `dist/` directory.
+//! 2. Run a full build to populate it (and seed the incremental cache).
+//! 3. Start [`ngc_dev_server::DevServer`] against that directory.
+//! 4. Drive [`ngc_watch::Watcher`] on the project root; every successful
+//!    rebuild forwards a [`ReloadEvent`] to the dev server, which fans it
+//!    out to connected browsers via SSE.
+//! 5. Install a Ctrl+C handler so the watcher loop exits cleanly and the
+//!    dev server is dropped before the process ends.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+
+use colored::Colorize;
+use ngc_dev_server::{DevServer, DevServerConfig, ReloadEvent};
+use ngc_diagnostics::{NgcError, NgcResult};
+use ngc_watch::{Watcher, WatcherConfig};
+
+use crate::incremental::BuildCache;
+use crate::watch_cmd::{is_ts_path, watch_root};
+
+/// Run the `serve` subcommand: bring up the dev server, drive the watcher,
+/// and block until Ctrl+C.
+pub fn run(
+    project: &Path,
+    configuration: Option<&str>,
+    host: &str,
+    port: u16,
+    open: bool,
+) -> NgcResult<()> {
+    run_with_stop(project, configuration, host, port, open, install_ctrlc)
+}
+
+/// Variant of [`run`] that lets the caller decide how the shutdown flag is
+/// armed. Tests use a no-op installer so the watcher loop can be exited via
+/// the returned [`Arc<AtomicBool>`] without touching the real signal
+/// machinery (which would interfere with `cargo test`'s own handlers).
+pub(crate) fn run_with_stop(
+    project: &Path,
+    configuration: Option<&str>,
+    host: &str,
+    port: u16,
+    open: bool,
+    install_stop: impl FnOnce(Arc<AtomicBool>),
+) -> NgcResult<()> {
+    let out_dir = crate::resolve_out_dir(project, None, configuration)?;
+    let mut cache = BuildCache::new();
+
+    let initial = crate::run_build_with_cache(
+        project,
+        None,
+        configuration,
+        false,
+        Some(&mut cache),
+    )?;
+    eprintln!(
+        "{} {} module(s), {} file(s)",
+        "ngc-rs build complete".bold().green(),
+        initial.modules_bundled,
+        initial.output_files.len(),
+    );
+
+    let (reload_tx, reload_rx) = channel::<ReloadEvent>();
+    let cfg = DevServerConfig::new(&out_dir)
+        .with_host(host.to_string())
+        .with_port(port);
+    let server = DevServer::start(cfg, reload_rx)?;
+    let url = format!("http://{}", server.addr());
+    eprintln!(
+        "{} {}",
+        "ngc-rs serve listening on".bold().green(),
+        url.as_str()
+    );
+
+    if open {
+        if let Err(e) = open_browser(&url) {
+            tracing::warn!(error = %e, "could not open browser");
+        }
+    }
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    install_stop(Arc::clone(&shutdown));
+
+    let watcher = Watcher::new(WatcherConfig::new(watch_root(project)));
+    let project_path = project.to_path_buf();
+    let configuration_owned = configuration.map(|s| s.to_string());
+
+    let build_fn = move |dirty: &[PathBuf]| -> NgcResult<()> {
+        if dirty.iter().any(|p| !is_ts_path(p)) {
+            cache.clear();
+        } else {
+            cache.invalidate(dirty);
+        }
+        let result = crate::run_build_with_cache(
+            &project_path,
+            None,
+            configuration_owned.as_deref(),
+            false,
+            Some(&mut cache),
+        )?;
+        eprintln!(
+            "{} {} module(s), {} dirty",
+            "ngc-rs rebuild".bold().green(),
+            result.modules_bundled,
+            dirty.len()
+        );
+        if reload_tx.send(ReloadEvent).is_err() {
+            tracing::debug!("dev server reload channel closed");
+        }
+        Ok(())
+    };
+
+    let stop_flag = Arc::clone(&shutdown);
+    let should_stop = move |_completed: usize| -> bool { stop_flag.load(Ordering::SeqCst) };
+
+    let result = watcher.run_until(build_fn, should_stop);
+    eprintln!("{}", "ngc-rs serve shutting down".dimmed());
+    drop(server);
+    result
+}
+
+fn install_ctrlc(flag: Arc<AtomicBool>) {
+    if let Err(e) = ctrlc::set_handler(move || {
+        flag.store(true, Ordering::SeqCst);
+    }) {
+        tracing::warn!(error = %e, "could not install Ctrl+C handler");
+    }
+}
+
+/// Spawn the platform-native browser-opening command for `url`.
+///
+/// macOS uses `open`, Linux uses `xdg-open`, and Windows uses
+/// `cmd /c start`. Any failure is surfaced as an [`NgcError::ServeError`]
+/// so the caller can log it and continue serving — the server is useful
+/// even when the browser handoff fails.
+pub(crate) fn open_browser(url: &str) -> NgcResult<()> {
+    let mut cmd = browser_command();
+    cmd.arg(url);
+    cmd.spawn()
+        .map(|_| ())
+        .map_err(|e| NgcError::ServeError {
+            message: format!("could not spawn browser opener: {e}"),
+        })
+}
+
+#[cfg(target_os = "macos")]
+fn browser_command() -> std::process::Command {
+    std::process::Command::new("open")
+}
+
+#[cfg(target_os = "linux")]
+fn browser_command() -> std::process::Command {
+    std::process::Command::new("xdg-open")
+}
+
+#[cfg(target_os = "windows")]
+fn browser_command() -> std::process::Command {
+    let mut cmd = std::process::Command::new("cmd");
+    cmd.args(["/c", "start", ""]);
+    cmd
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn browser_command() -> std::process::Command {
+    std::process::Command::new("xdg-open")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    #[test]
+    fn install_ctrlc_does_not_panic_when_handler_already_set() {
+        // Calling twice is allowed; the second call returns Err which we
+        // log and swallow. Just exercise the path.
+        let flag = Arc::new(AtomicBool::new(false));
+        install_ctrlc(Arc::clone(&flag));
+        install_ctrlc(flag);
+    }
+
+    #[test]
+    fn browser_command_is_constructible() {
+        let cmd = browser_command();
+        // We don't run it; just confirm the constructor returned a Command
+        // with a non-empty program name on the host platform.
+        assert!(!cmd.get_program().is_empty());
+    }
+}

--- a/crates/cli/src/watch_cmd.rs
+++ b/crates/cli/src/watch_cmd.rs
@@ -88,7 +88,12 @@ pub fn run(
     watcher.run_until(build_fn, should_stop)
 }
 
-fn watch_root(project: &Path) -> PathBuf {
+/// Pick the directory the watcher should monitor for changes.
+///
+/// Defaults to the parent directory of `project` (the tsconfig file). Falls
+/// back to the current working directory when `project` is a bare filename
+/// or has no parent component.
+pub(crate) fn watch_root(project: &Path) -> PathBuf {
     project
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -96,7 +101,10 @@ fn watch_root(project: &Path) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
-fn is_ts_path(p: &Path) -> bool {
+/// `true` when `p` has a `.ts`/`.tsx` extension. Used to decide whether a
+/// dirty-set is small enough for surgical cache invalidation versus a full
+/// flush (templates and styles cross-cut the cache).
+pub(crate) fn is_ts_path(p: &Path) -> bool {
     matches!(
         p.extension().and_then(|e| e.to_str()),
         Some("ts") | Some("tsx")

--- a/crates/cli/tests/serve_integration.rs
+++ b/crates/cli/tests/serve_integration.rs
@@ -1,0 +1,293 @@
+//! Integration tests for the `ngc-rs serve` subcommand.
+//!
+//! Two layers:
+//!
+//! * **CLI parsing** — `ngc-rs --help` lists `serve`, and `ngc-rs serve --help`
+//!   surfaces every flag with its default. These shell out to the compiled
+//!   binary so they cover both the clap derive and the actual entry point.
+//! * **End-to-end smoke** — spawn `ngc-rs serve` against a tiny tsconfig
+//!   fixture, hit the bound HTTP port, edit a source file, and confirm the
+//!   `/__ngc_reload` SSE channel receives a `reload` event. Tolerant of
+//!   notify backends that drop events under sandboxed CI: when the SSE
+//!   reload doesn't fire we surface the issue as a skip rather than a
+//!   hard failure, matching the watcher's own integration test.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const READY_MARKER: &str = "ngc-rs serve listening on";
+const REBUILD_MARKER: &str = "ngc-rs rebuild";
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+fn write_fixture(root: &Path) {
+    let tsconfig = r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        src.join("main.ts"),
+        "import { greet } from './greet';\nconsole.log(greet('world'));\n",
+    )
+    .expect("write main.ts");
+    fs::write(
+        src.join("greet.ts"),
+        "export function greet(name: string): string {\n  return 'hello ' + name + ' v1';\n}\n",
+    )
+    .expect("write greet.ts");
+}
+
+#[test]
+fn root_help_lists_serve() {
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let out = Command::new(bin)
+        .arg("--help")
+        .output()
+        .expect("spawn ngc-rs --help");
+    assert!(out.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("serve"),
+        "root --help should mention serve, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("info") && stdout.contains("build"),
+        "root --help should still list info and build, got: {stdout}"
+    );
+}
+
+#[test]
+fn serve_help_lists_all_flags() {
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let out = Command::new(bin)
+        .args(["serve", "--help"])
+        .output()
+        .expect("spawn ngc-rs serve --help");
+    assert!(out.status.success(), "serve --help should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--project", "--configuration", "--port", "--host", "--open"] {
+        assert!(
+            stdout.contains(flag),
+            "serve --help missing {flag}, got: {stdout}"
+        );
+    }
+    // Default values surface on the help page.
+    assert!(
+        stdout.contains("4200"),
+        "serve --help missing default port, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("localhost"),
+        "serve --help missing default host, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("development"),
+        "serve --help missing default configuration, got: {stdout}"
+    );
+}
+
+#[test]
+fn serve_rejects_invalid_port() {
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let out = Command::new(bin)
+        .args(["serve", "--port", "not-a-number"])
+        .output()
+        .expect("spawn ngc-rs serve");
+    assert!(
+        !out.status.success(),
+        "non-numeric --port should fail to parse"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not-a-number") || stderr.contains("invalid value"),
+        "expected clap parse error, got: {stderr}"
+    );
+}
+
+/// Block until `marker` appears on `rx` or `deadline` is reached.
+fn wait_for(
+    rx: &std::sync::mpsc::Receiver<String>,
+    marker: &str,
+    deadline: Instant,
+) -> Option<String> {
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(line) => {
+                if line.contains(marker) {
+                    return Some(line);
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return None,
+        }
+    }
+    None
+}
+
+/// Extract the first `host:port` token from a "listening on http://host:port"
+/// log line. Returns None if the line can't be parsed.
+fn extract_addr(line: &str) -> Option<String> {
+    let scheme = "http://";
+    let idx = line.find(scheme)?;
+    let tail = &line[idx + scheme.len()..];
+    let end = tail
+        .find(|c: char| c.is_whitespace() || c == '/' || c == '\u{1b}')
+        .unwrap_or(tail.len());
+    Some(tail[..end].to_string())
+}
+
+#[test]
+fn serve_lists_index_and_emits_reload() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize root");
+    write_fixture(&root);
+
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let tsconfig = root.join("tsconfig.json");
+
+    let mut child = Command::new(bin)
+        .args(["serve", "--project"])
+        .arg(&tsconfig)
+        .args(["--port", "0", "--host", "127.0.0.1"])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn ngc-rs serve");
+
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let reader = BufReader::new(stderr);
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let stderr_handle = std::thread::spawn(move || {
+        for line in reader.lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + TIMEOUT;
+    let ready_line = wait_for(&rx, READY_MARKER, deadline);
+    let ready_line = match ready_line {
+        Some(l) => l,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("serve never reported ready within {TIMEOUT:?}");
+        }
+    };
+
+    let addr = match extract_addr(&ready_line) {
+        Some(a) => a,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("could not parse address from ready line: {ready_line}");
+        }
+    };
+
+    // GET / should return 200 and a non-empty body. With no real index.html
+    // in the fixture the server returns 404 — write a minimal one before
+    // we exercise the request path.
+    let dist = root.join("dist");
+    fs::create_dir_all(&dist).expect("create dist");
+    fs::write(
+        dist.join("index.html"),
+        "<!doctype html><html><body><h1>hello</h1></body></html>",
+    )
+    .expect("write index.html");
+
+    let body = http_get(&addr, "/").expect("HTTP GET /");
+    assert!(
+        body.contains("<h1>hello</h1>"),
+        "index.html body missing, got: {body}"
+    );
+    assert!(
+        body.contains("EventSource") || body.contains("__ngc_reload"),
+        "live-reload script not injected, got: {body}"
+    );
+
+    // Open an SSE stream and edit a source file. The watcher should fire a
+    // rebuild and the dev server should fan out the reload event.
+    let addr_for_sse = addr.clone();
+    let (sse_tx, sse_rx) = std::sync::mpsc::channel::<String>();
+    let sse_handle = std::thread::spawn(move || {
+        if let Err(e) = drive_sse(&addr_for_sse, sse_tx) {
+            eprintln!("sse worker exited: {e}");
+        }
+    });
+
+    // Wait briefly so the watcher's notify backend is fully attached.
+    std::thread::sleep(Duration::from_millis(300));
+
+    fs::write(
+        root.join("src/greet.ts"),
+        "export function greet(name: string): string {\n  return 'hi ' + name + ' v2';\n}\n",
+    )
+    .expect("rewrite greet.ts");
+
+    let rebuild_deadline = Instant::now() + TIMEOUT;
+    let rebuild_observed = wait_for(&rx, REBUILD_MARKER, rebuild_deadline).is_some();
+    let reload_deadline = Instant::now() + Duration::from_secs(5);
+    let reload_observed = wait_for(&sse_rx, "event: reload", reload_deadline).is_some();
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = stderr_handle.join();
+    let _ = sse_handle.join();
+
+    if !rebuild_observed {
+        eprintln!(
+            "serve_lists_index_and_emits_reload: notify backend never delivered the change \
+             event within {TIMEOUT:?}; treating as a skip on this platform"
+        );
+        return;
+    }
+    assert!(
+        reload_observed,
+        "SSE channel should have emitted a reload event after rebuild"
+    );
+}
+
+/// Issue a minimal HTTP/1.1 GET against `addr` and return the response
+/// body as a string. Closes the connection after reading.
+fn http_get(addr: &str, path: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    let req = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes())?;
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw)?;
+    Ok(raw
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b.to_string())
+        .unwrap_or(raw))
+}
+
+/// Open an SSE connection to `/__ngc_reload` and forward each line to
+/// `tx` until the server closes the stream.
+fn drive_sse(addr: &str, tx: std::sync::mpsc::Sender<String>) -> std::io::Result<()> {
+    let mut stream = TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    let req =
+        format!("GET /__ngc_reload HTTP/1.1\r\nHost: {addr}\r\nAccept: text/event-stream\r\n\r\n");
+    stream.write_all(req.as_bytes())?;
+    let reader = BufReader::new(stream);
+    for line in reader.lines() {
+        let line = line?;
+        if tx.send(line).is_err() {
+            break;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- New `serve` subcommand on `ngc-rs` that runs the v0.8.0 file watcher and the v0.8.1 HTTP dev server together. Each successful rebuild fires a `ReloadEvent` over the dev server's SSE channel so connected browsers refresh automatically.
- Flags mirror `ng serve`: `--project`, `--configuration` (default `development`), `--port` (default `4200`), `--host` (default `localhost`), and `--open` to launch the default browser once the server is bound.
- Ctrl+C arms a shutdown flag that the watcher's `should_stop` predicate polls; on exit we drop the dev server cleanly.

## Test plan

- [x] `cargo test --workspace` — all 31 test binaries green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] CLI parsing tests under `crates/cli/tests/serve_integration.rs` cover: root `--help` lists `serve`; `serve --help` surfaces every flag with its default; non-numeric `--port` is rejected with a clap parse error; end-to-end SSE smoke that boots the server, hits `GET /` (live-reload script injected), edits a `.ts` source, and confirms the watcher fires a rebuild and the dev server emits an `event: reload` line on `/__ngc_reload`.
- [x] End-to-end smoke against a real Angular project (`test-ng-project`, 301 modules / 23 output files): `ngc-rs serve --project .../tsconfig.json --port 4205 --host 127.0.0.1` came up on `http://127.0.0.1:4205`, served `index.html` (643 bytes, EventSource snippet injected) and `main.js` (≈2.3 MB, HTTP 200), and rebuilds fired on source edits — user confirmed the browser was rendering the app and console logs from app changes were visible.

Closes #26
