### PR TITLE
feat(bundler,cli): enforce angular.json `budgets` in production builds

### DIFF
--- a/crates/bundler/src/budgets.rs
+++ b/crates/bundler/src/budgets.rs
@@ -1,0 +1,470 @@
+//! Size-budget enforcement for emitted bundles.
+//!
+//! Mirrors `@angular/build:application`'s `budgets` array semantics so a
+//! drop-in replacement doesn't silently ship over-size bundles. Given a
+//! list of `ResolvedBudget`s and the set of emitted output artifacts,
+//! [`evaluate`] returns every threshold violation as a [`BudgetViolation`].
+//! The cli wires those into `BuildResult.errors` / `BuildResult.warnings`
+//! and fails the build (exit 1) on any error-severity violation.
+//!
+//! Pure functions — no IO, no panics — so the unit tests can exercise the
+//! whole matrix without setting up a fixture project.
+
+use std::path::Path;
+
+use ngc_project_resolver::angular_json::{BudgetKind, ResolvedBudget};
+
+/// Coarse classification of an output file. Determines which budgets the
+/// file counts against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileKind {
+    /// JavaScript bundle (`.js`, `.mjs`, `.cjs`). Counts toward `Initial`
+    /// (when initial), `AnyScript`, `AllScript`, `All`, and named `Bundle`.
+    Script,
+    /// Stylesheet (`.css`). Counts toward `Initial` (when initial),
+    /// `AnyComponentStyle`, `All`, and named `Bundle`.
+    Style,
+    /// Anything else (source maps, HTML, assets). Excluded from every
+    /// budget.
+    Other,
+}
+
+impl FileKind {
+    /// Classify a path by extension.
+    pub fn from_path(p: &Path) -> Self {
+        match p.extension().and_then(|e| e.to_str()) {
+            Some("js" | "mjs" | "cjs") => FileKind::Script,
+            Some("css") => FileKind::Style,
+            _ => FileKind::Other,
+        }
+    }
+}
+
+/// One emitted artifact, normalised for budget evaluation.
+#[derive(Debug, Clone)]
+pub struct OutputArtifact<'a> {
+    /// Path to the file (used only for diagnostics/display).
+    pub path: &'a Path,
+    /// Bundle name without content hash or extension. For `main.abc123.js`
+    /// this is `"main"`; for `chunk-foo.def456.js` this is `"chunk-foo"`.
+    /// Used to match `Bundle`-kind budgets that target a named bundle.
+    pub bundle_name: String,
+    /// Size of the file in bytes.
+    pub size: u64,
+    /// Coarse classification.
+    pub kind: FileKind,
+    /// `true` when this file is part of the *initial* download —
+    /// `main`, `polyfills`, and global stylesheets. `false` for
+    /// lazy-loaded chunks. Drives `Initial`-kind budget summation.
+    pub is_initial: bool,
+}
+
+/// One budget threshold violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetViolation {
+    /// Which budget was tripped.
+    pub kind: BudgetKind,
+    /// Bundle name this violation is for (only set for `AnyScript`,
+    /// `AnyComponentStyle`, and `Bundle`-kind budgets that scope per file;
+    /// `None` for whole-app aggregates like `Initial`/`All`/`AllScript`).
+    pub bundle_name: Option<String>,
+    /// Actual size measured.
+    pub actual_size: u64,
+    /// Threshold that was exceeded.
+    pub threshold: u64,
+    /// Whether this should fail the build.
+    pub severity: ViolationSeverity,
+}
+
+/// Whether a budget violation is fatal or advisory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViolationSeverity {
+    /// Tripped `maximumWarning` — surfaced to the user but the build
+    /// completes.
+    Warning,
+    /// Tripped `maximumError` — fails the build (exit 1).
+    Error,
+}
+
+/// Evaluate every budget against the given outputs and return all
+/// violations in declaration order. Per-file budgets (`AnyScript`,
+/// `AnyComponentStyle`, `Bundle`) emit one violation per offending file;
+/// aggregate budgets (`Initial`, `All`, `AllScript`) emit at most one.
+pub fn evaluate(
+    budgets: &[ResolvedBudget],
+    outputs: &[OutputArtifact<'_>],
+) -> Vec<BudgetViolation> {
+    let mut violations = Vec::new();
+    for b in budgets {
+        match b.kind {
+            BudgetKind::Initial => {
+                let total: u64 = outputs
+                    .iter()
+                    .filter(|o| {
+                        o.is_initial && matches!(o.kind, FileKind::Script | FileKind::Style)
+                    })
+                    .map(|o| o.size)
+                    .sum();
+                push_aggregate(&mut violations, b, total, None);
+            }
+            BudgetKind::All => {
+                let total: u64 = outputs
+                    .iter()
+                    .filter(|o| matches!(o.kind, FileKind::Script | FileKind::Style))
+                    .map(|o| o.size)
+                    .sum();
+                push_aggregate(&mut violations, b, total, None);
+            }
+            BudgetKind::AllScript => {
+                let total: u64 = outputs
+                    .iter()
+                    .filter(|o| o.kind == FileKind::Script)
+                    .map(|o| o.size)
+                    .sum();
+                push_aggregate(&mut violations, b, total, None);
+            }
+            BudgetKind::AnyScript => {
+                for o in outputs.iter().filter(|o| o.kind == FileKind::Script) {
+                    push_aggregate(&mut violations, b, o.size, Some(o.bundle_name.clone()));
+                }
+            }
+            BudgetKind::AnyComponentStyle => {
+                for o in outputs.iter().filter(|o| o.kind == FileKind::Style) {
+                    push_aggregate(&mut violations, b, o.size, Some(o.bundle_name.clone()));
+                }
+            }
+            BudgetKind::Bundle => {
+                let Some(target) = b.name.as_deref() else {
+                    tracing::warn!("`Bundle` budget without a `name` field — skipped");
+                    continue;
+                };
+                for o in outputs.iter().filter(|o| o.bundle_name == target) {
+                    push_aggregate(&mut violations, b, o.size, Some(o.bundle_name.clone()));
+                }
+            }
+        }
+    }
+    violations
+}
+
+fn push_aggregate(
+    out: &mut Vec<BudgetViolation>,
+    budget: &ResolvedBudget,
+    actual: u64,
+    bundle_name: Option<String>,
+) {
+    if let Some(threshold) = budget.maximum_error {
+        if actual > threshold {
+            out.push(BudgetViolation {
+                kind: budget.kind,
+                bundle_name: bundle_name.clone(),
+                actual_size: actual,
+                threshold,
+                severity: ViolationSeverity::Error,
+            });
+            // When both warning and error trip on the same metric, only
+            // the more severe one is reported (matches ng build).
+            return;
+        }
+    }
+    if let Some(threshold) = budget.maximum_warning {
+        if actual > threshold {
+            out.push(BudgetViolation {
+                kind: budget.kind,
+                bundle_name,
+                actual_size: actual,
+                threshold,
+                severity: ViolationSeverity::Warning,
+            });
+        }
+    }
+}
+
+/// Format a byte count the same way ng build does — three significant
+/// digits, kibibyte/mebibyte units (kb/mb meaning ×1024). Used for the
+/// human-readable budget table written to stderr.
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    let b = bytes as f64;
+    if b >= MB {
+        format!("{:.2} MB", b / MB)
+    } else if b >= KB {
+        format!("{:.2} kB", b / KB)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// Render a one-line, human-readable description of a violation suitable
+/// for stderr or `Diagnostic.message`.
+pub fn format_violation(v: &BudgetViolation) -> String {
+    let kind = match v.kind {
+        BudgetKind::Initial => "initial",
+        BudgetKind::AnyComponentStyle => "anyComponentStyle",
+        BudgetKind::AnyScript => "anyScript",
+        BudgetKind::Bundle => "bundle",
+        BudgetKind::All => "all",
+        BudgetKind::AllScript => "allScript",
+    };
+    let target = v
+        .bundle_name
+        .as_deref()
+        .map(|n| format!(" ({n})"))
+        .unwrap_or_default();
+    let kind_label = match v.severity {
+        ViolationSeverity::Error => "exceeded maximum budget",
+        ViolationSeverity::Warning => "exceeded maximum warning budget",
+    };
+    let over = v.actual_size.saturating_sub(v.threshold);
+    format!(
+        "{kind} budget{target} {kind_label}: {} > {} (over by {})",
+        format_bytes(v.actual_size),
+        format_bytes(v.threshold),
+        format_bytes(over),
+    )
+}
+
+/// Strip a content hash and extension from a filename, returning the
+/// "bundle name" used to match `Bundle`-kind budgets and to populate
+/// [`OutputArtifact::bundle_name`].
+///
+/// Examples:
+/// - `main.A1B2C3D4.js` → `main`
+/// - `chunk-foo.DEADBEEF.js` → `chunk-foo`
+/// - `polyfills.js` → `polyfills`
+/// - `styles.css` → `styles`
+/// - `vendor.js.map` → `vendor` (but `.map` files should be classified as
+///   `Other` and excluded before reaching this helper)
+pub fn bundle_name_from_filename(filename: &str) -> String {
+    // Strip the final extension (`.js`, `.css`, etc.)
+    let stem = filename
+        .rsplit_once('.')
+        .map(|(s, _)| s)
+        .unwrap_or(filename);
+    // If what remains has a trailing `.HEX` segment that looks like a
+    // content hash (8+ hex chars), strip it too. `.map` and other
+    // sub-extensions don't match because we only strip when the segment is
+    // a hex string.
+    if let Some((before, last)) = stem.rsplit_once('.') {
+        if last.len() >= 6 && last.len() <= 32 && last.chars().all(|c| c.is_ascii_hexdigit()) {
+            return before.to_string();
+        }
+    }
+    stem.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn budget(
+        kind: BudgetKind,
+        warn: Option<u64>,
+        err: Option<u64>,
+        name: Option<&str>,
+    ) -> ResolvedBudget {
+        ResolvedBudget {
+            kind,
+            name: name.map(String::from),
+            maximum_warning: warn,
+            maximum_error: err,
+        }
+    }
+
+    fn artifact<'a>(
+        path: &'a PathBuf,
+        bundle_name: &str,
+        size: u64,
+        kind: FileKind,
+        is_initial: bool,
+    ) -> OutputArtifact<'a> {
+        OutputArtifact {
+            path,
+            bundle_name: bundle_name.to_string(),
+            size,
+            kind,
+            is_initial,
+        }
+    }
+
+    #[test]
+    fn parses_hashed_main_chunk_to_main() {
+        assert_eq!(bundle_name_from_filename("main.A1B2C3D4.js"), "main");
+    }
+
+    #[test]
+    fn parses_hashed_chunk_with_dash_in_name() {
+        assert_eq!(
+            bundle_name_from_filename("chunk-foo-bar.DEADBEEF.js"),
+            "chunk-foo-bar"
+        );
+    }
+
+    #[test]
+    fn parses_unhashed_filename() {
+        assert_eq!(bundle_name_from_filename("polyfills.js"), "polyfills");
+        assert_eq!(bundle_name_from_filename("styles.css"), "styles");
+    }
+
+    #[test]
+    fn does_not_strip_non_hex_segment() {
+        // `dev` is not hex; treat the whole stem as the bundle name.
+        assert_eq!(bundle_name_from_filename("main.dev.js"), "main.dev");
+    }
+
+    #[test]
+    fn classifies_extensions() {
+        assert_eq!(FileKind::from_path(Path::new("main.js")), FileKind::Script);
+        assert_eq!(FileKind::from_path(Path::new("main.mjs")), FileKind::Script);
+        assert_eq!(
+            FileKind::from_path(Path::new("styles.css")),
+            FileKind::Style
+        );
+        assert_eq!(
+            FileKind::from_path(Path::new("main.js.map")),
+            FileKind::Other
+        );
+        assert_eq!(
+            FileKind::from_path(Path::new("index.html")),
+            FileKind::Other
+        );
+    }
+
+    #[test]
+    fn formats_bytes_with_three_significant_digits() {
+        assert_eq!(format_bytes(0), "0 bytes");
+        assert_eq!(format_bytes(512), "512 bytes");
+        assert_eq!(format_bytes(2048), "2.00 kB");
+        assert_eq!(format_bytes(1_572_864), "1.50 MB");
+    }
+
+    #[test]
+    fn initial_budget_sums_initial_script_and_style_only() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let p2 = PathBuf::from("/dist/styles.css");
+        let p3 = PathBuf::from("/dist/chunk-lazy.js");
+        let outputs = vec![
+            artifact(&p1, "main", 600 * 1024, FileKind::Script, true),
+            artifact(&p2, "styles", 200 * 1024, FileKind::Style, true),
+            artifact(&p3, "chunk-lazy", 9_999_999, FileKind::Script, false),
+        ];
+        // Threshold 700 KiB; initial total is 800 KiB → trips error.
+        let budgets = vec![budget(
+            BudgetKind::Initial,
+            Some(500 * 1024),
+            Some(700 * 1024),
+            None,
+        )];
+        let v = evaluate(&budgets, &outputs);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].severity, ViolationSeverity::Error);
+        assert_eq!(v[0].actual_size, 800 * 1024);
+        assert_eq!(v[0].threshold, 700 * 1024);
+    }
+
+    #[test]
+    fn warning_only_when_below_error_threshold() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let outputs = vec![artifact(&p1, "main", 600 * 1024, FileKind::Script, true)];
+        let budgets = vec![budget(
+            BudgetKind::Initial,
+            Some(500 * 1024),
+            Some(700 * 1024),
+            None,
+        )];
+        let v = evaluate(&budgets, &outputs);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].severity, ViolationSeverity::Warning);
+    }
+
+    #[test]
+    fn no_violation_when_within_thresholds() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let outputs = vec![artifact(&p1, "main", 100 * 1024, FileKind::Script, true)];
+        let budgets = vec![budget(
+            BudgetKind::Initial,
+            Some(500 * 1024),
+            Some(700 * 1024),
+            None,
+        )];
+        let v = evaluate(&budgets, &outputs);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn any_script_budget_emits_per_chunk_violations() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let p2 = PathBuf::from("/dist/chunk-a.js");
+        let p3 = PathBuf::from("/dist/chunk-b.js");
+        let outputs = vec![
+            artifact(&p1, "main", 100, FileKind::Script, true),
+            artifact(&p2, "chunk-a", 600, FileKind::Script, false),
+            artifact(&p3, "chunk-b", 200, FileKind::Script, false),
+        ];
+        let budgets = vec![budget(BudgetKind::AnyScript, Some(150), None, None)];
+        let v = evaluate(&budgets, &outputs);
+        // chunk-a (600) and chunk-b (200) trip; main (100) doesn't.
+        assert_eq!(v.len(), 2);
+        let names: Vec<_> = v.iter().filter_map(|x| x.bundle_name.as_deref()).collect();
+        assert!(names.contains(&"chunk-a"));
+        assert!(names.contains(&"chunk-b"));
+    }
+
+    #[test]
+    fn bundle_budget_targets_named_bundle_only() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let p2 = PathBuf::from("/dist/chunk-a.js");
+        let outputs = vec![
+            artifact(&p1, "main", 100, FileKind::Script, true),
+            artifact(&p2, "chunk-a", 1_000, FileKind::Script, false),
+        ];
+        let budgets = vec![budget(BudgetKind::Bundle, None, Some(500), Some("chunk-a"))];
+        let v = evaluate(&budgets, &outputs);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].bundle_name.as_deref(), Some("chunk-a"));
+    }
+
+    #[test]
+    fn all_script_budget_sums_every_script() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let p2 = PathBuf::from("/dist/chunk.js");
+        let p3 = PathBuf::from("/dist/styles.css");
+        let outputs = vec![
+            artifact(&p1, "main", 400, FileKind::Script, true),
+            artifact(&p2, "chunk", 400, FileKind::Script, false),
+            artifact(&p3, "styles", 1_000_000, FileKind::Style, true),
+        ];
+        let budgets = vec![budget(BudgetKind::AllScript, None, Some(500), None)];
+        let v = evaluate(&budgets, &outputs);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].actual_size, 800);
+        // Should NOT have included the stylesheet.
+    }
+
+    #[test]
+    fn missing_thresholds_yield_no_violations() {
+        let p1 = PathBuf::from("/dist/main.js");
+        let outputs = vec![artifact(&p1, "main", 9_999_999, FileKind::Script, true)];
+        let budgets = vec![budget(BudgetKind::Initial, None, None, None)];
+        let v = evaluate(&budgets, &outputs);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn format_violation_includes_actual_threshold_and_overage() {
+        let v = BudgetViolation {
+            kind: BudgetKind::Initial,
+            bundle_name: None,
+            actual_size: 800 * 1024,
+            threshold: 700 * 1024,
+            severity: ViolationSeverity::Error,
+        };
+        let s = format_violation(&v);
+        assert!(s.contains("initial"));
+        assert!(s.contains("800.00 kB"));
+        assert!(s.contains("700.00 kB"));
+        assert!(s.contains("over by 100.00 kB"));
+    }
+}

