### PR TITLE
perf(template-compiler): pool node subprocess for SCSS/Sass/Less/Stylus preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rayon",
+ "serde_json",
  "tempfile",
  "tracing",
  "which",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dashmap",
  "insta",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "glob",
  "ngc-diagnostics",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "clap",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/template-compiler/Cargo.toml
+++ b/crates/template-compiler/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 ngc-diagnostics = { path = "../diagnostics" }
+serde_json = "1.0"
 oxc_allocator = "0.122"
 oxc_diagnostics = "0.122"
 oxc_parser = "0.122"

--- a/crates/template-compiler/src/preprocessor.rs
+++ b/crates/template-compiler/src/preprocessor.rs
@@ -1,20 +1,32 @@
 //! Component-style preprocessor harness for SCSS / Sass / Less / Stylus.
 //!
-//! Mirrors the PostCSS/Tailwind subprocess pattern used for global styles:
-//! a short Node script is spawned, the raw source is piped to stdin, and the
-//! compiled CSS is read back from stdout. The matching npm package (`sass`,
-//! `less`, or `stylus`) must be installed in the project; if it is missing we
-//! surface a clear [`NgcError::StyleError`] so the user can `npm install` it.
+//! Each language is backed by a single long-lived Node worker, keyed by
+//! `(language, project_root)`. Workers speak NDJSON over stdin/stdout: one
+//! request line in, one response line out. A `Mutex` around each worker
+//! serialises rayon callers — Node is single-threaded anyway — and the cost
+//! that previously dominated the build (a fresh `Command::new("node")` plus
+//! `require('sass')` per component) collapses to a single startup amortised
+//! across every styled component in the build.
+//!
+//! The matching npm package (`sass`, `less`, or `stylus`) must be installed
+//! in the project; if it is missing we surface a clear [`NgcError::StyleError`]
+//! so the user can `npm install` it. If a worker dies mid-build (parser
+//! crashed, OOM, etc.) we surface the captured stderr as a `StyleError` and
+//! drop the entry so the next request spawns a fresh worker.
 
-use std::io::Write;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
 
 use ngc_diagnostics::{NgcError, NgcResult};
 
 /// Style source language, derived from a file extension or from
 /// `inlineStyleLanguage` in `angular.json`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum StyleLanguage {
     /// Plain CSS — passthrough (no subprocess).
     #[default]
@@ -63,12 +75,12 @@ impl StyleLanguage {
         }
     }
 
-    fn node_script(self) -> &'static str {
+    fn worker_script(self) -> &'static str {
         match self {
-            StyleLanguage::Scss => SCSS_SCRIPT,
-            StyleLanguage::Sass => SASS_INDENTED_SCRIPT,
-            StyleLanguage::Less => LESS_SCRIPT,
-            StyleLanguage::Stylus => STYLUS_SCRIPT,
+            StyleLanguage::Scss => SCSS_WORKER,
+            StyleLanguage::Sass => SASS_INDENTED_WORKER,
+            StyleLanguage::Less => LESS_WORKER,
+            StyleLanguage::Stylus => STYLUS_WORKER,
             StyleLanguage::Css => "",
         }
     }
@@ -77,10 +89,10 @@ impl StyleLanguage {
 /// Compile `content` into plain CSS using `language`'s preprocessor.
 ///
 /// `project_root` is used to locate the npm package in `node_modules` and as
-/// the subprocess's working directory (so relative `@use`/`@import` resolve
+/// the worker's working directory (so relative `@use`/`@import` resolve
 /// against the project). `source_path` is attached to diagnostics.
 ///
-/// Plain CSS is returned unchanged — no subprocess is spawned.
+/// Plain CSS is returned unchanged — no subprocess is involved.
 pub fn preprocess_style(
     content: &str,
     language: StyleLanguage,
@@ -106,61 +118,38 @@ pub fn preprocess_style(
         });
     }
 
-    let mut child = Command::new("node")
-        .arg("-e")
-        .arg(language.node_script())
-        .current_dir(project_root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| NgcError::StyleError {
-            path: source_path.to_path_buf(),
-            message: format!(
-                "could not run node for {} preprocessing: {e}",
-                language.as_str()
-            ),
-        })?;
+    let slot = worker_slot(language, project_root);
+    let mut guard = slot
+        .lock()
+        .map_err(|_| style_error(source_path, language, "worker mutex poisoned"))?;
 
