### PR TITLE
feat(builder,cli): add `application` builder + `BuilderOutput`-shaped --output-json

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::time::Instant;
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;
@@ -20,15 +21,125 @@ mod polyfills;
 mod serve_cmd;
 mod watch_cmd;
 
-/// Result of the bundled build pipeline.
-#[derive(serde::Serialize)]
+/// Severity of a build-pipeline diagnostic, surfaced both to stdout JSON
+/// and to the architect builder shim (`@ngc-rs/builder:application`).
+#[derive(Debug, serde::Serialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum Severity {
+    /// Fatal diagnostic — the build did not complete successfully.
+    Error,
+    /// Non-fatal diagnostic — surfaced to the user but the build still
+    /// produced output.
+    Warning,
+}
+
+/// One entry in [`BuildResult::errors`] or [`BuildResult::warnings`]. The
+/// shape mirrors what the `@angular-devkit/architect` protocol expects on
+/// `BuilderOutput`, with optional file/line/column for editor jump-to-source.
+#[derive(Debug, serde::Serialize, Clone)]
+struct Diagnostic {
+    /// File the diagnostic originated from, when one is known.
+    file: Option<PathBuf>,
+    /// 1-based source line, when the underlying error carries location info.
+    line: Option<u32>,
+    /// 1-based source column, when the underlying error carries location info.
+    column: Option<u32>,
+    /// Human-readable description of what went wrong.
+    message: String,
+    /// Severity of the diagnostic.
+    severity: Severity,
+}
+
+impl Diagnostic {
+    /// Build a [`Diagnostic`] from any [`NgcError`], copying its file/line/
+    /// column accessors into the diagnostic and stringifying its
+    /// `Display` form for the message.
+    fn from_ngc_error(err: &NgcError, severity: Severity) -> Self {
+        Self {
+            file: err.file().map(|p| p.to_path_buf()),
+            line: err.line(),
+            column: err.column(),
+            message: err.to_string(),
+            severity,
+        }
+    }
+}
+
+/// Classification of a single output artifact written under `dist/`. The
+/// architect builder consumes this to report JS/CSS/HTML/maps separately
+/// without re-parsing extensions on the consumer side.
+#[derive(Debug, serde::Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum OutputKind {
+    /// JavaScript module (`.js`, `.mjs`, `.cjs`).
+    Script,
+    /// Stylesheet (`.css`).
+    Style,
+    /// Hypertext document (`.html`, `.htm`).
+    Html,
+    /// Source map sidecar (`.map`).
+    SourceMap,
+    /// Anything else copied through to `dist/` (images, fonts, JSON, etc.).
+    Asset,
+}
+
+impl OutputKind {
+    /// Classify a path by file extension. Falls back to [`OutputKind::Asset`]
+    /// for unrecognised extensions and for paths with no extension.
+    fn from_path(p: &Path) -> Self {
+        match p.extension().and_then(|e| e.to_str()) {
+            Some("js" | "mjs" | "cjs") => OutputKind::Script,
+            Some("css") => OutputKind::Style,
+            Some("html" | "htm") => OutputKind::Html,
+            Some("map") => OutputKind::SourceMap,
+            _ => OutputKind::Asset,
+        }
+    }
+}
+
+/// One file written under [`BuildResult::output_path`], with size and kind.
+/// `BuildResult.output_files` is a `Vec<OutputFile>`; internal callers
+/// (watch/serve loops) read only `.len()` and the aggregate
+/// `total_size_bytes` field, so the structural change is local.
+#[derive(Debug, serde::Serialize, Clone)]
+struct OutputFile {
+    /// Absolute path to the written file.
+    path: PathBuf,
+    /// Size of the file in bytes (0 if `stat` failed).
+    size: u64,
+    /// Coarse classification of the file by extension.
+    kind: OutputKind,
+}
+
+/// Result of the bundled build pipeline. Shaped to drop directly into a
+/// `BuilderOutput` for `@angular-devkit/architect` — the builder shim
+/// consumes the JSON form emitted by `--output-json` verbatim. On failure
+/// the binary still emits this shape (with `success: false` and `errors`
+/// populated) before exiting non-zero, so the shim can parse a coherent
+/// result regardless of exit code.
+#[derive(Debug, serde::Serialize)]
 struct BuildResult {
+    /// Whether the pipeline completed without fatal errors. The shim maps
+    /// this to `BuilderOutput.success`.
+    success: bool,
+    /// Top-level error message when `success` is `false`. Mirrors the
+    /// `error` field of `BuilderOutput`.
+    error: Option<String>,
+    /// Per-file diagnostics that prevented a successful build.
+    errors: Vec<Diagnostic>,
+    /// Per-file warnings emitted by the pipeline. Empty today; reserved for
+    /// post-1.0 expansion (e.g. JIT-fallback warnings).
+    warnings: Vec<Diagnostic>,
+    /// Absolute path to the dist directory.
+    output_path: PathBuf,
+    /// Every file written under `output_path`, with size and kind.
+    output_files: Vec<OutputFile>,
     /// Number of modules included in the bundle.
     modules_bundled: usize,
-    /// Paths to all output files produced.
-    output_files: Vec<PathBuf>,
     /// Total size in bytes of all output files.
     total_size_bytes: u64,
+    /// Wall-clock duration of the build pipeline.
+    duration_ms: u64,
 }
 
 #[derive(Parser)]
@@ -205,40 +316,60 @@ fn main() {
             configuration,
             output_json,
             localize,
-        } => match run_build(
-            &project,
-            out_dir.as_deref(),
-            configuration.as_deref(),
-            localize,
-        ) {
-            Ok(result) => {
-                if output_json {
-                    let json = serde_json::to_string_pretty(&result)
-                        .expect("BuildResult serialization should not fail");
-                    println!("{json}");
-                } else {
-                    println!("{}", "ngc-rs build complete".bold().green());
-                    println!("  {:<16}{}", "Bundled:".dimmed(), result.modules_bundled);
-                    println!(
-                        "  {:<16}{}",
-                        "Output files:".dimmed(),
-                        result.output_files.len()
-                    );
-                    println!(
-                        "  {:<16}{}",
-                        "Total size:".dimmed(),
-                        format_bytes(result.total_size_bytes)
-                    );
-                    for path in &result.output_files {
-                        println!("  {:<16}{}", "".dimmed(), path.display());
+        } => {
+            let started = Instant::now();
+            match run_build(
+                &project,
+                out_dir.as_deref(),
+                configuration.as_deref(),
+                localize,
+            ) {
+                Ok(result) => {
+                    if output_json {
+                        let json = serde_json::to_string_pretty(&result)
+                            .expect("BuildResult serialization should not fail");
+                        println!("{json}");
+                    } else {
+                        println!("{}", "ngc-rs build complete".bold().green());
+                        println!("  {:<16}{}", "Bundled:".dimmed(), result.modules_bundled);
+                        println!(
+                            "  {:<16}{}",
+                            "Output files:".dimmed(),
+                            result.output_files.len()
+                        );
+                        println!(
+                            "  {:<16}{}",
+                            "Total size:".dimmed(),
+                            format_bytes(result.total_size_bytes)
+                        );
+                        for f in &result.output_files {
+                            println!("  {:<16}{}", "".dimmed(), f.path.display());
+                        }
                     }
                 }
+                Err(e) => {
+                    if output_json {
+                        let result = BuildResult {
+                            success: false,
+                            error: Some(e.to_string()),
+                            errors: vec![Diagnostic::from_ngc_error(&e, Severity::Error)],
+                            warnings: Vec::new(),
+                            output_path: out_dir.clone().unwrap_or_else(|| PathBuf::from("dist")),
+                            output_files: Vec::new(),
+                            modules_bundled: 0,
+                            total_size_bytes: 0,
+                            duration_ms: started.elapsed().as_millis() as u64,
+                        };
+                        let json = serde_json::to_string_pretty(&result)
+                            .expect("BuildResult serialization should not fail");
+                        println!("{json}");
+                    } else {
+                        eprintln!("{} {e}", "Error:".red().bold());
+                    }
+                    process::exit(1);
+                }
             }
-            Err(e) => {
-                eprintln!("{} {e}", "Error:".red().bold());
-                process::exit(1);
-            }
-        },
+        }
     }
 }
 