--- a/crates/bundler/src/lib.rs
+++ b/crates/bundler/src/lib.rs
@@ -4,6 +4,7 @@
 //! bundled ESM files with external imports hoisted and project-local imports
 //! inlined. Supports code splitting via dynamic `import()` detection.
 
+pub mod budgets;
 mod chunk;
 mod concat;
 mod minify;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -330,7 +330,20 @@ fn main() {
                             .expect("BuildResult serialization should not fail");
                         println!("{json}");
                     } else {
-                        println!("{}", "ngc-rs build complete".bold().green());
+                        // Print budget warnings/errors before the
+                        // success/failure summary so they're easy to find
+                        // even when the bundle list scrolls off-screen.
+                        for w in &result.warnings {
+                            eprintln!("{} {}", "Warning:".yellow().bold(), w.message);
+                        }
+                        for e in &result.errors {
+                            eprintln!("{} {}", "Error:".red().bold(), e.message);
+                        }
+                        if result.success {
+                            println!("{}", "ngc-rs build complete".bold().green());
+                        } else {
+                            println!("{}", "ngc-rs build failed".bold().red());
+                        }
                         println!("  {:<16}{}", "Bundled:".dimmed(), result.modules_bundled);
                         println!(
                             "  {:<16}{}",
@@ -345,6 +358,12 @@ fn main() {
                         for f in &result.output_files {
                             println!("  {:<16}{}", "".dimmed(), f.path.display());
                         }
+                    }
+                    // Budget errors (and any other non-fatal-pipeline-but-
+                    // fatal-build conditions) populate `errors` while still
+                    // returning Ok from the pipeline. Honour them here.
+                    if !result.success {
+                        process::exit(1);
                     }
                 }
                 Err(e) => {
@@ -1063,10 +1082,75 @@ pub(crate) fn run_build_with_cache(
     let total_size_bytes = output_files.iter().map(|f| f.size).sum();
     drop(io_span);
 
+    // Step 14: budget enforcement. Compute size violations against
+    // angular.json's `budgets` array and append them to errors/warnings.
+    // Empty when the project declares no budgets for the active
+    // configuration; quick rejection avoids the per-file work.
+    let mut errors: Vec<Diagnostic> = Vec::new();
+    if let Some(ap) = angular_project.as_ref() {
+        if !ap.budgets.is_empty() {
+            let main_filename = bundle_output.main_filename.as_str();
+            let artifacts: Vec<ngc_bundler::budgets::OutputArtifact<'_>> = output_files
+                .iter()
+                .map(|f| {
+                    let kind = match f.kind {
+                        OutputKind::Script => ngc_bundler::budgets::FileKind::Script,
+                        OutputKind::Style => ngc_bundler::budgets::FileKind::Style,
+                        _ => ngc_bundler::budgets::FileKind::Other,
+                    };
+                    let filename = f.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    let bundle_name = ngc_bundler::budgets::bundle_name_from_filename(filename);
+                    // An output is "initial" if its bundle name is `main`,
+                    // `polyfills`, or `styles`, OR it's the precise file
+                    // the bundler reported as the main entry chunk.
+                    let is_initial = filename == main_filename
+                        || matches!(bundle_name.as_str(), "main" | "polyfills" | "styles");
+                    ngc_bundler::budgets::OutputArtifact {
+                        path: &f.path,
+                        bundle_name,
+                        size: f.size,
+                        kind,
+                        is_initial,
+                    }
+                })
+                .collect();
+            for v in ngc_bundler::budgets::evaluate(&ap.budgets, &artifacts) {
+                let message = ngc_bundler::budgets::format_violation(&v);
+                let diag = Diagnostic {
+                    file: v.bundle_name.as_ref().and_then(|name| {
+                        artifacts
+                            .iter()
+                            .find(|a| &a.bundle_name == name)
+                            .map(|a| a.path.to_path_buf())
+                    }),
+                    line: None,
+                    column: None,
+                    message,
+                    severity: match v.severity {
+                        ngc_bundler::budgets::ViolationSeverity::Error => Severity::Error,
+                        ngc_bundler::budgets::ViolationSeverity::Warning => Severity::Warning,
+                    },
+                };
+                match v.severity {
+                    ngc_bundler::budgets::ViolationSeverity::Error => errors.push(diag),
+                    ngc_bundler::budgets::ViolationSeverity::Warning => warnings.push(diag),
+                }
+            }
+        }
+    }
+
+    let success = errors.is_empty();
     Ok(BuildResult {
-        success: true,
-        error: None,
-        errors: Vec::new(),
+        success,
+        error: if success {
+            None
+        } else {
+            Some(format!(
+                "{} budget violation(s) exceeded the maximumError threshold",
+                errors.len()
+            ))
+        },
+        errors,
         warnings,
         output_path: out_dir,
         output_files,

--- a/crates/cli/tests/budgets_integration.rs
+++ b/crates/cli/tests/budgets_integration.rs
@@ -1,0 +1,170 @@
+//! End-to-end test that the `budgets` array in angular.json is parsed,
+//! evaluated against emitted output, and reflected in both the human
+//! summary (exit code) and the `--output-json` payload (`success`,
+//! `errors`, `warnings`).
+//!
+//! Uses an unrealistically tight `initial` budget (1 byte) so any
+//! non-trivial Angular build hits the threshold deterministically.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn write_fixture(root: &Path, budgets_json: &str) {
+    let tsconfig = r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        src.join("main.ts"),
+        "export const x: number = 1;\nconsole.log(x);\n",
+    )
+    .expect("write main.ts");
+
+    let angular_json = format!(
+        r#"{{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {{
+    "demo": {{
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "architect": {{
+        "build": {{
+          "builder": "@angular/build:application",
+          "options": {{
+            "tsConfig": "tsconfig.json"
+          }},
+          "configurations": {{
+            "production": {{
+              "budgets": {budgets}
+            }}
+          }}
+        }}
+      }}
+    }}
+  }}
+}}
+"#,
+        budgets = budgets_json
+    );
+    fs::write(root.join("angular.json"), angular_json).expect("write angular.json");
+}
+
+#[test]
+fn over_budget_production_build_fails_and_emits_json_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // 1-byte budget — guaranteed to fail for any non-empty bundle.
+    write_fixture(dir.path(), r#"[{"type": "initial", "maximumError": 1}]"#);
+
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let out_dir = dir.path().join("dist");
+    let output = Command::new(bin)
+        .args(["build", "--project"])
+        .arg(dir.path().join("tsconfig.json"))
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .args(["-c", "production", "--output-json"])
+        .output()
+        .expect("spawn ngc-rs build");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "build should fail with a budget error",
+    );
+
+    let v: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("failure path must emit valid JSON; parse error: {e}\nstdout:\n{stdout}");
+    });
+
+    assert_eq!(v["success"], Value::Bool(false), "success should be false");
+    let errors = v["errors"].as_array().expect("errors array");
+    assert!(!errors.is_empty(), "errors should be populated");
+    let msg = errors[0]["message"].as_str().expect("message");
+    assert!(
+        msg.contains("initial") && msg.contains("exceeded maximum budget"),
+        "expected initial-budget error message, got: {msg}",
+    );
+    // Output files were written before the budget check, so the array
+    // should be populated even though the build is reported as failed.
+    assert!(
+        !v["output_files"]
+            .as_array()
+            .expect("output_files")
+            .is_empty(),
+        "outputs should still be reported on budget failure",
+    );
+}
+
+#[test]
+fn under_budget_production_build_succeeds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // 10 MB budget — easily under for the trivial fixture above.
+    write_fixture(
+        dir.path(),
+        r#"[{"type": "initial", "maximumError": "10mb"}]"#,
+    );
+
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let out_dir = dir.path().join("dist");
+    let output = Command::new(bin)
+        .args(["build", "--project"])
+        .arg(dir.path().join("tsconfig.json"))
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .args(["-c", "production", "--output-json"])
+        .output()
+        .expect("spawn ngc-rs build");
+
+    assert_eq!(output.status.code(), Some(0), "build should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let v: Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(v["success"], Value::Bool(true));
+    assert_eq!(v["errors"].as_array().expect("errors").len(), 0);
+}
+
+#[test]
+fn warning_only_budget_does_not_fail_the_build() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // 1-byte warning, no error threshold — should warn but exit 0.
+    write_fixture(dir.path(), r#"[{"type": "initial", "maximumWarning": 1}]"#);
+
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let out_dir = dir.path().join("dist");
+    let output = Command::new(bin)
+        .args(["build", "--project"])
+        .arg(dir.path().join("tsconfig.json"))
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .args(["-c", "production", "--output-json"])
+        .output()
+        .expect("spawn ngc-rs build");
+
+    assert_eq!(output.status.code(), Some(0), "warning should not fail");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let v: Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(v["success"], Value::Bool(true));
+    let warnings = v["warnings"].as_array().expect("warnings array");
+    assert!(!warnings.is_empty(), "warning should be present");
+    assert_eq!(
+        warnings[0]["severity"],
+        Value::String("warning".to_string()),
+    );
+}

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -148,6 +148,89 @@ pub struct RawBuildOptions {
     /// Path to the service-worker configuration file. Defaults to
     /// `ngsw-config.json` at the workspace root when omitted.
     pub ngsw_config_path: Option<String>,
+    /// Per-bundle and per-initial size budgets.
+    pub budgets: Option<Vec<RawBudget>>,
+}
+
+/// One entry in `architect.build.options.budgets` (or in a per-configuration
+/// override). Mirrors the schema accepted by `@angular/build:application`.
+/// Sizes accept either a raw byte count (number) or a string with a unit
+/// suffix (`"500kb"`, `"1.2mb"`, `"800b"`); the parser follows ng build's
+/// convention where `kb` means `kibibyte` (×1024) — confusing but compatible.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RawBudget {
+    /// Budget type. One of: `initial`, `anyComponentStyle`, `anyScript`,
+    /// `bundle`, `all`, `allScript`. Unknown types are ignored at resolve
+    /// time with a warning rather than failing the parse.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Required when `kind = "bundle"` — the bundle name to apply to.
+    pub name: Option<String>,
+    /// Baseline used for delta budgets (`"+10%"` etc.). Currently parsed
+    /// but not enforced; we treat absolute sizes only.
+    pub baseline: Option<RawBudgetSize>,
+    /// Threshold above which a warning is emitted.
+    pub maximum_warning: Option<RawBudgetSize>,
+    /// Threshold above which an error is emitted (build fails).
+    pub maximum_error: Option<RawBudgetSize>,
+    /// Shorthand alias for `maximum_warning` when no separate min/max
+    /// distinction is needed.
+    pub warning: Option<RawBudgetSize>,
+    /// Shorthand alias for `maximum_error`.
+    pub error: Option<RawBudgetSize>,
+}
+
+/// A budget threshold value: either a raw byte count or a size string with
+/// a unit suffix.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum RawBudgetSize {
+    /// Raw byte count (`"maximumError": 1048576`).
+    Number(u64),
+    /// Size string with optional unit suffix (`"1mb"`, `"500kb"`, `"800b"`).
+    /// Percentage strings (`"5%"`) are accepted by the parser but are not
+    /// honoured by the enforcer in v1.0 (treated as 0 → never trips).
+    String(String),
+}
+
+impl RawBudgetSize {
+    /// Parse the value into an absolute byte count. Returns `None` for
+    /// unparseable strings or percentage values (which would require a
+    /// baseline to resolve).
+    pub fn to_bytes(&self) -> Option<u64> {
+        match self {
+            RawBudgetSize::Number(n) => Some(*n),
+            RawBudgetSize::String(s) => parse_size_string(s),
+        }
+    }
+}
+
+/// Parse an Angular size string like `"500kb"`, `"1.2mb"`, `"800b"` into a
+/// byte count. Matches ng build's behaviour: `kb` and `mb` use multiples of
+/// 1024 (kibibyte/mebibyte) despite the misleading name. Percentage
+/// strings (`"10%"`) return `None` — delta budgets aren't supported in v1.0.
+fn parse_size_string(raw: &str) -> Option<u64> {
+    let s = raw.trim().to_ascii_lowercase();
+    if s.is_empty() {
+        return None;
+    }
+    if s.ends_with('%') {
+        return None;
+    }
+    let (num_part, multiplier) = if let Some(num) = s.strip_suffix("gb") {
+        (num.trim(), 1024u64 * 1024 * 1024)
+    } else if let Some(num) = s.strip_suffix("mb") {
+        (num.trim(), 1024u64 * 1024)
+    } else if let Some(num) = s.strip_suffix("kb") {
+        (num.trim(), 1024u64)
+    } else if let Some(num) = s.strip_suffix('b') {
+        (num.trim(), 1u64)
+    } else {
+        (s.as_str(), 1u64)
+    };
+    let value: f64 = num_part.parse().ok()?;
+    Some((value * multiplier as f64) as u64)
 }
 
 /// `serviceWorker` accepts either a bool (Angular 15+) or a string path