-    {
-        let stdin = child.stdin.as_mut().ok_or_else(|| NgcError::StyleError {
-            path: source_path.to_path_buf(),
-            message: format!("could not open stdin for {} subprocess", language.as_str()),
-        })?;
-        stdin
-            .write_all(content.as_bytes())
-            .map_err(|e| NgcError::StyleError {
-                path: source_path.to_path_buf(),
-                message: format!(
-                    "could not write to {} subprocess stdin: {e}",
-                    language.as_str()
-                ),
-            })?;
+    if guard.is_none() {
+        *guard = Some(StyleWorker::spawn(language, project_root, source_path)?);
     }
+    let worker = guard.as_mut().expect("just inserted");
 
-    let output = child.wait_with_output().map_err(|e| NgcError::StyleError {
-        path: source_path.to_path_buf(),
-        message: format!("failed to await {} subprocess: {e}", language.as_str()),
-    })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(NgcError::StyleError {
+    match worker.request(content) {
+        Ok(WorkerOutcome::Css(css)) => Ok(css),
+        Ok(WorkerOutcome::CompileError(message)) => Err(NgcError::StyleError {
             path: source_path.to_path_buf(),
             message: format!(
                 "{} preprocessing failed: {}",
                 language.as_str(),
-                stderr.trim()
+                message.trim()
             ),
-        });
+        }),
+        Err(fatal) => {
+            *guard = None;
+            Err(NgcError::StyleError {
+                path: source_path.to_path_buf(),
+                message: format!(
+                    "{} preprocessor subprocess crashed: {}",
+                    language.as_str(),
+                    fatal
+                ),
+            })
+        }
     }
-    String::from_utf8(output.stdout).map_err(|e| NgcError::StyleError {
-        path: source_path.to_path_buf(),
-        message: format!(
-            "{} preprocessor output was not valid UTF-8: {e}",
-            language.as_str()
-        ),
-    })
 }
 
 /// Convenience: read a style file from disk and preprocess it.
@@ -186,67 +175,278 @@ pub struct ComponentStyles {
     pub resolved_urls: Vec<PathBuf>,
 }
 
-const SCSS_SCRIPT: &str = r#"
-const sass = require('sass');
-const chunks = [];
-process.stdin.on('data', c => chunks.push(c));
-process.stdin.on('end', () => {
-    try {
-        const input = Buffer.concat(chunks).toString('utf8');
-        const out = sass.compileString(input);
-        process.stdout.write(out.css);
-    } catch (err) {
-        console.error(err && err.message ? err.message : String(err));
-        process.exit(1);
+// ---------------------------------------------------------------------------
+// Worker registry
+// ---------------------------------------------------------------------------
+
+type WorkerSlot = Arc<Mutex<Option<StyleWorker>>>;
+
+fn worker_slot(language: StyleLanguage, project_root: &Path) -> WorkerSlot {
+    static REGISTRY: OnceLock<Mutex<HashMap<(StyleLanguage, PathBuf), WorkerSlot>>> =
+        OnceLock::new();
+    let registry = REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
+    let key = (language, project_root.to_path_buf());
+    let mut map = registry.lock().expect("worker registry poisoned");
+    map.entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(None)))
+        .clone()
+}
+
+fn style_error(source_path: &Path, language: StyleLanguage, what: &str) -> NgcError {
+    NgcError::StyleError {
+        path: source_path.to_path_buf(),
+        message: format!("{}: {}", language.as_str(), what),
     }
-});
-"#;
+}
 