@@ -279,6 +410,8 @@ pub(crate) fn run_build_with_cache(
     localize: bool,
     mut cache: Option<&mut incremental::BuildCache>,
 ) -> NgcResult<BuildResult> {
+    let started_at = Instant::now();
+
     // Step 1: Try to find angular.json
     let angular_project = find_and_resolve_angular_json(project, configuration)?;
 
@@ -348,7 +481,11 @@ pub(crate) fn run_build_with_cache(
         compile_decorators_cached(&files, &style_ctx, cache.as_deref_mut(), &file_hashes)?;
     drop(templates_span);
 
-    // Report any JIT fallbacks
+    // Report any JIT fallbacks. Each fallback also goes into
+    // `BuildResult.warnings` so the architect builder shim can surface it
+    // through `BuilderContext.logger.warn` rather than relying on stderr
+    // scraping.
+    let mut warnings: Vec<Diagnostic> = Vec::new();
     for cf in &compiled {
         if cf.jit_fallback {
             eprintln!(
@@ -356,6 +493,13 @@ pub(crate) fn run_build_with_cache(
                 "Warning:".yellow().bold(),
                 cf.source_path.display()
             );
+            warnings.push(Diagnostic {
+                file: Some(cf.source_path.clone()),
+                line: None,
+                column: None,
+                message: format!("JIT fallback for {}", cf.source_path.display()),
+                severity: Severity::Warning,
+            });
         }
     }
 
@@ -900,18 +1044,35 @@ pub(crate) fn run_build_with_cache(
         output_files = localized_files;
     }
 
-    // Compute total size
-    let total_size_bytes = output_files
-        .iter()
-        .filter_map(|p| std::fs::metadata(p).ok())
-        .map(|m| m.len())
-        .sum();
+    // Stat each written path and tag it with its OutputKind. Failed stats
+    // (e.g. file removed mid-build) report size 0 rather than aborting —
+    // matches the prior behaviour of silently dropping such entries from
+    // the size sum.
+    let output_files: Vec<OutputFile> = output_files
+        .into_iter()
+        .map(|p| {
+            let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+            let kind = OutputKind::from_path(&p);
+            OutputFile {
+                path: p,
+                size,
+                kind,
+            }
+        })
+        .collect();
+    let total_size_bytes = output_files.iter().map(|f| f.size).sum();
     drop(io_span);
 
     Ok(BuildResult {
-        modules_bundled,
+        success: true,
+        error: None,
+        errors: Vec::new(),
+        warnings,
+        output_path: out_dir,
         output_files,
+        modules_bundled,
         total_size_bytes,
+        duration_ms: started_at.elapsed().as_millis() as u64,
     })
 }
 

--- a/crates/cli/tests/build_json_output.rs
+++ b/crates/cli/tests/build_json_output.rs
@@ -1,0 +1,133 @@
+//! Integration tests that exercise the `--output-json` payload of
+//! `ngc-rs build`. The shape is consumed by `@ngc-rs/builder:application`,
+//! so any drift in field names or types is a public-API break — these
+//! tests pin the contract.
+//!
+//! Both the success and failure paths must emit a valid JSON object on
+//! stdout: failure runs still set `success: false` and populate `errors`
+//! before exiting non-zero, so the architect builder shim can parse a
+//! coherent result without scraping stderr.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn write_minimal_fixture(root: &Path) {
+    let tsconfig = r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        src.join("main.ts"),
+        "export const x: number = 1;\nconsole.log(x);\n",
+    )
+    .expect("write main.ts");
+}
+
+fn run_build_json(root: &Path, out_dir: &Path) -> (i32, String, String) {
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let output = Command::new(bin)
+        .args(["build", "--project"])
+        .arg(root.join("tsconfig.json"))
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--output-json")
+        .output()
+        .expect("spawn ngc-rs build");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    (output.status.code().unwrap_or(-1), stdout, stderr)
+}
+
+#[test]
+fn output_json_success_payload_matches_builder_output_shape() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_minimal_fixture(dir.path());
+    let out_dir = dir.path().join("dist");
+
+    let (code, stdout, stderr) = run_build_json(dir.path(), &out_dir);
+    assert_eq!(code, 0, "build should succeed; stderr:\n{stderr}");
+
+    let v: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout is not valid JSON: {e}\n--- stdout ---\n{stdout}");
+    });
+
+    // Required fields and their types.
+    assert_eq!(v["success"], Value::Bool(true));
+    assert!(v["error"].is_null());
+    assert!(v["errors"].is_array());
+    assert_eq!(v["errors"].as_array().expect("errors").len(), 0);
+    assert!(v["warnings"].is_array());
+    assert!(v["output_path"].is_string());
+    assert!(v["output_files"].is_array());
+    assert!(v["modules_bundled"].is_number());
+    assert!(v["total_size_bytes"].is_number());
+    assert!(v["duration_ms"].is_number());
+
+    // Output-files entries each have path/size/kind with the expected
+    // kebab-case kind enum.
+    let files = v["output_files"].as_array().expect("output_files");
+    assert!(!files.is_empty(), "expected at least one output file");
+    for f in files {
+        assert!(f["path"].is_string(), "output file missing path: {f}");
+        assert!(f["size"].is_number(), "output file missing size: {f}");
+        let kind = f["kind"].as_str().expect("kind");
+        assert!(
+            matches!(kind, "script" | "style" | "html" | "source-map" | "asset"),
+            "unexpected output kind: {kind}",
+        );
+    }
+}
+
+#[test]
+fn output_json_failure_payload_emits_valid_json_with_success_false() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Intentionally invalid: tsconfig missing on the path we point at.
+    let out_dir = dir.path().join("dist");
+    let bogus_tsconfig = dir.path().join("does-not-exist.json");
+
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let output = Command::new(bin)
+        .args(["build", "--project"])
+        .arg(&bogus_tsconfig)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--output-json")
+        .output()
+        .expect("spawn ngc-rs build");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "build should fail when tsconfig is missing",
+    );
+
+    let v: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("failure path must still emit valid JSON; parse error: {e}\nstdout:\n{stdout}");
+    });
+
+    assert_eq!(v["success"], Value::Bool(false));
+    assert!(
+        v["error"].is_string(),
+        "failure payload should populate `error`: {v}"
+    );
+    assert!(
+        v["errors"].is_array() && !v["errors"].as_array().unwrap().is_empty(),
+        "failure payload should populate `errors`: {v}"
+    );
+    let first = &v["errors"][0];
+    assert!(first["message"].is_string());
+    assert_eq!(first["severity"], Value::String("error".to_string()));
+}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -265,6 +265,71 @@ pub enum NgcError {
 /// A type alias for Results using NgcError.
 pub type NgcResult<T> = Result<T, NgcError>;
 
+impl NgcError {
+    /// Returns the source file associated with this error, when one exists.
+    /// Variants that describe a file or location problem expose their `path`
+    /// field; variants that describe a stage-level failure (e.g.
+    /// [`NgcError::BundleError`], [`NgcError::ConfigError`]) return `None`.
+    /// The architect builder shim consumes this to populate `Diagnostic.file`.
+    pub fn file(&self) -> Option<&std::path::Path> {
+        match self {
+            NgcError::Io { path, .. }
+            | NgcError::TsConfigParse { path, .. }
+            | NgcError::TsConfigExtendsNotFound { path }
+            | NgcError::ParseError { path, .. }
+            | NgcError::TransformError { path, .. }
+            | NgcError::TemplateParseError { path, .. }
+            | NgcError::TemplateCompileError { path, .. }
+            | NgcError::AngularJsonParse { path, .. }
+            | NgcError::ProjectNotFound { path, .. }
+            | NgcError::AssetError { path, .. }
+            | NgcError::StyleError { path, .. }
+            | NgcError::SourceMapError { path, .. }
+            | NgcError::MinifyError { path, .. }
+            | NgcError::LinkerError { path, .. } => Some(path),
+            NgcError::UnresolvedImport { from_file, .. } => Some(from_file),
+            NgcError::TsConfigCircularExtends { chain } => chain.first().map(PathBuf::as_path),
+            NgcError::CircularDependency { cycle } => cycle.first().map(PathBuf::as_path),
+            NgcError::InvalidPathAlias { .. }
+            | NgcError::BundleError { .. }
+            | NgcError::JsonOutputError { .. }
+            | NgcError::ChunkError { .. }
+            | NgcError::NpmResolutionError { .. }
+            | NgcError::ConfigError { .. }
+            | NgcError::WatchError { .. }
+            | NgcError::ServeError { .. } => None,
+        }
+    }
+
+    /// Returns the 1-based source line number associated with this error,
+    /// when one is available. Only variants that carry parser/compiler
+    /// location data populate this.
+    pub fn line(&self) -> Option<u32> {
+        match self {
+            NgcError::ParseError { line, .. }
+            | NgcError::TransformError { line, .. }
+            | NgcError::TemplateParseError { line, .. }
+            | NgcError::TemplateCompileError { line, .. }
+            | NgcError::LinkerError { line, .. } => *line,
+            _ => None,
+        }
+    }
+
+    /// Returns the 1-based source column number associated with this error,
+    /// when one is available. Only variants that carry parser/compiler
+    /// location data populate this.
+    pub fn column(&self) -> Option<u32> {
+        match self {
+            NgcError::ParseError { column, .. }
+            | NgcError::TransformError { column, .. }
+            | NgcError::TemplateParseError { column, .. }
+            | NgcError::TemplateCompileError { column, .. }
+            | NgcError::LinkerError { column, .. } => *column,
+            _ => None,
+        }
+    }
+}
+
 /// Format an optional `(line, column)` pair as `:line:col` (or `:line` when
 /// only the line is known) for embedding in `Display` output. Returns an
 /// empty string when neither is known.
@@ -326,5 +391,48 @@ mod tests {
     fn fmt_loc_renders_empty_when_missing() {
         assert_eq!(fmt_loc(None, None), "");
         assert_eq!(fmt_loc(None, Some(5)), "");
+    }
+
+    #[test]
+    fn file_accessor_returns_path_for_file_variants() {
+        let e = NgcError::ParseError {
+            path: PathBuf::from("/x/y.ts"),
+            message: "boom".into(),
+            line: Some(3),
+            column: Some(7),
+        };
+        assert_eq!(e.file(), Some(std::path::Path::new("/x/y.ts")));
+        assert_eq!(e.line(), Some(3));
+        assert_eq!(e.column(), Some(7));
+    }
+
+    #[test]
+    fn file_accessor_returns_from_file_for_unresolved_import() {
+        let e = NgcError::UnresolvedImport {
+            specifier: "./missing".into(),
+            from_file: PathBuf::from("/x/main.ts"),
+        };
+        assert_eq!(e.file(), Some(std::path::Path::new("/x/main.ts")));
+        assert_eq!(e.line(), None);
+        assert_eq!(e.column(), None);
+    }
+
+    #[test]
+    fn file_accessor_returns_none_for_stage_level_variants() {
+        let e = NgcError::BundleError {
+            message: "boom".into(),
+        };
+        assert_eq!(e.file(), None);
+        assert_eq!(e.line(), None);
+        assert_eq!(e.column(), None);
+    }
+
+    #[test]
+    fn file_accessor_returns_first_path_in_chain() {
+        let chain = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        let e = NgcError::TsConfigCircularExtends {
+            chain: chain.clone(),
+        };
+        assert_eq!(e.file(), Some(chain[0].as_path()));
     }
 }

--- a/packages/builder/builders.json
+++ b/packages/builder/builders.json
@@ -1,6 +1,11 @@
 {
   "$schema": "../../node_modules/@angular-devkit/architect/src/builders-schema.json",
   "builders": {
+    "application": {
+      "implementation": "./dist/build/builder",
+      "schema": "./schemas/application.json",
+      "description": "Application builder backed by ngc-rs (drop-in for @angular/build:application)."
+    },
     "dev-server": {
       "implementation": "./dist/serve/builder",
       "schema": "./schemas/dev-server.json",

--- a/packages/builder/schemas/application.json
+++ b/packages/builder/schemas/application.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "ngc-rs application target",
+  "description": "Application builder options for @ngc-rs/builder. Mirrors the most-used subset of @angular/build:application so projects can swap one line in angular.json. Fields not yet handled by ngc-rs are accepted for forward compatibility but documented as ignored. SSR/server/prerender fields are rejected with a hard error so users know upfront.",
+  "type": "object",
+  "properties": {
+    "tsConfig": {
+      "type": "string",
+      "description": "Path to the project's tsconfig.json. Forwarded as `--project` to ngc-rs build."
+    },
+    "outputPath": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "base": { "type": "string" },
+            "browser": { "type": "string" }
+          },
+          "required": ["base"],
+          "additionalProperties": false
+        }
+      ],
+      "description": "Output directory for build artifacts. May be a string or `{ base, browser }`. Forwarded as `--out-dir` to ngc-rs build."
+    },
+    "browser": {
+      "type": "string",
+      "description": "Entry point file (Angular 17+ `browser` field). Read from angular.json by ngc-rs's project resolver; not used directly by the builder shim."
+    },
+    "main": {
+      "type": "string",
+      "description": "Legacy entry point alias. Read from angular.json by ngc-rs's project resolver; not used directly by the builder shim."
+    },
+    "polyfills": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ],
+      "description": "Polyfill entry points. Read from angular.json by ngc-rs."
+    },
+    "index": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "input": { "type": "string" },
+            "output": { "type": "string" }
+          },
+          "required": ["input"],
+          "additionalProperties": false
+        },
+        { "type": "boolean" }
+      ],
+      "description": "Index HTML template. Read from angular.json by ngc-rs."
+    },
+    "assets": {
+      "type": "array",
+      "description": "Static asset entries. Read from angular.json by ngc-rs.",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "properties": {
+              "glob": { "type": "string" },
+              "input": { "type": "string" },
+              "output": { "type": "string" },
+              "ignore": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "styles": {
+      "type": "array",
+      "description": "Global stylesheets. Read from angular.json by ngc-rs.",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "properties": {
+              "input": { "type": "string" },
+              "inject": { "type": "boolean" },
+              "bundleName": { "type": "string" }
+            },
+            "required": ["input"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "scripts": {
+      "type": "array",
+      "description": "Global script entries. NOT YET supported by ngc-rs build. Setting this to a non-empty array fails the build with an explanatory error.",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "object" }
+        ]
+      },
+      "default": []
+    },
+    "fileReplacements": {
+      "type": "array",
+      "description": "Per-configuration file replacements. Read from angular.json by ngc-rs.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "replace": { "type": "string" },
+          "with": { "type": "string" }
+        },
+        "required": ["replace", "with"],
+        "additionalProperties": false
+      }
+    },
+    "sourceMap": {
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "object",
+          "properties": {
+            "scripts": { "type": "boolean" },
+            "styles": { "type": "boolean" },
+            "vendor": { "type": "boolean" },
+            "hidden": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "description": "Source map output. ngc-rs hardcodes source map behaviour per `--configuration` (development = inline, production = external). Setting this option logs a warning if it conflicts with the configuration's default; the configuration default wins."
+    },
+    "optimization": {
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "object",
+          "properties": {
+            "scripts": { "type": "boolean" },
+            "styles": {
+              "oneOf": [
+                { "type": "boolean" },
+                { "type": "object" }
+              ]
+            },
+            "fonts": {
+              "oneOf": [
+                { "type": "boolean" },
+                { "type": "object" }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "description": "Optimization toggles. ngc-rs hardcodes optimization per `--configuration` (development = off, production = on). Setting this option logs a warning if it conflicts with the configuration's default; the configuration default wins."
+    },
+    "outputHashing": {
+      "type": "string",
+      "enum": ["none", "all", "media", "bundles"],
+      "description": "Filename hashing scheme. ngc-rs uses content hashes in production and stable names in development. Setting this option logs a warning if it conflicts; the configuration default wins."
+    },
+    "namedChunks": {
+      "type": "boolean",
+      "description": "Use named chunks instead of hashes. Accepted for compatibility but ngc-rs always derives chunk names from the lazy-route module path."
+    },
+    "vendorChunk": {
+      "type": "boolean",
+      "description": "Emit a separate vendor bundle. Legacy webpack option. Ignored by ngc-rs (no equivalent in its bundler)."
+    },
+    "aot": {
+      "type": "boolean",
+      "description": "Ahead-of-time compilation. Always on in ngc-rs (no JIT path). Setting this to false logs a warning."
+    },
+    "baseHref": {
+      "type": "string",
+      "description": "URL prefix for the application. Read from angular.json by ngc-rs."
+    },
+    "deployUrl": {
+      "type": "string",
+      "description": "URL prefix for static assets. Read from angular.json by ngc-rs."
+    },
+    "crossOrigin": {
+      "type": "string",
+      "enum": ["none", "anonymous", "use-credentials"],
+      "description": "crossorigin attribute on injected script/link tags. Read from angular.json by ngc-rs."
+    },
+    "subresourceIntegrity": {
+      "type": "boolean",
+      "description": "Emit SRI hashes on injected script/link tags. Read from angular.json by ngc-rs."
+    },
+    "serviceWorker": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "string" }
+      ],
+      "description": "Generate `ngsw.json` service-worker manifest. Read from angular.json by ngc-rs."
+    },
+    "ngswConfigPath": {
+      "type": "string",
+      "description": "Path to a custom ngsw config. Read from angular.json by ngc-rs."
+    },
+    "preserveSymlinks": {
+      "type": "boolean",
+      "description": "Preserve symlinks during module resolution. Accepted for compatibility; ngc-rs always canonicalises paths."
+    },
+    "statsJson": {
+      "type": "boolean",
+      "description": "Emit a webpack-style stats.json. NOT supported by ngc-rs. Setting this to true logs a warning."
+    },
+    "budgets": {
+      "type": "array",
+      "description": "Performance budgets. NOT yet enforced by ngc-rs but accepted for compatibility.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "externalDependencies": {
+      "type": "array",
+      "description": "Modules to keep external (not bundled). Accepted for compatibility but currently ignored by ngc-rs.",
+      "items": { "type": "string" }
+    },
+    "allowedCommonJsDependencies": {
+      "type": "array",
+      "description": "CommonJS dependencies to allow without warning. Accepted for compatibility; ngc-rs has no equivalent restriction.",
+      "items": { "type": "string" }
+    },
+    "extractLicenses": {
+      "type": "boolean",
+      "description": "Extract third-party licenses. Always on in ngc-rs (3rdpartylicenses.txt is always emitted)."
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Verbose output. Accepted for compatibility but currently ignored by ngc-rs (use `RUST_LOG=info` env var for tracing output)."
+    },
+    "progress": {
+      "type": "boolean",
+      "description": "Display build progress. Accepted for compatibility but currently ignored by ngc-rs."
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Run in watch mode. NOT yet supported by the application builder; use the `dev-server` builder for incremental rebuilds. Setting this to true fails the build."
+    },
+    "prerender": {
+      "description": "Prerender pages at build time. SSR-related; NOT supported by ngc-rs. Setting this fails the build with a clear error.",
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "object" }
+      ]
+    },
+    "ssr": {
+      "description": "Server-side rendering output. SSR is out of scope for ngc-rs v1. Setting this fails the build.",
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "object" }
+      ]
+    },
+    "server": {
+      "type": "string",
+      "description": "Server entry point for SSR. Out of scope for ngc-rs v1. Setting this fails the build."
+    },
+    "outputMode": {
+      "type": "string",
+      "enum": ["static", "server"],
+      "description": "Static vs server output mode. Server mode is out of scope for ngc-rs v1. Setting `server` fails the build."
+    },
+    "ngcRsBinary": {
+      "type": "string",
+      "description": "Optional override for the ngc-rs binary path. If unset, the shim looks at the NGC_RS_BINARY env var, then a node_modules platform package, then a workspace-relative target/release/ngc-rs, and finally PATH."
+    },
+    "localize": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "array", "items": { "type": "string" } }
+      ],
+      "description": "Generate per-locale builds. When set to true ngc-rs is invoked with `--localize` and emits one output tree per `i18n.locales` entry in angular.json. Selecting a locale subset (array form) is NOT yet honoured by ngc-rs and logs a warning."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/builder/src/build/README.md
+++ b/packages/builder/src/build/README.md
@@ -1,1 +1,0 @@
-Reserved for the build builder added by issue #28.

