### PR TITLE
feat(builder): ng serve adapter for @angular/build:dev-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ngc-diagnostics",
  "tempfile",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64",
  "clap",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -92,23 +92,31 @@ pub(crate) fn run_with_stop(
         } else {
             cache.invalidate(dirty);
         }
-        let result = crate::run_build_with_cache(
+        let outcome = crate::run_build_with_cache(
             &project_path,
             None,
             configuration_owned.as_deref(),
             false,
             Some(&mut cache),
-        )?;
-        eprintln!(
-            "{} {} module(s), {} dirty",
-            "ngc-rs rebuild".bold().green(),
-            result.modules_bundled,
-            dirty.len()
         );
-        if reload_tx.send(ReloadEvent).is_err() {
-            tracing::debug!("dev server reload channel closed");
+        match outcome {
+            Ok(result) => {
+                eprintln!(
+                    "{} {} module(s), {} dirty",
+                    "ngc-rs rebuild".bold().green(),
+                    result.modules_bundled,
+                    dirty.len()
+                );
+                if reload_tx.send(ReloadEvent).is_err() {
+                    tracing::debug!("dev server reload channel closed");
+                }
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("{} {e}", "ngc-rs rebuild failed:".bold().red());
+                Err(e)
+            }
         }
-        Ok(())
     };
 
     let stop_flag = Arc::clone(&shutdown);

--- a/packages/builder/.gitignore
+++ b/packages/builder/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,0 +1,78 @@
+# @ngc-rs/builder
+
+Angular `@angular-devkit/architect` builders backed by [ngc-rs](https://github.com/lukekania/ngc-rs).
+
+## Builders
+
+| Name         | Status              |
+| ------------ | ------------------- |
+| `dev-server` | Implemented (#27)   |
+| `application`| Reserved for #28    |
+
+## Usage
+
+Install:
+
+```sh
+npm install --save-dev @ngc-rs/builder
+```
+
+Edit `angular.json`, swap the `serve` target's builder:
+
+```json
+{
+  "projects": {
+    "my-app": {
+      "architect": {
+        "serve": {
+          "builder": "@ngc-rs/builder:dev-server",
+          "options": {
+            "buildTarget": "my-app:build:development",
+            "port": 4200,
+            "host": "localhost",
+            "proxyConfig": "proxy.conf.json"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Then run `ng serve` as usual.
+
+## Binary discovery
+
+The builder spawns the `ngc-rs` binary in this priority order:
+
+1. `ngcRsBinary` builder option (resolved relative to the workspace root).
+2. `NGC_RS_BINARY` environment variable.
+3. `<workspaceRoot>/target/release/ngc-rs` (and parent directories) — convenient
+   for local development against a Cargo workspace.
+4. `ngc-rs` from `PATH`.
+
+## Proxy support
+
+`proxyConfig` is implemented in the Node shim rather than in `ngc-rs serve`.
+When set, the shim listens on the user-configured `host`/`port`, spawns
+`ngc-rs serve` on an ephemeral loopback port, and forwards requests either to
+the configured proxy target or back to `ngc-rs`. Both the webpack-style map
+form and Angular's array form (`{ context, target, ... }`) are supported.
+WebSocket upgrades are not yet forwarded.
+
+## Unsupported options
+
+`ssl`, `sslKey`, `sslCert`, `hmr`, `define`, `headers`, `liveReload`, `watch`,
+`poll`, `inspect`, `prebundle`, `allowedHosts`, `servePath` and `verbose` are
+not yet supported. `ssl=true` produces a hard error rather than silently
+falling back to HTTP. The remaining options are accepted only in the schema
+fields listed in `schemas/dev-server.json`.
+
+## Development
+
+```sh
+cd packages/builder
+npm install
+npm run build
+npm test
+```

--- a/packages/builder/builders.json
+++ b/packages/builder/builders.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../node_modules/@angular-devkit/architect/src/builders-schema.json",
+  "builders": {
+    "dev-server": {
+      "implementation": "./dist/serve/builder",
+      "schema": "./schemas/dev-server.json",
+      "description": "Dev server backed by ngc-rs."
+    }
+  }
+}

--- a/packages/builder/package-lock.json
+++ b/packages/builder/package-lock.json
@@ -1,0 +1,1439 @@
+{
+  "name": "@ngc-rs/builder",
+  "version": "0.8.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ngc-rs/builder",
+      "version": "0.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/architect": "~0.2102.0",
+        "@angular-devkit/core": "^21.2.0",
+        "rxjs": "^7.8.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "~5.9.3",
+        "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@angular-devkit/architect": {
+      "version": "0.2102.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.8.tgz",
+      "integrity": "sha512-b7su7AHIO5F2I6InEu/Bx/oXvGjdCP7kos2tGX73he/lPrTuizooils62OgAzgJ2UeKscyRNUjBPieFCy6XvHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "21.2.8",
+        "rxjs": "7.8.2"
+      },
+      "bin": {
+        "architect": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/core": {
+      "version": "21.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.8.tgz",
+      "integrity": "sha512-DyxCILaaic/hfcfiBjAC/SdKE1ybSQIrU62/K5Msn3gZtThZj/T7cG0VHfbmpEFcgYkrQ9caUt6MCg8OoOVDzw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.2",
+        "source-map": "0.7.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ngc-rs/builder",
+  "version": "0.8.3",
+  "description": "Angular @angular-devkit/architect builders backed by ngc-rs.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukekania/ngc-rs",
+    "directory": "packages/builder"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "builders": "./builders.json",
+  "files": [
+    "dist",
+    "schemas",
+    "builders.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@angular-devkit/architect": "~0.2102.0",
+    "@angular-devkit/core": "^21.2.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "~5.9.3",
+    "vitest": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=20.11.0"
+  }
+}

--- a/packages/builder/schemas/dev-server.json
+++ b/packages/builder/schemas/dev-server.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "ngc-rs dev-server target",
+  "description": "Dev-server builder options for @ngc-rs/builder. Mirrors a subset of @angular/build:dev-server so projects can swap one line in angular.json. Anything not listed under properties is intentionally not yet supported and is rejected at validation time.",
+  "type": "object",
+  "properties": {
+    "buildTarget": {
+      "type": "string",
+      "description": "Build builder target to derive options from in the format `project:target[:configuration]`. Currently used only to resolve the build configuration name.",
+      "pattern": "^[^:\\s]*:[^:\\s]*(:[^\\s]+)?$"
+    },
+    "port": {
+      "type": "number",
+      "description": "Port the dev server listens on.",
+      "default": 4200
+    },
+    "host": {
+      "type": "string",
+      "description": "Host the dev server binds to.",
+      "default": "localhost"
+    },
+    "open": {
+      "type": "boolean",
+      "description": "Open the configured URL in the default browser once the server is ready.",
+      "default": false,
+      "alias": "o"
+    },
+    "ssl": {
+      "type": "boolean",
+      "description": "Serve over HTTPS. Currently unsupported by ngc-rs serve. Setting this to true fails the build with an explanatory error.",
+      "default": false
+    },
+    "sslKey": {
+      "type": "string",
+      "description": "SSL key path. Currently unsupported."
+    },
+    "sslCert": {
+      "type": "string",
+      "description": "SSL certificate path. Currently unsupported."
+    },
+    "proxyConfig": {
+      "type": "string",
+      "description": "Path to a JSON proxy configuration file. The shim hosts an in-process reverse proxy and forwards matching requests to the configured target. See https://angular.dev/tools/cli/serve#proxying-to-a-backend-server."
+    },
+    "project": {
+      "type": "string",
+      "description": "Path to the project's tsconfig.json passed to ngc-rs serve. Defaults to `tsconfig.json` in the workspace root.",
+      "default": "tsconfig.json"
+    },
+    "ngcRsBinary": {
+      "type": "string",
+      "description": "Optional override for the ngc-rs binary path. If unset, the shim looks at the NGC_RS_BINARY env var, then a workspace-relative target/release/ngc-rs, and finally PATH."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/builder/src/build/README.md
+++ b/packages/builder/src/build/README.md
@@ -1,0 +1,1 @@
+Reserved for the build builder added by issue #28.

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -1,0 +1,2 @@
+export { default as devServerBuilder } from './serve/builder';
+export type { DevServerOptions } from './serve/options';

--- a/packages/builder/src/serve/__tests__/errors.test.ts
+++ b/packages/builder/src/serve/__tests__/errors.test.ts
@@ -35,6 +35,25 @@ describe('parseDiagnostics', () => {
     expect(first?.message).toContain('failed to resolve');
   });
 
+  it('extracts the file path from ngc-rs rebuild-failed lines', () => {
+    const out = parseDiagnostics(
+      'ngc-rs rebuild failed: template compile error in /a/b/app.ts: parser panicked: Unterminated string',
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.file).toBe('/a/b/app.ts');
+    expect(out[0]?.message).toContain('Unterminated string');
+  });
+
+  it('captures line/col when present in rebuild-failed messages', () => {
+    const out = parseDiagnostics(
+      'ngc-rs rebuild failed: error in /a/b/app.ts:42:7 unexpected token',
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.file).toBe('/a/b/app.ts');
+    expect(out[0]?.line).toBe(42);
+    expect(out[0]?.column).toBe(7);
+  });
+
   it('returns nothing for purely informational output', () => {
     expect(parseDiagnostics('ngc-rs build complete 12 modules')).toHaveLength(0);
   });

--- a/packages/builder/src/serve/__tests__/errors.test.ts
+++ b/packages/builder/src/serve/__tests__/errors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDiagnostics, stripAnsi, summarizeDiagnostics } from '../errors';
+
+describe('parseDiagnostics', () => {
+  it('extracts file/line/column from a typical compiler line', () => {
+    const out = parseDiagnostics(
+      'src/app/hello.component.ts:12:5 - error TS2304: Cannot find name "Foo".',
+    );
+    expect(out).toHaveLength(1);
+    const first = out[0];
+    expect(first).toBeDefined();
+    expect(first?.file).toBe('src/app/hello.component.ts');
+    expect(first?.line).toBe(12);
+    expect(first?.column).toBe(5);
+    expect(first?.message).toContain('Cannot find name');
+  });
+
+  it('strips ANSI color codes before parsing', () => {
+    const ansi = '\u001b[31msrc/a.ts:3:1 -\u001b[0m parse error here';
+    const out = parseDiagnostics(ansi);
+    expect(out).toHaveLength(1);
+    const first = out[0];
+    expect(first).toBeDefined();
+    expect(first?.file).toBe('src/a.ts');
+    expect(first?.line).toBe(3);
+  });
+
+  it('captures bare Error: lines without coordinates', () => {
+    const out = parseDiagnostics('Error: failed to resolve module "x"');
+    expect(out).toHaveLength(1);
+    const first = out[0];
+    expect(first).toBeDefined();
+    expect(first?.file).toBeNull();
+    expect(first?.message).toContain('failed to resolve');
+  });
+
+  it('returns nothing for purely informational output', () => {
+    expect(parseDiagnostics('ngc-rs build complete 12 modules')).toHaveLength(0);
+  });
+});
+
+describe('summarizeDiagnostics', () => {
+  it('formats a multi-diagnostic block with file:line:col prefixes', () => {
+    const summary = summarizeDiagnostics([
+      { file: 'a.ts', line: 1, column: 2, message: 'oops' },
+      { file: null, line: null, column: null, message: 'bare msg' },
+    ]);
+    expect(summary).toContain('a.ts:1:2 oops');
+    expect(summary).toContain('bare msg');
+  });
+
+  it('returns a fallback string when no diagnostics were parsed', () => {
+    expect(summarizeDiagnostics([])).toMatch(/no parseable diagnostics/);
+  });
+});
+
+describe('stripAnsi', () => {
+  it('removes color escapes', () => {
+    expect(stripAnsi('\u001b[1mhi\u001b[0m')).toBe('hi');
+  });
+});

--- a/packages/builder/src/serve/__tests__/locate.test.ts
+++ b/packages/builder/src/serve/__tests__/locate.test.ts
@@ -1,0 +1,73 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { locateNgcRs } from '../locate';
+
+function makeWorkspace(): { dir: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ngcrs-locate-'));
+  return {
+    dir,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe('locateNgcRs', () => {
+  it('honors an explicit option override', () => {
+    const ws = makeWorkspace();
+    try {
+      const out = locateNgcRs(ws.dir, '/explicit/path/ngc-rs', {});
+      expect(out).toEqual({ binary: '/explicit/path/ngc-rs', source: 'option' });
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('resolves a relative option path against the workspace root', () => {
+    const ws = makeWorkspace();
+    try {
+      const out = locateNgcRs(ws.dir, './bin/ngc-rs', {});
+      expect(out.binary).toBe(path.join(ws.dir, 'bin', 'ngc-rs'));
+      expect(out.source).toBe('option');
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('reads NGC_RS_BINARY from env when no option is set', () => {
+    const ws = makeWorkspace();
+    try {
+      const out = locateNgcRs(ws.dir, null, { NGC_RS_BINARY: '/from/env/ngc-rs' });
+      expect(out).toEqual({ binary: '/from/env/ngc-rs', source: 'env' });
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('falls through to PATH when no candidate exists', () => {
+    const ws = makeWorkspace();
+    try {
+      const out = locateNgcRs(ws.dir, null, {});
+      expect(out.source).toBe('path');
+      expect(out.binary).toMatch(/ngc-rs/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it('finds an executable under <workspace>/target/release', () => {
+    const ws = makeWorkspace();
+    try {
+      const dir = path.join(ws.dir, 'target', 'release');
+      fs.mkdirSync(dir, { recursive: true });
+      const bin = path.join(dir, process.platform === 'win32' ? 'ngc-rs.exe' : 'ngc-rs');
+      fs.writeFileSync(bin, '#!/bin/sh\necho hi\n', { mode: 0o755 });
+      const out = locateNgcRs(ws.dir, null, {});
+      expect(out.source).toBe('workspace-target');
+      expect(out.binary).toBe(bin);
+    } finally {
+      ws.cleanup();
+    }
+  });
+});

--- a/packages/builder/src/serve/__tests__/options.test.ts
+++ b/packages/builder/src/serve/__tests__/options.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DevServerOptions,
+  OptionTranslationError,
+  formatUrl,
+  translateOptions,
+} from '../options';
+
+const base: Partial<DevServerOptions> = {
+  buildTarget: 'app:build:development',
+  port: 4200,
+  host: 'localhost',
+};
+
+describe('translateOptions', () => {
+  it('produces serve args with project, configuration, host, and port', () => {
+    const t = translateOptions(base, '/ws');
+    expect(t.args).toEqual([
+      'serve',
+      '--project',
+      'tsconfig.json',
+      '--configuration',
+      'development',
+      '--host',
+      'localhost',
+      '--port',
+      '4200',
+    ]);
+    expect(t.proxyEnabled).toBe(false);
+    expect(t.url).toBe('http://localhost:4200/');
+  });
+
+  it('drops configuration when buildTarget has only two segments', () => {
+    const t = translateOptions({ ...base, buildTarget: 'app:build' }, '/ws');
+    expect(t.args).not.toContain('--configuration');
+  });
+
+  it('uses 127.0.0.1:0 for the spawn target when proxyConfig is set', () => {
+    const t = translateOptions(
+      { ...base, proxyConfig: 'proxy.conf.json' },
+      '/ws',
+    );
+    expect(t.proxyEnabled).toBe(true);
+    expect(t.proxyConfigPath).toBe('/ws/proxy.conf.json');
+    expect(t.spawnHost).toBe('127.0.0.1');
+    expect(t.spawnPort).toBe(0);
+    expect(t.proxyHost).toBe('localhost');
+    expect(t.proxyPort).toBe(4200);
+    const portIdx = t.args.indexOf('--port');
+    expect(t.args[portIdx + 1]).toBe('0');
+  });
+
+  it('rejects ssl=true with a clear error', () => {
+    expect(() =>
+      translateOptions({ ...base, ssl: true }, '/ws'),
+    ).toThrow(OptionTranslationError);
+  });
+
+  it('rejects sslKey/sslCert', () => {
+    expect(() =>
+      translateOptions({ ...base, sslKey: '/k' }, '/ws'),
+    ).toThrow(OptionTranslationError);
+  });
+
+  it('honors a custom project tsconfig', () => {
+    const t = translateOptions(
+      { ...base, project: 'tsconfig.app.json' },
+      '/ws',
+    );
+    const projectIdx = t.args.indexOf('--project');
+    expect(t.args[projectIdx + 1]).toBe('tsconfig.app.json');
+  });
+
+  it('handles missing buildTarget by emitting no --configuration flag', () => {
+    const t = translateOptions({ port: 4200, host: 'localhost' }, '/ws');
+    expect(t.args).not.toContain('--configuration');
+  });
+});
+
+describe('formatUrl', () => {
+  it('replaces 0.0.0.0 with localhost for display', () => {
+    expect(formatUrl('0.0.0.0', 4200)).toBe('http://localhost:4200/');
+  });
+  it('keeps custom hostnames untouched', () => {
+    expect(formatUrl('app.local', 8080)).toBe('http://app.local:8080/');
+  });
+});

--- a/packages/builder/src/serve/__tests__/process.test.ts
+++ b/packages/builder/src/serve/__tests__/process.test.ts
@@ -1,0 +1,99 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { createNgcRsRunner, NgcEvent } from '../process';
+
+function writeFakeBin(script: string): { dir: string; bin: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ngcrs-fake-'));
+  const bin = path.join(dir, 'fake');
+  fs.writeFileSync(bin, `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+  return { dir, bin };
+}
+
+function collect(runner: ReturnType<typeof createNgcRsRunner>): {
+  events: NgcEvent[];
+  done: Promise<void>;
+} {
+  const events: NgcEvent[] = [];
+  const done = new Promise<void>((resolve) => {
+    runner.events.on('event', (ev: NgcEvent) => {
+      events.push(ev);
+      if (ev.type === 'exit') {
+        resolve();
+      }
+    });
+  });
+  return { events, done };
+}
+
+describe('createNgcRsRunner', () => {
+  it('detects the listening line and emits a ready event', async () => {
+    const { dir, bin } = writeFakeBin(
+      'echo "ngc-rs serve listening on http://127.0.0.1:54321" >&2; exit 0',
+    );
+    try {
+      const runner = createNgcRsRunner({ binary: bin, args: [], cwd: dir });
+      const { events, done } = collect(runner);
+      runner.start();
+      await done;
+      const ready = events.find((e) => e.type === 'ready');
+      expect(ready).toBeDefined();
+      if (ready && ready.type === 'ready') {
+        expect(ready.address).toBe('127.0.0.1:54321');
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses build failures from stderr', async () => {
+    const { dir, bin } = writeFakeBin(
+      'echo "ngc-rs build failed" >&2; echo "src/a.ts:5:3 - error TS123: nope" >&2; exit 1',
+    );
+    try {
+      const runner = createNgcRsRunner({ binary: bin, args: [], cwd: dir });
+      const { events, done } = collect(runner);
+      runner.start();
+      await done;
+      const failure = events.find((e) => e.type === 'rebuild-failure');
+      expect(failure).toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stop() terminates the child cleanly', async () => {
+    const { dir, bin } = writeFakeBin(
+      'trap "exit 0" INT; echo "ngc-rs serve listening on http://127.0.0.1:0"; while true; do sleep 0.1; done',
+    );
+    try {
+      const runner = createNgcRsRunner({ binary: bin, args: [], cwd: dir });
+      const { done } = collect(runner);
+      runner.start();
+      await new Promise((r) => setTimeout(r, 200));
+      const stopP = runner.stop();
+      await stopP;
+      await done;
+      expect(runner.isRunning()).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('forwards stdout lines as stdout events', async () => {
+    const { dir, bin } = writeFakeBin('echo first; echo second; exit 0');
+    try {
+      const runner = createNgcRsRunner({ binary: bin, args: [], cwd: dir });
+      const { events, done } = collect(runner);
+      runner.start();
+      await done;
+      const lines = events.filter((e) => e.type === 'stdout').map((e) => (e as { line: string }).line);
+      expect(lines).toContain('first');
+      expect(lines).toContain('second');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/builder/src/serve/__tests__/process.test.ts
+++ b/packages/builder/src/serve/__tests__/process.test.ts
@@ -64,6 +64,40 @@ describe('createNgcRsRunner', () => {
     }
   });
 
+  it('treats "ngc-rs rebuild failed" as failure, not success', async () => {
+    const { dir, bin } = writeFakeBin(
+      'echo "ngc-rs rebuild failed: parser panicked at /a/b.ts" >&2; exit 0',
+    );
+    try {
+      const runner = createNgcRsRunner({ binary: bin, args: [], cwd: dir });
+      const { events, done } = collect(runner);
+      runner.start();
+      await done;
+      const failure = events.find((e) => e.type === 'rebuild-failure');
+      const ok = events.find((e) => e.type === 'rebuild-success');
+      expect(failure).toBeDefined();
+      expect(ok).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats "ngc-rs rebuild N module(s)" as success', async () => {
+    const { dir, bin } = writeFakeBin(
+      'echo "ngc-rs rebuild 42 module(s), 1 dirty" >&2; exit 0',
+    );
+    try {
+      const runner = createNgcRsRunner({ binary: bin, args: [], cwd: dir });
+      const { events, done } = collect(runner);
+      runner.start();
+      await done;
+      const ok = events.find((e) => e.type === 'rebuild-success');
+      expect(ok).toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('stop() terminates the child cleanly', async () => {
     const { dir, bin } = writeFakeBin(
       'trap "exit 0" INT; echo "ngc-rs serve listening on http://127.0.0.1:0"; while true; do sleep 0.1; done',

--- a/packages/builder/src/serve/__tests__/proxy.test.ts
+++ b/packages/builder/src/serve/__tests__/proxy.test.ts
@@ -1,0 +1,190 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  loadProxyConfig,
+  matchRule,
+  normalizeProxyConfig,
+  ProxyConfigError,
+  rewritePath,
+  startProxyServer,
+} from '../proxy';
+
+const tmpFiles: string[] = [];
+
+afterEach(() => {
+  while (tmpFiles.length) {
+    const f = tmpFiles.pop();
+    if (f) {
+      try {
+        fs.rmSync(f, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+});
+
+function writeTmp(content: string, ext = '.json'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ngcrs-proxy-'));
+  tmpFiles.push(dir);
+  const file = path.join(dir, `proxy${ext}`);
+  fs.writeFileSync(file, content, 'utf8');
+  return file;
+}
+
+describe('normalizeProxyConfig', () => {
+  it('accepts the webpack-style map form', () => {
+    const rules = normalizeProxyConfig(
+      { '/api': { target: 'http://example.test', changeOrigin: true } },
+      'inline',
+    );
+    expect(rules).toHaveLength(1);
+    const first = rules[0];
+    expect(first).toBeDefined();
+    expect(first?.contexts).toEqual(['/api']);
+    expect(first?.target).toBe('http://example.test');
+    expect(first?.changeOrigin).toBe(true);
+  });
+
+  it('accepts the array form with context arrays', () => {
+    const rules = normalizeProxyConfig(
+      [{ context: ['/a', '/b'], target: 'http://t' }],
+      'inline',
+    );
+    expect(rules).toHaveLength(1);
+    expect(rules[0]?.contexts).toEqual(['/a', '/b']);
+  });
+
+  it('strips trailing wildcards from contexts', () => {
+    const rules = normalizeProxyConfig(
+      { '/api/*': { target: 'http://t' } },
+      'inline',
+    );
+    expect(rules[0]?.contexts).toEqual(['/api']);
+  });
+
+  it('throws when target is missing', () => {
+    expect(() =>
+      normalizeProxyConfig({ '/api': { changeOrigin: true } }, 'inline'),
+    ).toThrow(ProxyConfigError);
+  });
+
+  it('compiles pathRewrite into RegExp objects', () => {
+    const rules = normalizeProxyConfig(
+      { '/api': { target: 'http://t', pathRewrite: { '^/api': '' } } },
+      'inline',
+    );
+    const rewritten = rewritePath(rules[0]!, '/api/foo');
+    expect(rewritten).toBe('/foo');
+  });
+});
+
+describe('loadProxyConfig', () => {
+  it('reads a JSON file from disk', () => {
+    const file = writeTmp(
+      JSON.stringify({ '/api': { target: 'http://example.test' } }),
+    );
+    const rules = loadProxyConfig(file);
+    expect(rules[0]?.target).toBe('http://example.test');
+  });
+
+  it('strips JSON comments before parsing', () => {
+    const file = writeTmp(
+      '// header comment\n{ "/api": { "target": "http://t" /* inline */ } }',
+    );
+    const rules = loadProxyConfig(file);
+    expect(rules[0]?.target).toBe('http://t');
+  });
+});
+
+describe('matchRule', () => {
+  it('matches an exact context prefix', () => {
+    const rules = normalizeProxyConfig(
+      { '/api': { target: 'http://t' } },
+      'inline',
+    );
+    expect(matchRule(rules, '/api/foo')).not.toBeNull();
+    expect(matchRule(rules, '/static/main.js')).toBeNull();
+  });
+});
+
+describe('startProxyServer', () => {
+  it('forwards a request to the upstream when no rule matches', async () => {
+    const upstream = http.createServer((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain');
+      res.end(`upstream:${req.url}`);
+    });
+    await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const handle = await startProxyServer({
+      rules: [],
+      upstream: { host: '127.0.0.1', port: upstreamPort },
+      listen: { host: '127.0.0.1', port: 0 },
+    });
+    try {
+      const addr = handle.address();
+      const body = await fetchText(`http://${addr.host}:${addr.port}/hello`);
+      expect(body).toBe('upstream:/hello');
+    } finally {
+      await handle.close();
+      upstream.close();
+    }
+  });
+
+  it('forwards to a proxy target when a rule matches', async () => {
+    const target = http.createServer((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain');
+      res.end(`target:${req.url}`);
+    });
+    await new Promise<void>((r) => target.listen(0, '127.0.0.1', () => r()));
+    const targetPort = (target.address() as { port: number }).port;
+
+    const upstream = http.createServer((_req, res) => {
+      res.end('upstream-fallback');
+    });
+    await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const rules = normalizeProxyConfig(
+      { '/api': { target: `http://127.0.0.1:${targetPort}`, pathRewrite: { '^/api': '' } } },
+      'inline',
+    );
+    const handle = await startProxyServer({
+      rules,
+      upstream: { host: '127.0.0.1', port: upstreamPort },
+      listen: { host: '127.0.0.1', port: 0 },
+    });
+    try {
+      const addr = handle.address();
+      const body = await fetchText(`http://${addr.host}:${addr.port}/api/foo`);
+      expect(body).toBe('target:/foo');
+
+      const fallback = await fetchText(`http://${addr.host}:${addr.port}/static/x`);
+      expect(fallback).toBe('upstream-fallback');
+    } finally {
+      await handle.close();
+      target.close();
+      upstream.close();
+    }
+  });
+});
+
+function fetchText(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}

--- a/packages/builder/src/serve/builder.ts
+++ b/packages/builder/src/serve/builder.ts
@@ -1,0 +1,223 @@
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { Observable, Subject } from 'rxjs';
+
+import {
+  DevServerOptions,
+  OptionTranslationError,
+  TranslatedServeArgs,
+  translateOptions,
+} from './options';
+import { locateNgcRs } from './locate';
+import {
+  loadProxyConfig,
+  ProxyConfigError,
+  ProxyRule,
+  ProxyServerHandle,
+  startProxyServer,
+} from './proxy';
+import { createNgcRsRunner, NgcEvent, summarizeDiagnostics } from './process';
+
+interface DevServerBuilderOutput extends BuilderOutput {
+  baseUrl: string;
+  port?: number;
+  address?: string;
+}
+
+export function execute(
+  options: DevServerOptions,
+  context: BuilderContext,
+): Observable<BuilderOutput> {
+  const subject = new Subject<DevServerBuilderOutput>();
+
+  startServer(options, context, subject).catch((err) => {
+    const message = (err as Error).message;
+    context.logger.error(`ngc-rs builder failed: ${message}`);
+    subject.next({ success: false, baseUrl: '', error: message });
+    subject.complete();
+  });
+
+  return subject.asObservable();
+}
+
+async function startServer(
+  options: DevServerOptions,
+  context: BuilderContext,
+  subject: Subject<DevServerBuilderOutput>,
+): Promise<void> {
+  let translated: TranslatedServeArgs;
+  try {
+    translated = translateOptions(options, context.workspaceRoot);
+  } catch (err) {
+    if (err instanceof OptionTranslationError) {
+      throw err;
+    }
+    throw err;
+  }
+
+  const located = locateNgcRs(
+    context.workspaceRoot,
+    options.ngcRsBinary ?? null,
+    process.env,
+  );
+  context.logger.info(
+    `ngc-rs binary: ${located.binary} (resolved from ${located.source})`,
+  );
+
+  let proxyRules: ProxyRule[] | null = null;
+  if (translated.proxyEnabled && translated.proxyConfigPath) {
+    try {
+      proxyRules = loadProxyConfig(translated.proxyConfigPath);
+    } catch (err) {
+      if (err instanceof ProxyConfigError) {
+        throw err;
+      }
+      throw new ProxyConfigError(
+        `unexpected error loading proxy config: ${(err as Error).message}`,
+      );
+    }
+    context.logger.info(
+      `loaded ${proxyRules.length} proxy rule(s) from ${translated.proxyConfigPath}`,
+    );
+  }
+
+  const runner = createNgcRsRunner({
+    binary: located.binary,
+    args: translated.args,
+    cwd: context.workspaceRoot,
+  });
+
+  let proxyHandle: ProxyServerHandle | null = null;
+
+  context.addTeardown(async () => {
+    await runner.stop();
+    if (proxyHandle) {
+      try {
+        await proxyHandle.close();
+      } catch (err) {
+        context.logger.warn(`proxy shutdown error: ${(err as Error).message}`);
+      }
+    }
+    subject.complete();
+  });
+
+  context.reportRunning();
+
+  runner.events.on('event', (raw: NgcEvent) => {
+    handleEvent(raw);
+  });
+
+  runner.start();
+
+  function handleEvent(ev: NgcEvent): void {
+    switch (ev.type) {
+      case 'stdout':
+        context.logger.info(ev.line);
+        return;
+      case 'stderr':
+        context.logger.warn(ev.line);
+        return;
+      case 'ready':
+        onReady(ev.address);
+        return;
+      case 'rebuild-success': {
+        const baseUrl = currentBaseUrl();
+        subject.next({ success: true, baseUrl });
+        return;
+      }
+      case 'rebuild-failure': {
+        const summary = summarizeDiagnostics(ev.diagnostics);
+        context.logger.error(summary);
+        subject.next({ success: false, baseUrl: currentBaseUrl(), error: summary });
+        return;
+      }
+      case 'exit':
+        if (ev.code !== 0 && ev.code !== null) {
+          context.logger.error(`ngc-rs serve exited with code ${ev.code}`);
+        }
+        subject.complete();
+        return;
+    }
+  }
+
+  function currentBaseUrl(): string {
+    if (proxyHandle) {
+      const a = proxyHandle.address();
+      return `http://${a.host}:${a.port}/`;
+    }
+    return translated.url;
+  }
+
+  function onReady(address: string): void {
+    const upstreamPort = parsePort(address);
+    if (proxyRules && upstreamPort !== null) {
+      startProxyServer({
+        rules: proxyRules,
+        upstream: { host: '127.0.0.1', port: upstreamPort },
+        listen: { host: translated.proxyHost, port: translated.proxyPort },
+        log: (line) => context.logger.info(line),
+      })
+        .then((handle) => {
+          proxyHandle = handle;
+          const addr = handle.address();
+          const url = `http://${addr.host}:${addr.port}/`;
+          context.logger.info(`ngc-rs builder proxy listening on ${url}`);
+          subject.next({
+            success: true,
+            baseUrl: url,
+            port: addr.port,
+            address: addr.host,
+          });
+          maybeOpenBrowser(translated.open, url, context);
+        })
+        .catch((err: Error) => {
+          context.logger.error(`could not start proxy: ${err.message}`);
+          subject.next({
+            success: false,
+            baseUrl: translated.url,
+            error: `proxy startup failed: ${err.message}`,
+          });
+        });
+      return;
+    }
+
+    const url = translated.url;
+    context.logger.info(`ngc-rs serve ready at ${url}`);
+    subject.next({
+      success: true,
+      baseUrl: url,
+      port: translated.proxyPort,
+      address: translated.proxyHost,
+    });
+    maybeOpenBrowser(translated.open, url, context);
+  }
+}
+
+function parsePort(address: string): number | null {
+  const match = /:(\d+)/.exec(address);
+  if (!match || !match[1]) {
+    return null;
+  }
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function maybeOpenBrowser(open: boolean, url: string, context: BuilderContext): void {
+  if (!open) {
+    return;
+  }
+  const cmd =
+    process.platform === 'darwin' ? 'open'
+      : process.platform === 'win32' ? 'cmd'
+        : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { spawn } = require('node:child_process') as typeof import('node:child_process');
+    const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    child.unref();
+  } catch (err) {
+    context.logger.warn(`could not open browser: ${(err as Error).message}`);
+  }
+}
+
+export default createBuilder<DevServerOptions>(execute);

--- a/packages/builder/src/serve/errors.ts
+++ b/packages/builder/src/serve/errors.ts
@@ -26,6 +26,8 @@ export function parseDiagnostics(stderrChunk: string): ParsedDiagnostic[] {
 
 const FILE_LINE_COL = /^\s*(?:Error:?\s*)?([\/\.\w][^\s:]*\.\w+):(\d+):(\d+)\s*[-:]?\s*(.*)$/;
 const ERROR_PREFIX = /^\s*Error:\s+(.+)$/i;
+const NGC_REBUILD_FAILED = /^\s*ngc-rs (?:rebuild|build) failed:\s*(.+)$/i;
+const FILE_PATH_INLINE = /(?:in\s+)?(\/[\w./-]+\.\w+|[A-Za-z]:[\w./\\-]+\.\w+)(?::(\d+)(?::(\d+))?)?/;
 
 function parseLine(line: string): ParsedDiagnostic | null {
   const trimmed = line.trim();
@@ -42,6 +44,22 @@ function parseLine(line: string): ParsedDiagnostic | null {
       column: Number.isFinite(colNo) ? colNo : null,
       message: (fileMatch[4] ?? '').trim() || trimmed,
     };
+  }
+  const ngcMatch = NGC_REBUILD_FAILED.exec(trimmed);
+  if (ngcMatch && ngcMatch[1]) {
+    const detail = ngcMatch[1];
+    const inline = FILE_PATH_INLINE.exec(detail);
+    if (inline) {
+      const lineNo = inline[2] ? Number(inline[2]) : null;
+      const colNo = inline[3] ? Number(inline[3]) : null;
+      return {
+        file: inline[1] ?? null,
+        line: lineNo !== null && Number.isFinite(lineNo) ? lineNo : null,
+        column: colNo !== null && Number.isFinite(colNo) ? colNo : null,
+        message: detail,
+      };
+    }
+    return { file: null, line: null, column: null, message: detail };
   }
   const errMatch = ERROR_PREFIX.exec(trimmed);
   if (errMatch) {

--- a/packages/builder/src/serve/errors.ts
+++ b/packages/builder/src/serve/errors.ts
@@ -1,0 +1,68 @@
+export interface ParsedDiagnostic {
+  file: string | null;
+  line: number | null;
+  column: number | null;
+  message: string;
+}
+
+const ANSI_RE = /\u001b\[[0-9;]*m/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+export function parseDiagnostics(stderrChunk: string): ParsedDiagnostic[] {
+  const cleaned = stripAnsi(stderrChunk);
+  const lines = cleaned.split(/\r?\n/);
+  const diagnostics: ParsedDiagnostic[] = [];
+  for (const line of lines) {
+    const diag = parseLine(line);
+    if (diag) {
+      diagnostics.push(diag);
+    }
+  }
+  return diagnostics;
+}
+
+const FILE_LINE_COL = /^\s*(?:Error:?\s*)?([\/\.\w][^\s:]*\.\w+):(\d+):(\d+)\s*[-:]?\s*(.*)$/;
+const ERROR_PREFIX = /^\s*Error:\s+(.+)$/i;
+
+function parseLine(line: string): ParsedDiagnostic | null {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const fileMatch = FILE_LINE_COL.exec(trimmed);
+  if (fileMatch) {
+    const lineNo = Number(fileMatch[2]);
+    const colNo = Number(fileMatch[3]);
+    return {
+      file: fileMatch[1] ?? null,
+      line: Number.isFinite(lineNo) ? lineNo : null,
+      column: Number.isFinite(colNo) ? colNo : null,
+      message: (fileMatch[4] ?? '').trim() || trimmed,
+    };
+  }
+  const errMatch = ERROR_PREFIX.exec(trimmed);
+  if (errMatch) {
+    return { file: null, line: null, column: null, message: errMatch[1] ?? trimmed };
+  }
+  return null;
+}
+
+export function summarizeDiagnostics(diagnostics: ParsedDiagnostic[]): string {
+  if (diagnostics.length === 0) {
+    return 'ngc-rs reported a build failure (no parseable diagnostics in output).';
+  }
+  return diagnostics
+    .map((d) => {
+      if (d.file && d.line != null && d.column != null) {
+        return `${d.file}:${d.line}:${d.column} ${d.message}`.trim();
+      }
+      if (d.file) {
+        return `${d.file} ${d.message}`.trim();
+      }
+      return d.message;
+    })
+    .join('\n');
+}

--- a/packages/builder/src/serve/locate.ts
+++ b/packages/builder/src/serve/locate.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface LocateResult {
+  binary: string;
+  source: 'option' | 'env' | 'workspace-target' | 'path';
+}
+
+const BINARY_NAME = process.platform === 'win32' ? 'ngc-rs.exe' : 'ngc-rs';
+
+export function locateNgcRs(
+  workspaceRoot: string,
+  optionOverride: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): LocateResult {
+  if (optionOverride) {
+    const resolved = path.resolve(workspaceRoot, optionOverride);
+    return { binary: resolved, source: 'option' };
+  }
+
+  const fromEnv = env['NGC_RS_BINARY'];
+  if (fromEnv) {
+    const resolved = path.isAbsolute(fromEnv)
+      ? fromEnv
+      : path.resolve(workspaceRoot, fromEnv);
+    return { binary: resolved, source: 'env' };
+  }
+
+  const workspaceCandidate = path.join(workspaceRoot, 'target', 'release', BINARY_NAME);
+  if (fileIsExecutable(workspaceCandidate)) {
+    return { binary: workspaceCandidate, source: 'workspace-target' };
+  }
+
+  const upwards = findUpwards(workspaceRoot, ['target', 'release', BINARY_NAME]);
+  if (upwards) {
+    return { binary: upwards, source: 'workspace-target' };
+  }
+
+  return { binary: BINARY_NAME, source: 'path' };
+}
+
+function findUpwards(start: string, segments: string[]): string | null {
+  let current = start;
+  while (true) {
+    const candidate = path.join(current, ...segments);
+    if (fileIsExecutable(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function fileIsExecutable(p: string): boolean {
+  try {
+    const stat = fs.statSync(p);
+    if (!stat.isFile()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  if (process.platform === 'win32') {
+    return true;
+  }
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/builder/src/serve/options.ts
+++ b/packages/builder/src/serve/options.ts
@@ -1,0 +1,105 @@
+import { json } from '@angular-devkit/core';
+import * as path from 'node:path';
+
+export interface DevServerOptions extends json.JsonObject {
+  buildTarget: string;
+  port: number;
+  host: string;
+  open: boolean;
+  ssl: boolean;
+  sslKey: string | null;
+  sslCert: string | null;
+  proxyConfig: string | null;
+  project: string;
+  ngcRsBinary: string | null;
+}
+
+export interface TranslatedServeArgs {
+  args: string[];
+  configuration: string | null;
+  spawnHost: string;
+  spawnPort: number;
+  proxyEnabled: boolean;
+  proxyHost: string;
+  proxyPort: number;
+  proxyConfigPath: string | null;
+  open: boolean;
+  url: string;
+}
+
+export class OptionTranslationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OptionTranslationError';
+  }
+}
+
+const DEFAULT_PORT = 4200;
+const DEFAULT_HOST = 'localhost';
+
+export function translateOptions(
+  raw: Partial<DevServerOptions>,
+  workspaceRoot: string,
+): TranslatedServeArgs {
+  if (raw.ssl === true) {
+    throw new OptionTranslationError(
+      'ssl=true is not yet supported by ngc-rs serve. Remove the option or run a separate TLS-terminating proxy in front of ngc-rs.',
+    );
+  }
+  if (raw.sslKey || raw.sslCert) {
+    throw new OptionTranslationError(
+      'sslKey/sslCert are not yet supported by ngc-rs serve.',
+    );
+  }
+
+  const userPort = raw.port ?? DEFAULT_PORT;
+  const userHost = raw.host ?? DEFAULT_HOST;
+  const open = raw.open === true;
+
+  const configuration = parseConfigurationFromBuildTarget(raw.buildTarget);
+  const project = raw.project ?? 'tsconfig.json';
+
+  const proxyConfigPath = raw.proxyConfig
+    ? path.resolve(workspaceRoot, raw.proxyConfig)
+    : null;
+  const proxyEnabled = proxyConfigPath !== null;
+
+  const spawnHost = proxyEnabled ? '127.0.0.1' : userHost;
+  const spawnPort = proxyEnabled ? 0 : userPort;
+
+  const args: string[] = ['serve', '--project', project];
+  if (configuration) {
+    args.push('--configuration', configuration);
+  }
+  args.push('--host', spawnHost, '--port', String(spawnPort));
+
+  return {
+    args,
+    configuration,
+    spawnHost,
+    spawnPort,
+    proxyEnabled,
+    proxyHost: userHost,
+    proxyPort: userPort,
+    proxyConfigPath,
+    open,
+    url: formatUrl(userHost, userPort),
+  };
+}
+
+function parseConfigurationFromBuildTarget(buildTarget?: string): string | null {
+  if (!buildTarget) {
+    return null;
+  }
+  const parts = buildTarget.split(':');
+  if (parts.length >= 3 && parts[2]) {
+    return parts[2];
+  }
+  return null;
+}
+
+export function formatUrl(host: string, port: number): string {
+  const isLoopbackName = host === 'localhost' || host === '0.0.0.0';
+  const display = isLoopbackName ? 'localhost' : host;
+  return `http://${display}:${port}/`;
+}

--- a/packages/builder/src/serve/process.ts
+++ b/packages/builder/src/serve/process.ts
@@ -1,0 +1,168 @@
+import { ChildProcess, spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import { parseDiagnostics, ParsedDiagnostic, stripAnsi, summarizeDiagnostics } from './errors';
+
+const READY_PATTERN = /listening on\s+http(?:s)?:\/\/([^\s]+)/i;
+const REBUILD_OK_PATTERN = /ngc-rs rebuild\b/i;
+const BUILD_FAILED_PATTERN = /ngc-rs (?:rebuild )?(?:build )?(?:failed|error)/i;
+
+export interface NgcRsRunnerOptions {
+  binary: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export type NgcEvent =
+  | { type: 'ready'; address: string }
+  | { type: 'rebuild-success' }
+  | { type: 'rebuild-failure'; diagnostics: ParsedDiagnostic[]; raw: string }
+  | { type: 'stdout'; line: string }
+  | { type: 'stderr'; line: string }
+  | { type: 'exit'; code: number | null; signal: NodeJS.Signals | null };
+
+export interface NgcRsRunner {
+  events: EventEmitter;
+  start(): void;
+  stop(): Promise<void>;
+  isRunning(): boolean;
+}
+
+export function createNgcRsRunner(options: NgcRsRunnerOptions): NgcRsRunner {
+  const events = new EventEmitter();
+  let child: ChildProcess | null = null;
+  let stopRequested = false;
+  let stopResolve: (() => void) | null = null;
+  let stderrBuffer = '';
+  let stdoutBuffer = '';
+
+  const start = (): void => {
+    if (child) {
+      throw new Error('ngc-rs runner already started');
+    }
+    child = spawn(options.binary, options.args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...(options.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+
+    child.stdout?.on('data', (chunk: string) => {
+      stdoutBuffer = drainLines(stdoutBuffer + chunk, (line) => {
+        events.emit('event', { type: 'stdout', line } satisfies NgcEvent);
+        inspectLine(line, /*fromStderr*/ false);
+      });
+    });
+
+    child.stderr?.on('data', (chunk: string) => {
+      stderrBuffer = drainLines(stderrBuffer + chunk, (line) => {
+        events.emit('event', { type: 'stderr', line } satisfies NgcEvent);
+        inspectLine(line, /*fromStderr*/ true);
+      });
+    });
+
+    child.on('exit', (code, signal) => {
+      flushBuffers();
+      events.emit('event', { type: 'exit', code, signal } satisfies NgcEvent);
+      child = null;
+      if (stopResolve) {
+        stopResolve();
+        stopResolve = null;
+      }
+    });
+
+    child.on('error', (err) => {
+      events.emit('event', {
+        type: 'stderr',
+        line: `failed to spawn ngc-rs: ${err.message}`,
+      } satisfies NgcEvent);
+    });
+  };
+
+  const inspectLine = (line: string, fromStderr: boolean): void => {
+    const cleaned = stripAnsi(line);
+    const ready = READY_PATTERN.exec(cleaned);
+    if (ready && ready[1]) {
+      events.emit('event', { type: 'ready', address: ready[1] } satisfies NgcEvent);
+      return;
+    }
+    if (REBUILD_OK_PATTERN.test(cleaned)) {
+      events.emit('event', { type: 'rebuild-success' } satisfies NgcEvent);
+      return;
+    }
+    if (fromStderr && BUILD_FAILED_PATTERN.test(cleaned)) {
+      const diagnostics = parseDiagnostics(line);
+      events.emit('event', {
+        type: 'rebuild-failure',
+        diagnostics,
+        raw: cleaned,
+      } satisfies NgcEvent);
+    }
+  };
+
+  const flushBuffers = (): void => {
+    if (stdoutBuffer.length > 0) {
+      events.emit('event', { type: 'stdout', line: stdoutBuffer } satisfies NgcEvent);
+      inspectLine(stdoutBuffer, false);
+      stdoutBuffer = '';
+    }
+    if (stderrBuffer.length > 0) {
+      events.emit('event', { type: 'stderr', line: stderrBuffer } satisfies NgcEvent);
+      inspectLine(stderrBuffer, true);
+      stderrBuffer = '';
+    }
+  };
+
+  const stop = (): Promise<void> => {
+    if (!child) {
+      return Promise.resolve();
+    }
+    stopRequested = true;
+    const proc = child;
+    return new Promise<void>((resolve) => {
+      stopResolve = resolve;
+      try {
+        proc.kill('SIGINT');
+      } catch {
+        /* already exited */
+      }
+      const killTimer = setTimeout(() => {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          try {
+            proc.kill('SIGKILL');
+          } catch {
+            /* ignore */
+          }
+        }
+      }, 3_000);
+      killTimer.unref();
+    });
+  };
+
+  return {
+    events,
+    start,
+    stop,
+    isRunning: () => child !== null && !stopRequested,
+  };
+}
+
+export { summarizeDiagnostics };
+
+function drainLines(buffer: string, onLine: (line: string) => void): string {
+  let remaining = buffer;
+  let newlineIndex = remaining.indexOf('\n');
+  while (newlineIndex !== -1) {
+    const line = remaining.slice(0, newlineIndex).replace(/\r$/, '');
+    if (line.length > 0) {
+      onLine(line);
+    }
+    remaining = remaining.slice(newlineIndex + 1);
+    newlineIndex = remaining.indexOf('\n');
+  }
+  return remaining;
+}

--- a/packages/builder/src/serve/process.ts
+++ b/packages/builder/src/serve/process.ts
@@ -4,8 +4,8 @@ import { EventEmitter } from 'node:events';
 import { parseDiagnostics, ParsedDiagnostic, stripAnsi, summarizeDiagnostics } from './errors';
 
 const READY_PATTERN = /listening on\s+http(?:s)?:\/\/([^\s]+)/i;
-const REBUILD_OK_PATTERN = /ngc-rs rebuild\b/i;
-const BUILD_FAILED_PATTERN = /ngc-rs (?:rebuild )?(?:build )?(?:failed|error)/i;
+const REBUILD_OK_PATTERN = /ngc-rs rebuild\s+\d+\s+module/i;
+const BUILD_FAILED_PATTERN = /ngc-rs (?:rebuild|build)\s+failed\b/i;
 
 export interface NgcRsRunnerOptions {
   binary: string;

--- a/packages/builder/src/serve/proxy.ts
+++ b/packages/builder/src/serve/proxy.ts
@@ -1,0 +1,340 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as path from 'node:path';
+import { URL } from 'node:url';
+
+export interface ProxyRule {
+  contexts: string[];
+  target: string;
+  secure: boolean;
+  changeOrigin: boolean;
+  pathRewrite: Array<{ from: RegExp; to: string }>;
+  ws: boolean;
+}
+
+export interface ProxyConfigLoadError {
+  message: string;
+  cause?: unknown;
+}
+
+export class ProxyConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProxyConfigError';
+  }
+}
+
+export function loadProxyConfig(configPath: string): ProxyRule[] {
+  const ext = path.extname(configPath).toLowerCase();
+  let raw: unknown;
+  if (ext === '.json' || ext === '') {
+    const text = fs.readFileSync(configPath, 'utf8');
+    try {
+      raw = JSON.parse(stripJsonComments(text));
+    } catch (err) {
+      throw new ProxyConfigError(
+        `failed to parse proxy config JSON at ${configPath}: ${(err as Error).message}`,
+      );
+    }
+  } else if (ext === '.js' || ext === '.cjs' || ext === '.mjs') {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      raw = require(configPath);
+      if (raw && typeof raw === 'object' && 'default' in (raw as Record<string, unknown>)) {
+        const def = (raw as Record<string, unknown>)['default'];
+        if (def !== undefined) {
+          raw = def;
+        }
+      }
+    } catch (err) {
+      throw new ProxyConfigError(
+        `failed to load proxy config module at ${configPath}: ${(err as Error).message}`,
+      );
+    }
+  } else {
+    throw new ProxyConfigError(
+      `unsupported proxy config extension "${ext}" at ${configPath}`,
+    );
+  }
+  return normalizeProxyConfig(raw, configPath);
+}
+
+export function normalizeProxyConfig(raw: unknown, source: string): ProxyRule[] {
+  if (!raw || typeof raw !== 'object') {
+    throw new ProxyConfigError(`proxy config at ${source} must be an object or array`);
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((entry, idx) => normalizeArrayEntry(entry, source, idx));
+  }
+  const out: ProxyRule[] = [];
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    out.push(normalizeMapEntry(key, value, source));
+  }
+  return out;
+}
+
+function normalizeArrayEntry(entry: unknown, source: string, idx: number): ProxyRule {
+  if (!entry || typeof entry !== 'object') {
+    throw new ProxyConfigError(`proxy config entry [${idx}] in ${source} is not an object`);
+  }
+  const e = entry as Record<string, unknown>;
+  const ctx = e['context'];
+  let contexts: string[];
+  if (typeof ctx === 'string') {
+    contexts = [ctx];
+  } else if (Array.isArray(ctx) && ctx.every((c) => typeof c === 'string')) {
+    contexts = ctx as string[];
+  } else {
+    throw new ProxyConfigError(
+      `proxy config entry [${idx}] in ${source} is missing a "context" string or string[]`,
+    );
+  }
+  return buildRule(contexts, e, `entry [${idx}]`, source);
+}
+
+function normalizeMapEntry(key: string, value: unknown, source: string): ProxyRule {
+  if (!value || typeof value !== 'object') {
+    throw new ProxyConfigError(`proxy config entry "${key}" in ${source} is not an object`);
+  }
+  return buildRule([key], value as Record<string, unknown>, `entry "${key}"`, source);
+}
+
+function buildRule(
+  contexts: string[],
+  e: Record<string, unknown>,
+  label: string,
+  source: string,
+): ProxyRule {
+  const target = e['target'];
+  if (typeof target !== 'string' || target.length === 0) {
+    throw new ProxyConfigError(`proxy ${label} in ${source} requires a "target" string`);
+  }
+  const pathRewrite: Array<{ from: RegExp; to: string }> = [];
+  const rawRewrite = e['pathRewrite'];
+  if (rawRewrite && typeof rawRewrite === 'object' && !Array.isArray(rawRewrite)) {
+    for (const [from, to] of Object.entries(rawRewrite as Record<string, unknown>)) {
+      if (typeof to !== 'string') {
+        throw new ProxyConfigError(
+          `proxy ${label} in ${source} pathRewrite["${from}"] must be a string`,
+        );
+      }
+      pathRewrite.push({ from: new RegExp(from), to });
+    }
+  }
+  return {
+    contexts: contexts.map(stripGlobSuffix),
+    target,
+    secure: e['secure'] !== false,
+    changeOrigin: e['changeOrigin'] === true,
+    pathRewrite,
+    ws: e['ws'] === true,
+  };
+}
+
+function stripGlobSuffix(ctx: string): string {
+  if (ctx.endsWith('/*')) {
+    return ctx.slice(0, -2);
+  }
+  if (ctx.endsWith('*')) {
+    return ctx.slice(0, -1);
+  }
+  return ctx;
+}
+
+export function matchRule(rules: ProxyRule[], pathname: string): ProxyRule | null {
+  for (const rule of rules) {
+    for (const ctx of rule.contexts) {
+      if (pathname === ctx || pathname.startsWith(ctx + '/') || pathname.startsWith(ctx)) {
+        if (ctx === '' || pathname.startsWith(ctx)) {
+          return rule;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function rewritePath(rule: ProxyRule, pathname: string): string {
+  let out = pathname;
+  for (const { from, to } of rule.pathRewrite) {
+    out = out.replace(from, to);
+  }
+  return out;
+}
+
+export interface ProxyServerOptions {
+  rules: ProxyRule[];
+  upstream: { host: string; port: number };
+  listen: { host: string; port: number };
+  log?: (line: string) => void;
+}
+
+export interface ProxyServerHandle {
+  server: http.Server;
+  close(): Promise<void>;
+  address(): { host: string; port: number };
+}
+
+export function startProxyServer(options: ProxyServerOptions): Promise<ProxyServerHandle> {
+  const log = options.log ?? (() => {});
+  const server = http.createServer((req, res) => {
+    handleRequest(req, res, options, log).catch((err) => {
+      log(`proxy request failed: ${(err as Error).message}`);
+      if (!res.headersSent) {
+        res.statusCode = 502;
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.end(`bad gateway: ${(err as Error).message}`);
+      } else {
+        res.end();
+      }
+    });
+  });
+  // Disable response timeouts for SSE.
+  server.requestTimeout = 0;
+  server.keepAliveTimeout = 0;
+
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      const addr = server.address();
+      const host = options.listen.host;
+      const port = typeof addr === 'object' && addr ? addr.port : options.listen.port;
+      resolve({
+        server,
+        address: () => ({ host, port }),
+        close: () =>
+          new Promise<void>((res, rej) => {
+            server.close((err) => (err ? rej(err) : res()));
+            server.closeAllConnections();
+          }),
+      });
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(options.listen.port, options.listen.host);
+  });
+}
+
+async function handleRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  options: ProxyServerOptions,
+  log: (line: string) => void,
+): Promise<void> {
+  const url = req.url ?? '/';
+  const pathOnly = url.split('?')[0] ?? url;
+  const rule = matchRule(options.rules, pathOnly);
+  if (rule) {
+    return forwardToTarget(req, res, rule, url, log);
+  }
+  return forwardToUpstream(req, res, options.upstream, url);
+}
+
+function forwardToUpstream(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  upstream: { host: string; port: number },
+  url: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const headers = { ...req.headers };
+    delete headers['host'];
+    const proxyReq = http.request(
+      {
+        host: upstream.host,
+        port: upstream.port,
+        method: req.method,
+        path: url,
+        headers,
+      },
+      (proxyRes) => {
+        res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+        proxyRes.pipe(res);
+        proxyRes.on('end', () => resolve());
+        proxyRes.on('error', reject);
+      },
+    );
+    proxyReq.on('error', reject);
+    req.pipe(proxyReq);
+    req.on('aborted', () => proxyReq.destroy());
+  });
+}
+
+function forwardToTarget(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  rule: ProxyRule,
+  url: string,
+  log: (line: string) => void,
+): Promise<void> {
+  const target = new URL(rule.target);
+  const [pathOnly, query] = splitPathQuery(url);
+  const rewritten = rewritePath(rule, pathOnly);
+  const targetPath = joinTargetPath(target.pathname, rewritten) + (query ? `?${query}` : '');
+
+  const isHttps = target.protocol === 'https:';
+  const headers = { ...req.headers };
+  if (rule.changeOrigin) {
+    headers['host'] = target.host;
+  } else {
+    delete headers['host'];
+  }
+
+  const requestModule = isHttps ? requireHttps() : http;
+  log(`proxy ${req.method} ${url} -> ${target.protocol}//${target.host}${targetPath}`);
+
+  return new Promise((resolve, reject) => {
+    const proxyReq = requestModule.request(
+      {
+        protocol: target.protocol,
+        host: target.hostname,
+        port: target.port || (isHttps ? 443 : 80),
+        method: req.method,
+        path: targetPath,
+        headers,
+        rejectUnauthorized: rule.secure,
+      } as http.RequestOptions,
+      (proxyRes) => {
+        res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+        proxyRes.pipe(res);
+        proxyRes.on('end', () => resolve());
+        proxyRes.on('error', reject);
+      },
+    );
+    proxyReq.on('error', reject);
+    req.pipe(proxyReq);
+    req.on('aborted', () => proxyReq.destroy());
+  });
+}
+
+function splitPathQuery(url: string): [string, string | null] {
+  const idx = url.indexOf('?');
+  if (idx === -1) {
+    return [url, null];
+  }
+  return [url.slice(0, idx), url.slice(idx + 1)];
+}
+
+function joinTargetPath(base: string, rewritten: string): string {
+  const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  if (!trimmedBase) {
+    return rewritten;
+  }
+  if (rewritten.startsWith('/')) {
+    return trimmedBase + rewritten;
+  }
+  return trimmedBase + '/' + rewritten;
+}
+
+function requireHttps(): typeof http {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('node:https') as unknown as typeof http;
+}
+
+function stripJsonComments(s: string): string {
+  return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/**", "dist", "node_modules"]
+}

--- a/packages/builder/vitest.config.ts
+++ b/packages/builder/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 15_000,
+  },
+});


### PR DESCRIPTION
Closes #27. Completes the v0.8 — Watch Mode & Dev Server milestone.

## Summary

Introduces `@ngc-rs/builder`, a new Node/TypeScript shim that implements the `@angular-devkit/architect` builder protocol. Drop-in replacement for `@angular/build:dev-server`: swap the `serve` target's `builder` in `angular.json` and `ng serve` routes through `ngc-rs serve` for fast incremental rebuilds with live reload.

## Package layout

`packages/builder/` is laid out so the v1.0 build adapter (#28) can land beside this one without restructuring:

```
packages/builder/
├── package.json          # @ngc-rs/builder, version pinned to 0.8.3
├── builders.json         # architect manifest — dev-server today, build slot reserved
├── schemas/dev-server.json
├── src/serve/            # this PR
│   ├── builder.ts        # createBuilder entry, BuilderOutput emission, teardown
│   ├── options.ts        # angular.json -> ngc-rs serve flag translation
│   ├── locate.ts         # ngc-rs binary discovery (option > env > workspace target/release > PATH)
│   ├── process.ts        # spawn/lifecycle, line parsing, ready/rebuild events
│   ├── proxy.ts          # in-process proxy server for proxyConfig
│   └── errors.ts         # stderr -> ParsedDiagnostic with file:line:col extraction
└── src/build/            # reserved for #28
```

## Option translation

Implemented from `@angular/build:dev-server`'s schema: `port`, `host`, `open`, `proxyConfig`, plus `project` and `ngcRsBinary` extensions. `ssl=true`, `sslKey`, and `sslCert` produce a hard error rather than silently falling back to HTTP — see the schema for the explicit unsupported list. `buildTarget` is read only to pull the configuration name (e.g. `app:build:development` -> `--configuration development`).

## Proxy decision

Implemented in the Node shim, not in `ngc-rs serve`. Trade-off: the shim already runs as a parent process for `ng serve`, so adding a `node:http` reverse proxy there is much smaller than threading an HTTP client (and proxy semantics) through `crates/dev-server`. When `proxyConfig` is unset there is **no** Node middle layer — `ngc-rs serve` binds directly to the user's `host:port`. When `proxyConfig` is set, the shim takes the user port and `ngc-rs serve` is moved to an ephemeral loopback port. Both webpack-style map and Angular array forms are supported, with `pathRewrite` and `changeOrigin`. WebSocket upgrades are documented as not yet forwarded.

## Binary discovery

Lookup order: `ngcRsBinary` option (workspace-relative) -> `NGC_RS_BINARY` env -> `<workspaceRoot>/target/release/ngc-rs` (with parent-walk for monorepo layouts) -> `ngc-rs` from `PATH`.

## Error surfacing

`crates/cli/src/serve_cmd.rs` now logs `ngc-rs rebuild failed: <message>` to stderr on rebuild errors instead of swallowing them via the watcher's broadcast loop. The shim parses these lines, extracts the file path (and line:col when ngc-rs emits them), and emits a `BuilderOutput` with `success: false` and a structured `error` so `ng` prints them in the terminal.

## Manual smoke test

Ran against `test-ng-project` (Angular 21.2, `@angular/build` 21.2.7) with the workspace's `target/release/ngc-rs` resolved via `NGC_RS_BINARY`:

- ✅ `ng serve` boots, browser at `http://127.0.0.1:4250/` renders the app correctly.
- ✅ Editing `src/app/app.ts` triggers `ngc-rs rebuild N module(s), 1 dirty` and the SSE live-reload client refreshes the page.
- ✅ Adding `proxy.conf.json` with `{ "/api": { "target": "http://127.0.0.1:7474", "pathRewrite": { "^/api": "" } } }` and a fake target on 7474: `curl /api/v1/users` -> proxied (path rewritten); `curl /main.js` -> served by the underlying ngc-rs dev server.
- ✅ Forcing an unterminated string in `app.ts` surfaces in the `ng` terminal as `ngc-rs rebuild failed: ... template compile error in /…/app.ts: parser panicked: Unterminated string`, parsed file path included. (Browser overlay tracked separately under #107.)
- ✅ `Ctrl+C` on `ng serve` cleanly terminates both the Node parent and the `ngc-rs serve` child.

## Verification

- `cargo test --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo fmt --check` — green
- `packages/builder` -> `npx tsc -p tsconfig.json` clean, `npx vitest run` -> 5 files, 39 tests pass

## Test plan

- [ ] Reviewer runs `npm install` + `npm run build` + `npm test` in `packages/builder/`
- [ ] Reviewer swaps the builder in their own `angular.json` (or `test-ng-project`) and confirms the smoke flow above
- [ ] Reviewer confirms the `ssl: true` path produces the documented hard error
- [ ] Reviewer confirms the `proxyConfig` path-rewrite and fallback behavior

## Notes

- Browser error overlay deliberately deferred to follow-up #107 (within the v0.8 milestone) so the wire change can land alongside the rest of the dev-server protocol.
- The Node lockfile is committed so reviewers and CI can reproduce the exact dependency tree.