-const SASS_INDENTED_SCRIPT: &str = r#"
-const sass = require('sass');
-const chunks = [];
-process.stdin.on('data', c => chunks.push(c));
-process.stdin.on('end', () => {
-    try {
-        const input = Buffer.concat(chunks).toString('utf8');
-        const out = sass.compileString(input, { syntax: 'indented' });
-        process.stdout.write(out.css);
-    } catch (err) {
-        console.error(err && err.message ? err.message : String(err));
-        process.exit(1);
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+enum WorkerOutcome {
+    Css(String),
+    CompileError(String),
+}
+
+struct StyleWorker {
+    /// Stays alive as long as the worker. Drop kills the process.
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    stderr_buf: Arc<Mutex<String>>,
+    next_id: u64,
+    language: StyleLanguage,
+}
+
+impl StyleWorker {
+    fn spawn(language: StyleLanguage, project_root: &Path, source_path: &Path) -> NgcResult<Self> {
+        let mut child = Command::new("node")
+            .arg("-e")
+            .arg(language.worker_script())
+            .current_dir(project_root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| NgcError::StyleError {
+                path: source_path.to_path_buf(),
+                message: format!(
+                    "could not run node for {} preprocessing: {e}",
+                    language.as_str()
+                ),
+            })?;
+
+        let stdin = child.stdin.take().ok_or_else(|| NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!("could not open stdin for {} subprocess", language.as_str()),
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!("could not open stdout for {} subprocess", language.as_str()),
+        })?;
+        let stderr = child.stderr.take().ok_or_else(|| NgcError::StyleError {
+            path: source_path.to_path_buf(),
+            message: format!("could not open stderr for {} subprocess", language.as_str()),
+        })?;
+
+        let stderr_buf = Arc::new(Mutex::new(String::new()));
+        let stderr_buf_thr = Arc::clone(&stderr_buf);
+        thread::spawn(move || {
+            let mut reader = stderr;
+            let mut buf = Vec::new();
+            let _ = reader.read_to_end(&mut buf);
+            if let Ok(mut guard) = stderr_buf_thr.lock() {
+                guard.push_str(&String::from_utf8_lossy(&buf));
+            }
+        });
+
+        Ok(StyleWorker {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            stderr_buf,
+            next_id: 0,
+            language,
+        })
     }
-});
-"#;
 
-const LESS_SCRIPT: &str = r#"
-const less = require('less');
-const chunks = [];
-process.stdin.on('data', c => chunks.push(c));
-process.stdin.on('end', () => {
-    const input = Buffer.concat(chunks).toString('utf8');
-    less.render(input).then(out => {
-        process.stdout.write(out.css);
-    }).catch(err => {
-        console.error(err && err.message ? err.message : String(err));
-        process.exit(1);
-    });
-});
-"#;
+    fn request(&mut self, content: &str) -> Result<WorkerOutcome, String> {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
 
-const STYLUS_SCRIPT: &str = r#"
-const stylus = require('stylus');
-const chunks = [];
-process.stdin.on('data', c => chunks.push(c));
-process.stdin.on('end', () => {
-    const input = Buffer.concat(chunks).toString('utf8');
-    stylus.render(input, (err, css) => {
-        if (err) {
-            console.error(err && err.message ? err.message : String(err));
-            process.exit(1);
+        let payload = serde_json::json!({ "id": id, "input": content });
+        let line = serde_json::to_string(&payload)
+            .map_err(|e| format!("could not encode request: {e}"))?;
+
+        if let Err(e) = self
+            .stdin
+            .write_all(line.as_bytes())
+            .and_then(|_| self.stdin.write_all(b"\n"))
+            .and_then(|_| self.stdin.flush())
+        {
+            return Err(format!(
+                "could not write request: {e} ({})",
+                self.drain_stderr()
+            ));
         }
-        process.stdout.write(css);
+
+        let mut response = String::new();
+        let n = self
+            .stdout
+            .read_line(&mut response)
+            .map_err(|e| format!("could not read response: {e} ({})", self.drain_stderr()))?;
+        if n == 0 {
+            return Err(format!(
+                "subprocess exited before reply ({})",
+                self.drain_stderr()
+            ));
+        }
+
+        let value: serde_json::Value = serde_json::from_str(response.trim_end())
+            .map_err(|e| format!("malformed response: {e}; payload: {response}"))?;
+        let resp_id = value.get("id").and_then(|v| v.as_u64());
+        if resp_id != Some(id) {
+            return Err(format!(
+                "id mismatch: expected {id}, got {resp_id:?} (payload: {response})"
+            ));
+        }
+        let ok = value.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+        if !ok {
+            let err = value
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(no error message)")
+                .to_string();
+            return Ok(WorkerOutcome::CompileError(err));
+        }
+        let css = value
+            .get("css")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        Ok(WorkerOutcome::Css(css))
+    }
+
+    /// Best-effort capture of any stderr the worker emitted before dying. The
+    /// drain thread reads asynchronously, so we sleep briefly to give it a
+    /// chance to flush after an EOF on stdout.
+    fn drain_stderr(&self) -> String {
+        thread::sleep(Duration::from_millis(20));
+        let s = self
+            .stderr_buf
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            format!("no stderr from {} worker", self.language.as_str())
+        } else {
+            trimmed.to_string()
+        }
+    }
+}
+
+impl Drop for StyleWorker {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker scripts (NDJSON: one request line in, one response line out)
+// ---------------------------------------------------------------------------
+//
+// Request:  {"id": <u64>, "input": "<css source>"}
+// Response: {"id": <u64>, "ok": true,  "css":   "<compiled css>"}
+//        or {"id": <u64>, "ok": false, "error": "<message>"}
+
+const SCSS_WORKER: &str = r#"
+const sass = require('sass');
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+    let req;
+    try { req = JSON.parse(line); }
+    catch (e) {
+        process.stdout.write(JSON.stringify({ id: -1, ok: false, error: 'invalid request: ' + (e && e.message ? e.message : String(e)) }) + '\n');
+        return;
+    }
+    try {
+        const out = sass.compileString(req.input);
+        process.stdout.write(JSON.stringify({ id: req.id, ok: true, css: out.css }) + '\n');
+    } catch (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        process.stdout.write(JSON.stringify({ id: req.id, ok: false, error: msg }) + '\n');
+    }
+});
+rl.on('close', () => process.exit(0));
+"#;
+
+const SASS_INDENTED_WORKER: &str = r#"
+const sass = require('sass');
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+    let req;
+    try { req = JSON.parse(line); }
+    catch (e) {
+        process.stdout.write(JSON.stringify({ id: -1, ok: false, error: 'invalid request: ' + (e && e.message ? e.message : String(e)) }) + '\n');
+        return;
+    }
+    try {
+        const out = sass.compileString(req.input, { syntax: 'indented' });
+        process.stdout.write(JSON.stringify({ id: req.id, ok: true, css: out.css }) + '\n');
+    } catch (err) {
+        const msg = (err && err.message) ? err.message : String(err);
+        process.stdout.write(JSON.stringify({ id: req.id, ok: false, error: msg }) + '\n');
+    }
+});
+rl.on('close', () => process.exit(0));
+"#;
+
+const LESS_WORKER: &str = r#"
+const less = require('less');
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+    let req;
+    try { req = JSON.parse(line); }
+    catch (e) {
+        process.stdout.write(JSON.stringify({ id: -1, ok: false, error: 'invalid request: ' + (e && e.message ? e.message : String(e)) }) + '\n');
+        return;
+    }
+    less.render(req.input).then((out) => {
+        process.stdout.write(JSON.stringify({ id: req.id, ok: true, css: out.css }) + '\n');
+    }).catch((err) => {
+        const msg = (err && err.message) ? err.message : String(err);
+        process.stdout.write(JSON.stringify({ id: req.id, ok: false, error: msg }) + '\n');
     });
 });
