### PR TITLE
perf(cli): pre-scan linker flatten to fold post-flatten npm-resolve into first pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "dashmap",
  "insta",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "dashmap",
  "glob",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "base64",
  "clap",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 license = "MIT"
 authors = ["lukekania"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -432,14 +432,122 @@ pub(crate) fn run_build_with_cache(
 
     // Step 6.6: Link partially compiled Angular npm packages and flatten
     // NgModule references in component dependencies arrays.
+    //
+    // This is the orchestrator-by-hand version of `ngc_linker::link_modules`,
+    // structured so a *pre-scan* can predict the bare specifiers that the
+    // flatten pass would otherwise inject. By resolving them up front (and
+    // before flatten actually rewrites project files), the post-flatten
+    // resolution pass collapses to zero specifiers on the happy path —
+    // saving ~10–20 ms on Angular Material apps where flatten transitively
+    // pulls in subpath packages like `@angular/cdk/portal`.
     let link_span = tracing::info_span!("link").entered();
-    let linker_stats = ngc_linker::link_modules(&mut modules, &config_dir)?;
+    let registry = ngc_linker::ModuleRegistry::new();
+    let public_exports = ngc_linker::PublicExports::new();
+
+    // Pass 1: rewrite npm `ɵɵngDeclare*` → `ɵɵdefine*` and populate registry.
+    let mut linker_stats = ngc_linker::link_npm_modules(&mut modules, &config_dir, &registry)?;
     if linker_stats.files_linked > 0 {
         tracing::info!(
             "linked {} Angular package file(s)",
             linker_stats.files_linked
         );
     }
+
+    // Build the public-exports index over every linked npm file. Mirrors
+    // what `link_modules` does internally; needed for both pre-scan and the
+    // final flatten pass to know which specifier exports each identifier.
+    modules
+        .par_iter()
+        .filter(|(path, _)| ngc_linker::is_npm_path(path))
+        .for_each(|(path, source)| {
+            public_exports.scan_file(source, path);
+        });
+
+    // Pass A: register any `ɵɵdefineNgModule` calls (project AOT output and
+    // pre-compiled npm bundles).
+    linker_stats.modules_registered =
+        ngc_linker::module_registry::scan_define_ng_modules(&modules, &registry)?;
+
+    // Pre-scan: dry-run the flatten walk to discover specifiers it would
+    // inject as brand-new project imports, then resolve them in a delta
+    // npm-resolve before the actual flatten pass runs.
+    //
+    // Short-circuit: if every public-export specifier is already in
+    // `bare_specifiers`, flatten cannot emit a brand-new `import { … }
+    // from '<spec>'` — every name it adds would extend an existing import.
+    // Skipping the dry-run AST walk saves ~3 ms on small projects with a
+    // populated registry but no cross-subpath flattens (test-ng-project).
+    let bare_set: std::collections::HashSet<String> = bare_specifiers.iter().cloned().collect();
+    let prescan_new: Vec<String> = if public_exports.has_specifier_outside(&bare_set) {
+        ngc_linker::flatten::scan_introduced_specifiers(&modules, &registry, &public_exports)
+            .into_iter()
+            .filter(|s| !bare_set.contains(s))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if !prescan_new.is_empty() {
+        tracing::info!(
+            "pre-scan: resolving {} predicted specifier(s) before flatten: {:?}",
+            prescan_new.len(),
+            prescan_new
+        );
+        bare_specifiers.extend(prescan_new.iter().cloned());
+        let extra = ngc_npm_resolver::resolve_npm_dependencies(
+            &prescan_new,
+            &config_dir,
+            export_conditions,
+        )?;
+        tracing::info!(
+            "pre-scan: pulled in {} additional file(s) before flatten",
+            extra.modules.len()
+        );
+        for (path, source) in &extra.modules {
+            modules
+                .entry(path.clone())
+                .or_insert_with(|| source.clone());
+            npm_resolution
+                .modules
+                .entry(path.clone())
+                .or_insert_with(|| source.clone());
+        }
+        for spec in &prescan_new {
+            npm_resolution.resolved_specifiers.insert(spec.clone());
+        }
+        for edge in extra.edges {
+            npm_resolution.edges.push(edge);
+        }
+        // Link the newly-resolved npm files. `link_npm_modules` skips files
+        // already rewritten in the first pass via a substring check, so this
+        // only does work for genuinely new files.
+        let extra_stats = ngc_linker::link_npm_modules(&mut modules, &config_dir, &registry)?;
+        linker_stats.files_linked += extra_stats.files_linked;
+        // Extend public-exports + register-NgModule indices over the *new*
+        // npm files only — re-scanning the full set is correct but burns ~2ms
+        // re-parsing files already indexed in the first pass.
+        let new_paths: Vec<&PathBuf> = extra.modules.keys().collect();
+        new_paths.par_iter().for_each(|path| {
+            if let Some(source) = modules.get(*path) {
+                public_exports.scan_file(source, path);
+            }
+        });
+        let new_modules: HashMap<PathBuf, String> = new_paths
+            .iter()
+            .filter_map(|p| modules.get(*p).map(|s| ((*p).clone(), s.clone())))
+            .collect();
+        linker_stats.modules_registered +=
+            ngc_linker::module_registry::scan_define_ng_modules(&new_modules, &registry)?;
+    }
+
+    // Pass B: flatten standalone-component `dependencies` arrays. With the
+    // pre-scan in place this runs once over a complete registry / public-
+    // exports view, so its injected imports never reference unresolved
+    // specifiers on the happy path.
+    linker_stats.components_flattened = ngc_linker::flatten::flatten_component_dependencies(
+        &mut modules,
+        &registry,
+        &public_exports,
+    )?;
     if linker_stats.components_flattened > 0 {
         tracing::info!(
             "flattened NgModule imports in {} component file(s) across {} registered module(s)",
@@ -448,12 +556,12 @@ pub(crate) fn run_build_with_cache(
         );
     }
 
-    // Step 6.7: Resolve any bare specifiers the flatten pass introduced. When
-    // it injects an `import { CdkPortal } from '@angular/cdk/portal'` into a
-    // project file, that specifier wasn't known to the initial npm resolution
-    // — so we re-scan and resolve the delta, folding the new modules +
-    // internal edges into `npm_resolution` so the graph-construction below
-    // picks them up.
+    // Step 6.7: Correctness fallback. The pre-scan covers the well-known
+    // partial-compilation marker shape, but if any project source still
+    // ends up referencing a bare specifier the resolver hasn't seen (rare
+    // edge case — e.g. flatten injecting a name whose public-export was
+    // unknown until after the delta resolve registered new NgModules), we
+    // still want to resolve it rather than fail in the bundler.
     //
     // Scope the scan to PROJECT files only. Scanning npm files pulls in
     // spurious specifiers from packages' embedded test/dev code (e.g.
@@ -503,8 +611,8 @@ pub(crate) fn run_build_with_cache(
         for edge in extra.edges {
             npm_resolution.edges.push(edge);
         }
-        // Re-run the linker on any newly-pulled-in npm files so their
-        // ɵɵngDeclare calls are transformed too.
+        // Re-run the linker on any newly-pulled-in npm files and re-flatten
+        // so the now-registered NgModules expand correctly.
         let _ = ngc_linker::link_modules(&mut modules, &config_dir)?;
     }
     drop(link_span);

--- a/crates/linker/src/flatten.rs
+++ b/crates/linker/src/flatten.rs
@@ -111,6 +111,76 @@ pub fn flatten_component_dependencies(
     Ok(rewritten)
 }
 
+/// Dry-run flatten: walk every `ɵɵdefineComponent` call in `modules` and
+/// return the sorted, de-duplicated list of npm specifiers that
+/// [`flatten_component_dependencies`] would inject as **brand-new** import
+/// statements (i.e. specifiers not already present in any existing
+/// named-import in the file).
+///
+/// Used by the CLI as a pre-scan so the first npm-resolve call can pull in
+/// transitive Angular subpaths before flatten actually rewrites the project,
+/// eliminating the post-flatten resolution pass on the happy path. Specifiers
+/// that flatten would resolve by *extending an existing* same-source import
+/// are intentionally excluded — those are already in `bare_specifiers`.
+pub fn scan_introduced_specifiers(
+    modules: &HashMap<PathBuf, String>,
+    registry: &ModuleRegistry,
+    public_exports: &PublicExports,
+) -> Vec<String> {
+    if registry.is_empty() {
+        return Vec::new();
+    }
+
+    let work: Vec<(&PathBuf, &String)> = modules
+        .iter()
+        .filter(|(_, source)| source.contains("\u{0275}\u{0275}defineComponent"))
+        .collect();
+
+    let lists: Vec<Vec<String>> = work
+        .par_iter()
+        .map(|(_path, source)| collect_introduced_in_file(source, registry, public_exports))
+        .collect();
+
+    let mut seen = std::collections::BTreeSet::new();
+    for list in lists {
+        for spec in list {
+            seen.insert(spec);
+        }
+    }
+    seen.into_iter().collect()
+}
+
+/// Single-file dry-run helper for [`scan_introduced_specifiers`].
+///
+/// Mirrors the AST walk that [`flatten_one`] performs but discards the
+/// generated `dependencies`-array replacements — only the keys of
+/// `new_imports` are returned, since those are the specifiers that flatten
+/// would emit a fresh `import { … } from '<spec>';` for.
+fn collect_introduced_in_file(
+    source: &str,
+    registry: &ModuleRegistry,
+    public_exports: &PublicExports,
+) -> Vec<String> {
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, source, SourceType::mjs()).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return Vec::new();
+    }
+    let mut imports = collect_named_imports(&parsed.program);
+    let mut new_imports: HashMap<String, NewImport> = HashMap::new();
+    let mut deps_replacements = Vec::new();
+    visit_program_deps(
+        &parsed.program,
+        source,
+        registry,
+        public_exports,
+        &mut imports,
+        &mut new_imports,
+        &mut deps_replacements,
+    );
+    new_imports.into_keys().collect()
+}
+
 fn flatten_one(
     source: &str,
     path: &Path,

--- a/crates/linker/src/public_exports.rs
+++ b/crates/linker/src/public_exports.rs
@@ -110,6 +110,22 @@ impl PublicExports {
     pub fn is_empty(&self) -> bool {
         self.name_to_specifier.is_empty()
     }
+
+    /// Whether *any* registered specifier is absent from `known`.
+    ///
+    /// Used by the CLI's pre-scan short-circuit: if every public-export
+    /// specifier already appears in the initial bare-specifiers set, the
+    /// flatten pass cannot introduce a brand-new import and the dry-run
+    /// AST walk is pure overhead.
+    pub fn has_specifier_outside<S: AsRef<str>>(
+        &self,
+        known: &std::collections::HashSet<S>,
+    ) -> bool {
+        let known: std::collections::HashSet<&str> = known.iter().map(|s| s.as_ref()).collect();
+        self.name_to_specifier
+            .iter()
+            .any(|r| !known.contains(r.value().as_str()))
+    }
 }
 
 /// Return the exported *local* name of an export specifier.


### PR DESCRIPTION
Resolves #115.

Phase 1 baseline showed treasr-frontend's `link` span was inflated by a
**second** `resolve_npm_dependencies` call, triggered when the linker's
flatten pass injects an `import { CdkPortal } from '@angular/cdk/portal'`
into a project component file. That single specifier dragged in 240
additional npm files on every warm build.

This PR pre-scans the project's `ɵɵdefineComponent` calls (a dry-run of
the flatten walk that returns specifiers it would inject as **brand-new**
imports), resolves them inside the existing `npm_resolve` envelope, and
runs flatten exactly once over a complete registry / public-exports view.
The two-pass model is preserved as a correctness fallback.

## Summary

- New `ngc_linker::flatten::scan_introduced_specifiers` — public dry-run
  helper. Walks each component file's `dependencies: [...]` array, expands
  `NgModule` references via the registry, and returns the public-export
  specifiers that flatten would emit a fresh `import { … } from 'X'` for.
- New `PublicExports::has_specifier_outside` — short-circuit so the
  pre-scan AST walk is skipped when no public-export specifier could
  possibly fall outside the initial bare-specifier set.
- CLI `main.rs:474` decomposed into manual `link_npm_modules` →
  `public_exports` build → `scan_define_ng_modules` → pre-scan → optional
  delta resolve → `flatten_component_dependencies` (single pass), with the
  original post-flatten resolve kept as a correctness fallback.

## Hyperfine (warm cache, 10 runs each, mean ± σ)

| Project | Baseline (v0.9.4) | This PR | Δ |
|---|---:|---:|---:|
| `treasr-frontend` | 404.4 ± 8.7 ms | 387.0 ± 9.5 ms | **−17.4 ms (4.3% faster)** |
| `test-ng-project` | 301.9 ± 3.3 ms | 304.1 ± 2.7 ms | +2.2 ms (within stddev) |

### Per-span (treasr, 10 runs, RUST_LOG=info)

| Span | Baseline | This PR |
|---|---:|---:|
| `npm_resolve` | 30.9 ms | 30.5 ms |
| `link` | 63.3 ms | 56.4 ms (median) |
| **combined** | **94.2 ms** | **86.9 ms** ✓ (DoD ≤ 90 ms) |

### Log-line check (treasr)

```
INFO link: linked 34 Angular package file(s)
INFO link: pre-scan: resolving 1 predicted specifier(s) before flatten: ["@angular/cdk/portal"]
INFO link: pre-scan: pulled in 240 additional file(s) before flatten
INFO link: flattened NgModule imports in 33 component file(s) across 27 registered module(s)
```

The post-flatten `resolving N additional specifier(s) introduced by flatten pass`
line drops to **0 specifiers** on the happy path — DoD ✓.

## Test plan

- [x] `cargo test --workspace` — all suites green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `dist/` byte-identical to v0.9.4 baseline on both projects
      (only `ngsw.json` `timestamp` field differs, expected)
- [x] Pre-scan log fires on treasr (`@angular/cdk/portal`); does not fire on
      test-ng-project (no Angular CDK / Material)
- [x] Hyperfine 5+ runs both projects, results above