@@ -253,6 +336,9 @@ pub struct RawBuildConfiguration {
     pub cross_origin: Option<String>,
     /// Override for `subresourceIntegrity`.
     pub subresource_integrity: Option<bool>,
+    /// Override for `budgets` — typically only set in the `production`
+    /// configuration (development builds usually have no size limits).
+    pub budgets: Option<Vec<RawBudget>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -359,6 +445,64 @@ pub struct ResolvedAngularProject {
     /// Absolute path to the service-worker config file
     /// (defaults to `<base_dir>/ngsw-config.json`).
     pub ngsw_config_path: PathBuf,
+    /// Resolved size budgets — empty when angular.json declares none for
+    /// the active configuration. Honoured by the bundler in production
+    /// builds; ignored otherwise.
+    pub budgets: Vec<ResolvedBudget>,
+}
+
+/// Type of a resolved size budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetKind {
+    /// Combined size of the initial JS + CSS payload (`main`, `polyfills`,
+    /// global stylesheets — everything that loads before any lazy chunk).
+    Initial,
+    /// Per-component inline-style budget. We approximate this by checking
+    /// the global `styles.css` bundle since ngc-rs does not yet emit
+    /// per-component style bundles separately.
+    AnyComponentStyle,
+    /// Per-script-bundle budget. Each emitted JS chunk is checked
+    /// independently against this threshold.
+    AnyScript,
+    /// Budget for a specific named bundle. The `name` field selects the
+    /// target file (matched by basename without extension or content hash).
+    Bundle,
+    /// Combined size of every emitted script + stylesheet.
+    All,
+    /// Combined size of every emitted script.
+    AllScript,
+}
+
+impl BudgetKind {
+    /// Parse the angular.json `type` string. Returns `None` for unknown
+    /// values; the caller logs a tracing warning and drops the entry.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "initial" => Some(BudgetKind::Initial),
+            "anyComponentStyle" => Some(BudgetKind::AnyComponentStyle),
+            "anyScript" => Some(BudgetKind::AnyScript),
+            "bundle" => Some(BudgetKind::Bundle),
+            "all" => Some(BudgetKind::All),
+            "allScript" => Some(BudgetKind::AllScript),
+            _ => None,
+        }
+    }
+}
+
+/// A budget entry resolved into absolute byte counts. Sizes that could not
+/// be parsed (e.g. percentage strings for delta budgets, which require a
+/// baseline) are dropped at resolve time so the enforcer doesn't have to
+/// re-validate.
+#[derive(Debug, Clone)]
+pub struct ResolvedBudget {
+    /// What the budget applies to.
+    pub kind: BudgetKind,
+    /// Bundle name selector — required for `Bundle`, ignored otherwise.
+    pub name: Option<String>,
+    /// Threshold above which a warning is emitted.
+    pub maximum_warning: Option<u64>,
+    /// Threshold above which a build error is emitted.
+    pub maximum_error: Option<u64>,
 }
 
 /// Resolved i18n configuration with absolute paths.