+rl.on('close', () => process.exit(0));
+"#;
+
+const STYLUS_WORKER: &str = r#"
+const stylus = require('stylus');
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+    let req;
+    try { req = JSON.parse(line); }
+    catch (e) {
+        process.stdout.write(JSON.stringify({ id: -1, ok: false, error: 'invalid request: ' + (e && e.message ? e.message : String(e)) }) + '\n');
+        return;
+    }
+    stylus.render(req.input, (err, css) => {
+        if (err) {
+            const msg = (err && err.message) ? err.message : String(err);
+            process.stdout.write(JSON.stringify({ id: req.id, ok: false, error: msg }) + '\n');
+            return;
+        }
+        process.stdout.write(JSON.stringify({ id: req.id, ok: true, css: css }) + '\n');
+    });
+});
+rl.on('close', () => process.exit(0));
 "#;
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #110.

## Summary
- Each preprocessor language (SCSS, Sass-indented, Less, Stylus) now runs in a single long-lived Node worker per build, keyed by `(language, project_root)`.
- Workers speak NDJSON over stdin/stdout: one JSON request line in, one JSON response line out. Calls are serialised through `Arc<Mutex<Option<StyleWorker>>>` so rayon multi-component parallelism multiplexes safely onto the single Node process.
- Subprocess crashes are surfaced as `NgcError::StyleError` with captured stderr; the dead worker is dropped from the registry so the next request re-spawns instead of hanging.
- Public `preprocess_style()` / `preprocess_file()` signatures unchanged; all 8 existing SCSS/Less/Stylus integration tests pass without modification.

## Hyperfine (5 runs, --warmup 3)

### test-ng-project (16 components, `inlineStyleLanguage: scss`) — primary beneficiary
| build | mean ± σ | range |
|---|---|---|
| before | 2.474 s ± 0.488 s | 1.984 s … 2.993 s |
| after  | **325.4 ms ± 7.7 ms** | 315.0 ms … 335.0 ms |

→ **7.6× faster** (~2.15 s saved end-to-end). Per-stage tracing: `template_compile` collapsed from **1.71 s → 27.4 ms**, well below the issue's 250 ms target.

### treasr-frontend (no SCSS, control)
| build | mean ± σ | range |
|---|---|---|
| before | 448.7 ms ± 22.1 ms | 424.6 ms … 475.2 ms |
| after  | 410.6 ms ± 31.4 ms | 391.1 ms … 466.5 ms |

→ Within noise; no regression. Matches the issue prediction (~0 ms expected impact).

## Definition of done
- [x] Both projects build cleanly (`ngc-rs build --configuration production`); `dist/` matches `ng build` semantically (same pre-existing main.js content-hash non-determinism between runs, SCSS output byte-identical).
- [x] `test-ng-project` `template_compile` ≤ 250 ms (27.4 ms).
- [x] `treasr-frontend` no regression vs noise.
- [x] 5-run hyperfine reported above.
- [x] `cargo test --workspace` passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Subprocess crash surfaces clean `NgcError::StyleError` (stderr captured, no panic, no silent hang).

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Production build of `test-ng-project` (16 components, mixed SCSS `styleUrl` + `inlineStyleLanguage: scss` `styles: [...]`)
- [x] Production build of `treasr-frontend` (no SCSS path)
- [x] Hyperfine 5 runs on both projects
