### PR TITLE
perf(linker): replace RwLock<HashMap> with DashMap in module registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "base64",
  "clap",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
 name = "ngc-linker"
 version = "0.9.0"
 dependencies = [
+ "dashmap",
  "insta",
  "ngc-diagnostics",
  "ngc-template-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/linker/Cargo.toml
+++ b/crates/linker/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 ngc-diagnostics = { path = "../diagnostics" }
 ngc-template-compiler = { path = "../template-compiler" }
+dashmap = "6"
 oxc_allocator = "0.122"
 oxc_diagnostics = "0.122"
 oxc_parser = "0.122"

--- a/crates/linker/src/module_registry.rs
+++ b/crates/linker/src/module_registry.rs
@@ -26,8 +26,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
 
+use dashmap::mapref::entry::Entry;
+use dashmap::{DashMap, DashSet};
 use rayon::prelude::*;
 
 use ngc_diagnostics::{NgcError, NgcResult};
@@ -51,12 +52,12 @@ use crate::metadata;
 pub struct ModuleRegistry {
     /// Class name -> direct exports (in source order, possibly containing other
     /// module names that need transitive expansion).
-    raw_exports: RwLock<HashMap<String, Vec<String>>>,
+    raw_exports: DashMap<String, Vec<String>>,
     /// Set of class names known to be NgModules (i.e., have been registered).
-    is_module: RwLock<HashSet<String>>,
+    is_module: DashSet<String>,
     /// Memoized result of [`flatten`]. Cleared implicitly between builds since
     /// each build constructs a fresh registry.
-    flat_cache: RwLock<HashMap<String, Vec<String>>>,
+    flat_cache: DashMap<String, Vec<String>>,
 }
 
 impl ModuleRegistry {
@@ -74,60 +75,41 @@ impl ModuleRegistry {
     /// project file shadows an npm package's NgModule.
     pub fn register(&self, name: &str, exports: Vec<String>) {
         let mut changed = true;
-        {
-            let mut raw = match self.raw_exports.write() {
-                Ok(g) => g,
-                Err(p) => p.into_inner(),
-            };
-            match raw.get(name) {
-                Some(existing) if existing == &exports => {
+        match self.raw_exports.entry(name.to_string()) {
+            Entry::Occupied(mut e) => {
+                if e.get() == &exports {
                     changed = false;
-                }
-                Some(_) => {
+                } else {
                     tracing::warn!(
                         module = name,
                         "NgModule registered with conflicting exports; later registration wins"
                     );
-                    raw.insert(name.to_string(), exports);
-                }
-                None => {
-                    raw.insert(name.to_string(), exports);
+                    e.insert(exports);
                 }
             }
+            Entry::Vacant(v) => {
+                v.insert(exports);
+            }
         }
-        {
-            let mut set = match self.is_module.write() {
-                Ok(g) => g,
-                Err(p) => p.into_inner(),
-            };
-            set.insert(name.to_string());
-        }
+        self.is_module.insert(name.to_string());
         if changed {
-            if let Ok(mut cache) = self.flat_cache.write() {
-                cache.clear();
-            }
+            self.flat_cache.clear();
         }
     }
 
     /// Whether the given class name is a known NgModule.
     pub fn is_module(&self, name: &str) -> bool {
-        match self.is_module.read() {
-            Ok(g) => g.contains(name),
-            Err(p) => p.into_inner().contains(name),
-        }
+        self.is_module.contains(name)
     }
 
     /// Number of registered NgModules.
     pub fn len(&self) -> usize {
-        match self.is_module.read() {
-            Ok(g) => g.len(),
-            Err(p) => p.into_inner().len(),
-        }
+        self.is_module.len()
     }
 
     /// Whether the registry is empty.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.is_module.is_empty()
     }
 
     /// Return the transitively flattened directive/pipe class list for `name`.
@@ -141,17 +123,13 @@ impl ModuleRegistry {
     /// Order-preserving: depth-first source order with O(n) dedup. The lists
     /// are small (typically <30) so the linear contains-check is fine.
     pub fn flatten(&self, name: &str) -> Vec<String> {
-        if let Ok(cache) = self.flat_cache.read() {
-            if let Some(hit) = cache.get(name) {
-                return hit.clone();
-            }
+        if let Some(hit) = self.flat_cache.get(name) {
+            return hit.value().clone();
         }
         let mut visited = HashSet::new();
         let mut out = Vec::new();
         self.walk(name, &mut visited, &mut out);
-        if let Ok(mut cache) = self.flat_cache.write() {
-            cache.insert(name.to_string(), out.clone());
-        }
+        self.flat_cache.insert(name.to_string(), out.clone());
         out
     }
 
@@ -159,10 +137,7 @@ impl ModuleRegistry {
         if !visited.insert(name.to_string()) {
             return;
         }
-        let direct = match self.raw_exports.read() {
-            Ok(g) => g.get(name).cloned(),
-            Err(p) => p.into_inner().get(name).cloned(),
-        };
+        let direct = self.raw_exports.get(name).map(|r| r.value().clone());
         match direct {
             Some(exports) => {
                 for e in exports {
@@ -227,7 +202,7 @@ pub fn scan_define_ng_modules(
     modules: &HashMap<PathBuf, String>,
     registry: &ModuleRegistry,
 ) -> NgcResult<usize> {
-    // `ModuleRegistry` is RwLock-protected, so `scan_one` is thread-safe.
+    // `ModuleRegistry` is DashMap-backed, so `scan_one` is thread-safe.
     // Each file's parse + AST walk is independent, so fan out across rayon.
     modules
         .par_iter()

--- a/crates/linker/src/public_exports.rs
+++ b/crates/linker/src/public_exports.rs
@@ -26,10 +26,10 @@
 //! the import against that package. Identifiers with no public export are
 //! dropped from the flattened dependency list.
 
-use std::collections::HashMap;
 use std::path::Path;
-use std::sync::RwLock;
 
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{ExportSpecifier, ModuleExportName, Statement};
 use oxc_parser::Parser;
@@ -44,7 +44,7 @@ pub struct PublicExports {
     /// Preferred = first seen with a *canonical* specifier (see
     /// [`derive_specifier`]). Internal chunk files like
     /// `_router_module-chunk.mjs` are ignored.
-    name_to_specifier: RwLock<HashMap<String, String>>,
+    name_to_specifier: DashMap<String, String>,
 }
 
 impl PublicExports {
@@ -55,18 +55,12 @@ impl PublicExports {
 
     /// Is this identifier publicly exported from any tracked npm file?
     pub fn has(&self, name: &str) -> bool {
-        match self.name_to_specifier.read() {
-            Ok(g) => g.contains_key(name),
-            Err(p) => p.into_inner().contains_key(name),
-        }
+        self.name_to_specifier.contains_key(name)
     }
 
     /// Npm specifier that publicly exports `name`, or `None` if unknown.
     pub fn specifier_for(&self, name: &str) -> Option<String> {
-        match self.name_to_specifier.read() {
-            Ok(g) => g.get(name).cloned(),
-            Err(p) => p.into_inner().get(name).cloned(),
-        }
+        self.name_to_specifier.get(name).map(|r| r.value().clone())
     }
 
     /// Scan a single npm file's source for its top-level `export { … }` and
@@ -98,16 +92,10 @@ impl PublicExports {
             }
         }
         let mut added = 0;
-        if !exported.is_empty() {
-            let mut map = match self.name_to_specifier.write() {
-                Ok(g) => g,
-                Err(p) => p.into_inner(),
-            };
-            for name in exported {
-                map.entry(name).or_insert_with(|| {
-                    added += 1;
-                    specifier.clone()
-                });
+        for name in exported {
+            if let Entry::Vacant(v) = self.name_to_specifier.entry(name) {
+                v.insert(specifier.clone());
+                added += 1;
             }
         }
         added
@@ -115,15 +103,12 @@ impl PublicExports {
 
     /// Number of registered identifiers.
     pub fn len(&self) -> usize {
-        match self.name_to_specifier.read() {
-            Ok(g) => g.len(),
-            Err(p) => p.into_inner().len(),
-        }
+        self.name_to_specifier.len()
     }
 
     /// Whether the registry is empty.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.name_to_specifier.is_empty()
     }
 }
 


### PR DESCRIPTION
Closes #112.

Replaces `RwLock<HashMap>` (and the `RwLock<HashSet>` used as `is_module`) with `DashMap` / `DashSet` in the linker's hot data structures so rayon workers stop serializing on writer barriers when registering Angular modules and resolving public exports during the link pass.

## Sites changed

- `crates/linker/src/module_registry.rs` — `raw_exports`, `is_module`, `flat_cache` (3 fields).
- `crates/linker/src/public_exports.rs` — `name_to_specifier`.
- `crates/linker/Cargo.toml` — adds `dashmap = \"6\"` (already used by `ngc-bundler`, so no new workspace dep).

Pattern matches the cached canonicalize map in `crates/bundler/src/concat.rs:22`.

## API surface

- `ModuleRegistry::register / is_module / len / is_empty / flatten` — unchanged.
- `PublicExports::has / specifier_for / scan_file / len / is_empty` — unchanged.
- `register` keeps idempotent + last-write-wins-with-warn semantics via `DashMap::entry` + the `Occupied`/`Vacant` arms of `dashmap::mapref::entry::Entry`.
- `flat_cache` is still cleared whenever a registration changes raw_exports.
- All 116 linker unit + integration tests still pass.

## Verification

- `cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` — all green.
- Production builds of both `treasr-frontend` and `test-ng-project` succeed.
- `dist/` output is semantically equivalent across runs. Note: pre-PR `ngc-rs` is already non-deterministic in two narrow places (var-binding emission order and a benign rxjs barrel race where `switchMap`/`tap` can resolve from `rxjs/dist/esm5/index` or `rxjs/dist/esm5/operators/index` — both barrels re-export the same symbol). DashMap does not introduce additional non-determinism beyond what RwLock<HashMap> already exhibited under rayon.

## Hyperfine (5 runs, --warmup 2, mean ± stdev)

### treasr-frontend (production)

Total wall time:

| Binary | Wall time |
|---|---|
| before | 395.8 ms ± 10.7 ms |
| after | 399.4 ms ± 12.1 ms |

`link` span (RUST_LOG=info, 5 runs):

| Binary | Samples (ms) | Mean ± stdev | Median |
|---|---|---|---|
| before | 71.8, 65.2, 65.7, 67.8, 73.2 | 68.7 ± 3.5 ms | 67.8 ms |
| after  | 67.7, 60.8, 64.0, 65.6, 69.3 | 65.5 ± 3.2 ms | 65.6 ms |

Δ ≈ −3 ms on the link span, well under the issue's 10–25 ms estimate. The 64 ms link-span baseline is dominated by parsing + per-file AST walks for the 240 post-flatten npm files; lock contention on the four maps was a smaller contributor than expected. The DoD's `≤ 50 ms` post-PR target is therefore not met by this change alone — it will need to be combined with #115 (single-pass post-flatten resolution) and/or other linker work to reach that ceiling.

### test-ng-project (production)

Total wall time (dominated by SCSS subprocess spawns; high variance — see #110):

| Binary | Wall time |
|---|---|
| before | 2.047 s ± 0.043 s |
| after | 2.520 s ± 0.550 s (min 1.968 s, max 3.358 s — outlier-driven) |

`link` span (RUST_LOG=info, 5 runs):

| Binary | Samples (ms) | Mean ± stdev | Median |
|---|---|---|---|
| before | 12.2, 15.0, 11.5, 11.6, 11.8 | 12.4 ± 1.4 ms | 11.8 ms |
| after  | 12.8, 11.9, 11.4, 11.3, 11.9 | 11.9 ± 0.6 ms | 11.9 ms |

No regression on the link span (within the issue's ±2 ms tolerance). Total wall variance is unrelated to this change.

## Out-of-scope

- Removing the residual non-determinism in `PublicExports::scan_file` (the rxjs barrel race) — pre-existing and orthogonal to lock choice.