@@ -581,6 +725,16 @@ pub fn resolve_angular_project(
         .as_ref()
         .map(|raw| resolve_i18n(raw, &base_dir));
 
+    // Resolve budgets — per-configuration overrides take precedence over
+    // base options (matches Angular CLI's merge order). When neither
+    // declares budgets the resolved list is empty.
+    let raw_budgets = build_config
+        .and_then(|bc| bc.budgets.as_ref())
+        .or_else(|| options.and_then(|o| o.budgets.as_ref()));
+    let budgets = raw_budgets
+        .map(|list| resolve_budgets(list))
+        .unwrap_or_default();
+
     debug!(
         project = %name,
         output_path = %output_path.display(),
@@ -609,7 +763,48 @@ pub fn resolve_angular_project(
         i18n,
         service_worker,
         ngsw_config_path,
+        budgets,
     })
+}
+
+/// Convert a slice of `RawBudget` entries into `ResolvedBudget`s, dropping
+/// (with a tracing warning) any entries with an unknown `type` or with no
+/// parseable threshold.
+fn resolve_budgets(raw: &[RawBudget]) -> Vec<ResolvedBudget> {
+    raw.iter()
+        .filter_map(|b| {
+            let kind = match BudgetKind::parse(&b.kind) {
+                Some(k) => k,
+                None => {
+                    tracing::warn!("ignoring unknown budget type {:?} in angular.json", b.kind);
+                    return None;
+                }
+            };
+            let maximum_warning = b
+                .maximum_warning
+                .as_ref()
+                .or(b.warning.as_ref())
+                .and_then(|s| s.to_bytes());
+            let maximum_error = b
+                .maximum_error
+                .as_ref()
+                .or(b.error.as_ref())
+                .and_then(|s| s.to_bytes());
+            if maximum_warning.is_none() && maximum_error.is_none() {
+                tracing::warn!(
+                    "ignoring budget for {:?} — no maximumWarning or maximumError",
+                    b.kind
+                );
+                return None;
+            }
+            Some(ResolvedBudget {
+                kind,
+                name: b.name.clone(),
+                maximum_warning,
+                maximum_error,
+            })
+        })
+        .collect()
 }
 
 /// Resolve a `RawI18nConfig` from `angular.json` into absolute paths.