--- a/packages/builder/src/build/__tests__/options.test.ts
+++ b/packages/builder/src/build/__tests__/options.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ApplicationOptions,
+  OptionTranslationError,
+  translateOptions,
+} from '../options';
+
+const minimal: Partial<ApplicationOptions> = {
+  tsConfig: 'tsconfig.app.json',
+};
+
+describe('translateOptions (build)', () => {
+  it('emits build args with project, output-json, and the architect configuration', () => {
+    const t = translateOptions(minimal, '/ws', 'production');
+    expect(t.args).toEqual([
+      'build',
+      '--project',
+      'tsconfig.app.json',
+      '--output-json',
+      '--configuration',
+      'production',
+    ]);
+    expect(t.warnings).toEqual([]);
+  });
+
+  it('omits --configuration when the architect target has no configuration', () => {
+    const t = translateOptions(minimal, '/ws', null);
+    expect(t.args).not.toContain('--configuration');
+  });
+
+  it('forwards string outputPath as a workspace-relative --out-dir', () => {
+    const t = translateOptions(
+      { ...minimal, outputPath: 'dist/my-app' },
+      '/ws',
+      null,
+    );
+    const i = t.args.indexOf('--out-dir');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(t.args[i + 1]).toBe('/ws/dist/my-app');
+  });
+
+  it('uses the `base` field when outputPath is the {base, browser} object form', () => {
+    const t = translateOptions(
+      { ...minimal, outputPath: { base: 'dist/app', browser: 'browser' } },
+      '/ws',
+      null,
+    );
+    const i = t.args.indexOf('--out-dir');
+    expect(t.args[i + 1]).toBe('/ws/dist/app');
+  });
+
+  it('appends --localize when localize is true', () => {
+    const t = translateOptions({ ...minimal, localize: true }, '/ws', null);
+    expect(t.args).toContain('--localize');
+  });
+
+  it('appends --localize and warns when localize is an array (subset not yet honoured)', () => {
+    const t = translateOptions(
+      { ...minimal, localize: ['en', 'de'] },
+      '/ws',
+      null,
+    );
+    expect(t.args).toContain('--localize');
+    expect(t.warnings.some((w) => w.includes('locale subset'))).toBe(true);
+  });
+
+  it('rejects non-empty scripts arrays', () => {
+    expect(() =>
+      translateOptions(
+        { ...minimal, scripts: ['some.js'] as never },
+        '/ws',
+        null,
+      ),
+    ).toThrow(OptionTranslationError);
+  });
+
+  it('accepts empty scripts arrays without error', () => {
+    expect(() =>
+      translateOptions(
+        { ...minimal, scripts: [] as never },
+        '/ws',
+        null,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects watch=true, prerender, ssr, server, outputMode=server', () => {
+    expect(() =>
+      translateOptions({ ...minimal, watch: true }, '/ws', null),
+    ).toThrow(OptionTranslationError);
+    expect(() =>
+      translateOptions({ ...minimal, prerender: true }, '/ws', null),
+    ).toThrow(OptionTranslationError);
+    expect(() =>
+      translateOptions({ ...minimal, ssr: true }, '/ws', null),
+    ).toThrow(OptionTranslationError);
+    expect(() =>
+      translateOptions({ ...minimal, server: 'src/server.ts' }, '/ws', null),
+    ).toThrow(OptionTranslationError);
+    expect(() =>
+      translateOptions(
+        { ...minimal, outputMode: 'server' as never },
+        '/ws',
+        null,
+      ),
+    ).toThrow(OptionTranslationError);
+  });
+
+  it('warns when sourceMap, optimization, or outputHashing is set (hardcoded by ngc-rs per configuration)', () => {
+    const t = translateOptions(
+      {
+        ...minimal,
+        sourceMap: false,
+        optimization: true,
+        outputHashing: 'all',
+      },
+      '/ws',
+      'production',
+    );
+    expect(t.warnings.some((w) => w.includes('sourceMap'))).toBe(true);
+    expect(t.warnings.some((w) => w.includes('optimization'))).toBe(true);
+    expect(t.warnings.some((w) => w.includes('outputHashing'))).toBe(true);
+  });
+
+  it('warns on aot=false, statsJson, namedChunks, vendorChunk, preserveSymlinks', () => {
+    const t = translateOptions(
+      {
+        ...minimal,
+        aot: false,
+        statsJson: true,
+        namedChunks: true,
+        vendorChunk: true,
+        preserveSymlinks: true,
+      },
+      '/ws',
+      null,
+    );
+    expect(t.warnings.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('defaults tsConfig to "tsconfig.json" when omitted', () => {
+    const t = translateOptions({}, '/ws', null);
+    const i = t.args.indexOf('--project');
+    expect(t.args[i + 1]).toBe('tsconfig.json');
+  });
+});

--- a/packages/builder/src/build/__tests__/process.test.ts
+++ b/packages/builder/src/build/__tests__/process.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { runNgcBuild } from '../process';
+
+/// Build a tiny shell script that pretends to be `ngc-rs`. The script
+/// writes a fixed JSON payload to stdout and exits with the requested code,
+/// letting us exercise `runNgcBuild`'s parse + return-shape paths without
+/// depending on the real Rust binary.
+function makeFakeNgcRs(
+  payload: string,
+  exitCode: number,
+  stderr = '',
+): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ngc-rs-fake-'));
+  const script = path.join(dir, 'ngc-rs');
+  const stderrLine = stderr ? `printf '${stderr.replace(/'/g, "'\\''")}' >&2\n` : '';
+  fs.writeFileSync(
+    script,
+    `#!/bin/sh\n${stderrLine}cat <<'EOF'\n${payload}\nEOF\nexit ${exitCode}\n`,
+    { mode: 0o755 },
+  );
+  return script;
+}
+
+describe('runNgcBuild', () => {
+  it('parses a successful BuildResult JSON payload', async () => {
+    const payload = JSON.stringify({
+      success: true,
+      error: null,
+      errors: [],
+      warnings: [],
+      output_path: '/tmp/dist',
+      output_files: [
+        { path: '/tmp/dist/main.js', size: 100, kind: 'script' },
+      ],
+      modules_bundled: 1,
+      total_size_bytes: 100,
+      duration_ms: 12,
+    });
+    const bin = makeFakeNgcRs(payload, 0);
+    const run = await runNgcBuild({ binary: bin, args: ['build'], cwd: '/' });
+    expect(run.exitCode).toBe(0);
+    expect(run.result?.success).toBe(true);
+    expect(run.result?.modules_bundled).toBe(1);
+    expect(run.result?.output_files[0]?.kind).toBe('script');
+  });
+
+  it('parses a failure BuildResult even when the binary exits non-zero', async () => {
+    const payload = JSON.stringify({
+      success: false,
+      error: 'parse error in /a/b.ts:3:7: missing semicolon',
+      errors: [
+        {
+          file: '/a/b.ts',
+          line: 3,
+          column: 7,
+          message: 'missing semicolon',
+          severity: 'error',
+        },
+      ],
+      warnings: [],
+      output_path: '/tmp/dist',
+      output_files: [],
+      modules_bundled: 0,
+      total_size_bytes: 0,
+      duration_ms: 5,
+    });
+    const bin = makeFakeNgcRs(payload, 1);
+    const run = await runNgcBuild({ binary: bin, args: ['build'], cwd: '/' });
+    expect(run.exitCode).toBe(1);
+    expect(run.result?.success).toBe(false);
+    expect(run.result?.errors[0]?.line).toBe(3);
+  });
+
+  it('returns null result when stdout is empty (no JSON emitted)', async () => {
+    const bin = makeFakeNgcRs('', 1, 'thread main panicked');
+    const run = await runNgcBuild({ binary: bin, args: ['build'], cwd: '/' });
+    expect(run.result).toBeNull();
+    expect(run.exitCode).toBe(1);
+    expect(run.stderr).toContain('thread main panicked');
+  });
+
+  it('forwards stderr chunks via the onStderr callback', async () => {
+    const bin = makeFakeNgcRs('{"success":true,"error":null,"errors":[],"warnings":[],"output_path":"/x","output_files":[],"modules_bundled":0,"total_size_bytes":0,"duration_ms":1}', 0, 'log line\n');
+    const chunks: string[] = [];
+    await runNgcBuild({
+      binary: bin,
+      args: ['build'],
+      cwd: '/',
+      onStderr: (c) => chunks.push(c),
+    });
+    expect(chunks.join('')).toContain('log line');
+  });
+
+  it('rejects when the binary cannot be spawned', async () => {
+    await expect(
+      runNgcBuild({
+        binary: '/nonexistent/path/ngc-rs',
+        args: ['build'],
+        cwd: '/',
+      }),
+    ).rejects.toThrow(/failed to spawn/);
+  });
+});

--- a/packages/builder/src/build/builder.ts
+++ b/packages/builder/src/build/builder.ts
@@ -1,0 +1,150 @@
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { Observable, Subject } from 'rxjs';
+
+import { locateNgcRs } from '../serve/locate';
+import {
+  ApplicationOptions,
+  OptionTranslationError,
+  TranslatedBuildArgs,
+  translateOptions,
+} from './options';
+import { NgcBuildResult, NgcDiagnostic, runNgcBuild } from './process';
+
+interface ApplicationBuilderOutput extends BuilderOutput {
+  outputPath?: string;
+}
+
+export function execute(
+  options: ApplicationOptions,
+  context: BuilderContext,
+): Observable<BuilderOutput> {
+  const subject = new Subject<ApplicationBuilderOutput>();
+
+  void runOnce(options, context, subject)
+    .catch((err) => {
+      const message = (err as Error).message;
+      context.logger.error(`ngc-rs builder failed: ${message}`);
+      subject.next({ success: false, error: message });
+    })
+    .finally(() => {
+      subject.complete();
+    });
+
+  return subject.asObservable();
+}
+
+async function runOnce(
+  options: ApplicationOptions,
+  context: BuilderContext,
+  subject: Subject<ApplicationBuilderOutput>,
+): Promise<void> {
+  const configuration = context.target?.configuration ?? null;
+
+  let translated: TranslatedBuildArgs;
+  try {
+    translated = translateOptions(options, context.workspaceRoot, configuration);
+  } catch (err) {
+    if (err instanceof OptionTranslationError) {
+      context.logger.error(err.message);
+      subject.next({ success: false, error: err.message });
+      return;
+    }
+    throw err;
+  }
+
+  for (const w of translated.warnings) {
+    context.logger.warn(w);
+  }
+
+  const located = locateNgcRs(
+    context.workspaceRoot,
+    options.ngcRsBinary ?? null,
+    process.env,
+  );
+  context.logger.info(
+    `ngc-rs binary: ${located.binary} (resolved from ${located.source})`,
+  );
+
+  context.reportRunning();
+
+  const run = await runNgcBuild({
+    binary: located.binary,
+    args: translated.args,
+    cwd: context.workspaceRoot,
+    onStderr: (chunk) => {
+      // Forward unbuffered for visibility; the architect logger handles its
+      // own batching. Trim trailing newline so the logger doesn't emit a
+      // blank follow-up line.
+      const text = chunk.replace(/\n$/, '');
+      if (text.length > 0) {
+        context.logger.info(text);
+      }
+    },
+  });
+
+  if (!run.result) {
+    const tail = run.stderr.trim().split('\n').slice(-5).join('\n');
+    const message =
+      `ngc-rs exited with code ${run.exitCode ?? 'null'} without emitting valid JSON output.` +
+      (tail ? ` Last stderr lines:\n${tail}` : '');
+    context.logger.error(message);
+    subject.next({ success: false, error: message });
+    return;
+  }
+
+  reportDiagnostics(run.result, context);
+
+  if (!run.result.success) {
+    const message = run.result.error ?? 'ngc-rs build failed';
+    subject.next({
+      success: false,
+      error: message,
+      outputPath: run.result.output_path,
+    });
+    return;
+  }
+
+  context.logger.info(
+    `ngc-rs build complete: ${run.result.modules_bundled} module(s), ` +
+      `${run.result.output_files.length} file(s), ` +
+      `${formatBytes(run.result.total_size_bytes)}, ` +
+      `${run.result.duration_ms} ms`,
+  );
+
+  subject.next({
+    success: true,
+    outputPath: run.result.output_path,
+  });
+}
+
+function reportDiagnostics(result: NgcBuildResult, context: BuilderContext): void {
+  for (const w of result.warnings) {
+    context.logger.warn(formatDiagnostic(w));
+  }
+  for (const e of result.errors) {
+    context.logger.error(formatDiagnostic(e));
+  }
+}
+
+function formatDiagnostic(d: NgcDiagnostic): string {
+  const loc = d.file
+    ? d.line !== null
+      ? d.column !== null
+        ? `${d.file}:${d.line}:${d.column}`
+        : `${d.file}:${d.line}`
+      : d.file
+    : null;
+  return loc ? `${loc}: ${d.message}` : d.message;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KiB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+export default createBuilder<ApplicationOptions>(execute);

--- a/packages/builder/src/build/options.ts
+++ b/packages/builder/src/build/options.ts
@@ -1,0 +1,197 @@
+import { json } from '@angular-devkit/core';
+import * as path from 'node:path';
+
+/// Application builder options accepted by `@ngc-rs/builder:application`.
+/// Mirrors the most-used subset of `@angular/build:application` so projects
+/// can swap one line in `angular.json`. See `schemas/application.json` for
+/// per-field documentation.
+export interface ApplicationOptions extends json.JsonObject {
+  tsConfig: string;
+  outputPath: string | { base: string; browser?: string } | null;
+  browser: string | null;
+  main: string | null;
+  polyfills: string | string[] | null;
+  index: string | { input: string; output?: string } | boolean | null;
+  assets: json.JsonArray | null;
+  styles: json.JsonArray | null;
+  scripts: json.JsonArray | null;
+  fileReplacements: json.JsonArray | null;
+  sourceMap: boolean | json.JsonObject | null;
+  optimization: boolean | json.JsonObject | null;
+  outputHashing: 'none' | 'all' | 'media' | 'bundles' | null;
+  namedChunks: boolean | null;
+  vendorChunk: boolean | null;
+  aot: boolean | null;
+  baseHref: string | null;
+  deployUrl: string | null;
+  crossOrigin: 'none' | 'anonymous' | 'use-credentials' | null;
+  subresourceIntegrity: boolean | null;
+  serviceWorker: boolean | string | null;
+  ngswConfigPath: string | null;
+  preserveSymlinks: boolean | null;
+  statsJson: boolean | null;
+  budgets: json.JsonArray | null;
+  externalDependencies: string[] | null;
+  allowedCommonJsDependencies: string[] | null;
+  extractLicenses: boolean | null;
+  verbose: boolean | null;
+  progress: boolean | null;
+  watch: boolean | null;
+  prerender: boolean | json.JsonObject | null;
+  ssr: boolean | json.JsonObject | null;
+  server: string | null;
+  outputMode: 'static' | 'server' | null;
+  ngcRsBinary: string | null;
+  localize: boolean | string[] | null;
+}
+
+/// Result of translating raw [`ApplicationOptions`] into a CLI invocation.
+export interface TranslatedBuildArgs {
+  /// Argv to pass to `ngc-rs` (always begins with `'build'`).
+  args: string[];
+  /// Configuration name resolved from the architect target's `configuration`
+  /// field, when one was supplied. Used for warning attribution.
+  configuration: string | null;
+  /// Per-option warnings to surface via `BuilderContext.logger.warn`.
+  /// Compatibility hints — not fatal.
+  warnings: string[];
+}
+
+/// Thrown when an option is set in a way ngc-rs cannot honor (e.g. SSR
+/// fields, scripts array, watch=true). The builder turns this into a
+/// `BuilderOutput` with `success: false` and surfaces the message.
+export class OptionTranslationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OptionTranslationError';
+  }
+}
+
+/// Translate raw architect options into ngc-rs CLI args.
+///
+/// `configuration` is the architect target's configuration name (e.g.
+/// `"production"`), passed through as `--configuration`. ngc-rs then re-reads
+/// `angular.json` to pick up the per-configuration overrides — option-level
+/// overrides set in architect don't need to be re-passed.
+export function translateOptions(
+  raw: Partial<ApplicationOptions>,
+  workspaceRoot: string,
+  configuration: string | null,
+): TranslatedBuildArgs {
+  const warnings: string[] = [];
+
+  // Hard rejections — anything ngc-rs cannot do at all.
+  if (raw.scripts && Array.isArray(raw.scripts) && raw.scripts.length > 0) {
+    throw new OptionTranslationError(
+      'The `scripts` option (global script entries) is not yet supported by ngc-rs build. Move script imports into your application code, or open an issue to request the feature.',
+    );
+  }
+  if (raw.watch === true) {
+    throw new OptionTranslationError(
+      '`watch: true` on the application builder is not supported. Use the `@ngc-rs/builder:dev-server` builder for incremental rebuilds.',
+    );
+  }
+  if (raw.prerender) {
+    throw new OptionTranslationError(
+      'Prerendering is not supported by ngc-rs (SSR is out of scope for v1). Remove the `prerender` option or use `@angular/build:application` for prerender targets.',
+    );
+  }
+  if (raw.ssr) {
+    throw new OptionTranslationError(
+      'Server-side rendering is not supported by ngc-rs (SSR is out of scope for v1). Remove the `ssr` option.',
+    );
+  }
+  if (raw.server) {
+    throw new OptionTranslationError(
+      'The `server` option (SSR entry point) is not supported by ngc-rs. Remove it.',
+    );
+  }
+  if (raw.outputMode === 'server') {
+    throw new OptionTranslationError(
+      '`outputMode: "server"` is not supported by ngc-rs. Use `"static"` or omit the option.',
+    );
+  }
+
+  // Compatibility warnings — accepted, but ngc-rs's behaviour is hardcoded.
+  if (raw.aot === false) {
+    warnings.push(
+      'aot=false is ignored by ngc-rs; the build always runs ahead-of-time compilation.',
+    );
+  }
+  if (raw.statsJson === true) {
+    warnings.push('statsJson=true is ignored by ngc-rs (no webpack stats output).');
+  }
+  if (raw.namedChunks === true) {
+    warnings.push(
+      'namedChunks=true is ignored by ngc-rs; chunk filenames are derived from the lazy-route module path with a content hash in production.',
+    );
+  }
+  if (raw.vendorChunk === true) {
+    warnings.push(
+      'vendorChunk=true is ignored by ngc-rs (no separate vendor bundle).',
+    );
+  }
+  if (raw.preserveSymlinks === true) {
+    warnings.push(
+      'preserveSymlinks=true is ignored by ngc-rs; paths are always canonicalised.',
+    );
+  }
+  if (raw.optimization !== undefined && raw.optimization !== null) {
+    warnings.push(
+      'The `optimization` option is hardcoded by ngc-rs per `--configuration` (development = off, production = on); the option value is ignored.',
+    );
+  }
+  if (raw.sourceMap !== undefined && raw.sourceMap !== null) {
+    warnings.push(
+      'The `sourceMap` option is hardcoded by ngc-rs per `--configuration` (development = inline, production = external); the option value is ignored.',
+    );
+  }
+  if (raw.outputHashing !== undefined && raw.outputHashing !== null) {
+    warnings.push(
+      'The `outputHashing` option is hardcoded by ngc-rs per `--configuration` (production hashes bundles, development does not); the option value is ignored.',
+    );
+  }
+  if (raw.externalDependencies && raw.externalDependencies.length > 0) {
+    warnings.push(
+      '`externalDependencies` is currently ignored by ngc-rs; all imports are bundled.',
+    );
+  }
+  if (Array.isArray(raw.localize)) {
+    warnings.push(
+      'Selecting a locale subset via `localize` array is not yet honoured by ngc-rs; all locales declared in `angular.json` `i18n.locales` are emitted.',
+    );
+  }
+
+  const tsConfig = raw.tsConfig ?? 'tsconfig.json';
+  const outDir = resolveOutDir(raw.outputPath, workspaceRoot);
+  const localize = raw.localize === true || Array.isArray(raw.localize);
+
+  const args: string[] = ['build', '--project', tsConfig, '--output-json'];
+  if (configuration) {
+    args.push('--configuration', configuration);
+  }
+  if (outDir) {
+    args.push('--out-dir', outDir);
+  }
+  if (localize) {
+    args.push('--localize');
+  }
+
+  return { args, configuration, warnings };
+}
+
+function resolveOutDir(
+  outputPath: ApplicationOptions['outputPath'] | undefined,
+  workspaceRoot: string,
+): string | null {
+  if (!outputPath) {
+    return null;
+  }
+  if (typeof outputPath === 'string') {
+    return path.resolve(workspaceRoot, outputPath);
+  }
+  if (typeof outputPath === 'object' && typeof outputPath.base === 'string') {
+    return path.resolve(workspaceRoot, outputPath.base);
+  }
+  return null;
+}

--- a/packages/builder/src/build/process.ts
+++ b/packages/builder/src/build/process.ts
@@ -1,0 +1,119 @@
+import { spawn } from 'node:child_process';
+
+/// One entry in the JSON `errors` / `warnings` arrays emitted by
+/// `ngc-rs build --output-json`. Mirrors the Rust `Diagnostic` struct in
+/// `crates/cli/src/main.rs`.
+export interface NgcDiagnostic {
+  file: string | null;
+  line: number | null;
+  column: number | null;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+/// One entry in the JSON `output_files` array. Mirrors the Rust
+/// `OutputFile` struct in `crates/cli/src/main.rs`.
+export interface NgcOutputFile {
+  path: string;
+  size: number;
+  kind: 'script' | 'style' | 'html' | 'source-map' | 'asset';
+}
+
+/// JSON payload produced by `ngc-rs build --output-json`. Mirrors the Rust
+/// `BuildResult` struct in `crates/cli/src/main.rs`. The shape is
+/// intentionally a superset of `BuilderOutput` so the builder shim can drop
+/// the relevant fields straight onto the architect protocol's response.
+export interface NgcBuildResult {
+  success: boolean;
+  error: string | null;
+  errors: NgcDiagnostic[];
+  warnings: NgcDiagnostic[];
+  output_path: string;
+  output_files: NgcOutputFile[];
+  modules_bundled: number;
+  total_size_bytes: number;
+  duration_ms: number;
+}
+
+/// Outcome of running ngc-rs build once.
+export interface BuildRunResult {
+  /// Parsed JSON payload, when `--output-json` produced one. `null` when
+  /// the binary failed to emit valid JSON (e.g. the spawn itself failed).
+  result: NgcBuildResult | null;
+  /// Process exit code. `null` if the process was killed by signal.
+  exitCode: number | null;
+  /// Captured stderr (already stripped of ANSI control codes upstream by
+  /// caller if desired).
+  stderr: string;
+}
+
+export interface RunNgcBuildOptions {
+  /// Absolute path to the ngc-rs binary.
+  binary: string;
+  /// CLI args (typically begins with `'build'`).
+  args: string[];
+  /// Working directory passed to the spawn.
+  cwd: string;
+  /// Optional env override merged on top of `process.env`.
+  env?: NodeJS.ProcessEnv;
+  /// Hook for streaming stderr output. Called once per chunk; the chunk
+  /// preserves whatever the child wrote (multi-line OK). Used by the
+  /// builder to forward log lines to `BuilderContext.logger`.
+  onStderr?: (chunk: string) => void;
+}
+
+/// Run `ngc-rs build --output-json` once and parse the JSON payload from
+/// stdout. Resolves regardless of exit code — the architect builder maps
+/// `result.success` onto `BuilderOutput.success`. Rejects only if the
+/// child failed to spawn at all.
+export function runNgcBuild(options: RunNgcBuildOptions): Promise<BuildRunResult> {
+  return new Promise<BuildRunResult>((resolve, reject) => {
+    const child = spawn(options.binary, options.args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...(options.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk;
+      options.onStderr?.(chunk);
+    });
+
+    child.on('error', (err) => {
+      reject(new Error(`failed to spawn ngc-rs: ${err.message}`));
+    });
+
+    child.on('exit', (code) => {
+      const result = parseJsonPayload(stdout);
+      resolve({ result, exitCode: code, stderr });
+    });
+  });
+}
+
+function parseJsonPayload(stdout: string): NgcBuildResult | null {
+  // ngc-rs emits exactly one JSON object on stdout when `--output-json` is
+  // set. Be lenient about leading/trailing whitespace.
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as NgcBuildResult;
+    if (typeof parsed.success !== 'boolean') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -1,2 +1,4 @@
+export { default as applicationBuilder } from './build/builder';
 export { default as devServerBuilder } from './serve/builder';
+export type { ApplicationOptions } from './build/options';
 export type { DevServerOptions } from './serve/options';


### PR DESCRIPTION
## Summary

First sub-branch into `milestone/v1.0.0-cli-drop-in`. Adds the application builder counterpart to the existing dev-server builder so `ng build` (not just `ng serve`) routes through ngc-rs, and reshapes the binary's `--output-json` payload to match the `@angular-devkit/architect` `BuilderOutput` protocol.

- **TS** — new `packages/builder/src/build/` (builder.ts, options.ts, process.ts) + `schemas/application.json` mirroring the most-used subset of `@angular/build:application`. Registered in `builders.json` and exported from `src/index.ts`. SSR/server/prerender/scripts/watch options reject with a clear error; hardcoded-per-configuration knobs (sourceMap, optimization, outputHashing) accept and warn.
- **Rust** — `BuildResult` reshaped (success, error, errors[], warnings[], output_path, output_files[{path,size,kind}], modules_bundled, total_size_bytes, duration_ms). `--output-json` now emits a valid object on the failure path too (success: false, errors populated, exit 1) so the shim can parse a coherent result regardless of exit code. New `NgcError::file()/line()/column()` accessors thread location data through.
- **Tests** — vitest covers option translation + JSON parse. New `crates/cli/tests/build_json_output.rs` integration test pins the JSON contract end-to-end (success and failure paths).

## Test plan
- [x] `cargo test -p ngc-diagnostics` — 12 pass (incl. 4 new accessor tests)
- [x] `cargo test -p ngc-rs --test build_json_output` — 2 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `npm test` in `packages/builder/` — 56 pass
- [x] Manual: swap `@angular/build:application` to `@ngc-rs/builder:application` on treasr-frontend, diff `dist/` against `ng build` baseline (deferred to milestone-branch validation)

## Closes / refs

Closes #28
Refs #29 (treasr-frontend swap verification — completed end-to-end via the milestone → main PR)