### PR DESCRIPTION
## Summary

Fifth sub-branch of the v1.0.0 milestone, stacked on #125 (application builder — needs Branch 1's `BuildResult.errors` / `warnings` shape so violations can populate the architect-protocol JSON cleanly).

Closes the only remaining v1.0 milestone gap: drop-in projects with size budgets in `angular.json` will now fail their production build the same way `ng build` does, instead of silently shipping over-size bundles.

- **Parser** — `angular_json.rs` adds `RawBudget` + `RawBudgetSize`, plus the resolved `BudgetKind` and `ResolvedBudget` types. Parses every type the `@angular/build:application` schema accepts: `initial`, `anyComponentStyle`, `anyScript`, `bundle`, `all`, `allScript`. Sizes accept raw numbers or strings with `b`/`kb`/`mb`/`gb` suffixes (matching ng build's "kb means kibibyte" convention). Per-configuration budgets override base options. Per-configuration parsing means `production` typically declares budgets while `development` doesn't.
- **Evaluator** — new `crates/bundler/src/budgets.rs`. Pure function: takes a `[ResolvedBudget]` and a `[OutputArtifact]` (path + size + classified `FileKind` + `is_initial`), returns every `BudgetViolation` (kind, target, actual, threshold, severity). Aggregate budgets emit one violation each; per-file budgets (`AnyScript`, `AnyComponentStyle`, `Bundle`) emit one per offending file. When both warning + error trip on the same metric, only the more severe one is reported (matches ng build).
- **Wiring** — `cli/src/main.rs` runs the evaluator after writing outputs, populates `BuildResult.errors` for error-severity violations and `BuildResult.warnings` for warnings, and sets `success = errors.is_empty()`. `main()` honors `result.success` and exits 1 even when the pipeline returned `Ok`. The `--output-json` payload reports the failure cleanly so `@ngc-rs/builder:application` surfaces it through `BuilderContext.logger`.

## Test plan
- [x] 14 new bundler unit tests (`cargo test -p ngc-bundler budgets`) covering: extension classification, byte formatting, hashed/unhashed bundle-name extraction, every budget kind, warning-vs-error precedence, missing thresholds
- [x] 3 new CLI integration tests (`cargo test -p ngc-rs --test budgets_integration`) — over-budget production build emits valid JSON + exits 1; under-budget succeeds; warning-only doesn't fail
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: rebuild treasr-frontend with `-c production` (its budgets: `initial: 950kb warn / 1.2mb err`, `anyComponentStyle: 6kb/10kb`, `anyScript: 500kb/1mb`) — confirm budget table matches `ng build` output

## Closes / refs

Closes #34
