### PR TITLE
feat(bundler): honor angular.json `define` build-time string replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -868,16 +868,31 @@ pub(crate) fn run_build_with_cache(
         }
     }
 
-    // Production-only: substitute Angular's build-time flags with their
-    // literal values so the minifier can dead-code-eliminate `if (ngDevMode)`
-    // branches throughout `@angular/core` and friends. Replaces the runtime
-    // `globalThis.ngDevMode = false` prologue from earlier ngc-rs versions.
-    if configuration == Some("production") {
+    // Build the active define map:
+    //   * Production builds seed with the ngc-rs built-ins (`ngDevMode = false`,
+    //     etc.) so the minifier can dead-code-eliminate `if (ngDevMode)`
+    //     branches throughout `@angular/core` and friends. This replaces the
+    //     runtime `globalThis.ngDevMode = false` prologue from earlier
+    //     ngc-rs versions.
+    //   * `define` entries from `angular.json` are then layered on top —
+    //     user values override built-ins on collision (with a warning).
+    //   * Non-production builds get only the user-supplied entries, matching
+    //     `@angular/build:application`'s behaviour.
+    let mut define_map = if configuration == Some("production") {
+        ngc_ts_transform::DefineMap::production_angular()
+    } else {
+        ngc_ts_transform::DefineMap::new()
+    };
+    if let Some(ap) = angular_project.as_ref() {
+        if !ap.define.is_empty() {
+            define_map.merge_overriding(ngc_ts_transform::DefineMap::from_map(
+                ap.define.iter().map(|(k, v)| (k.clone(), v.clone())),
+            ));
+        }
+    }
+    if !define_map.is_empty() {
         let define_span = tracing::info_span!("define_substitution").entered();
-        ngc_ts_transform::apply_defines_to_modules(
-            &mut modules,
-            &ngc_ts_transform::DefineMap::production_angular(),
-        );
+        ngc_ts_transform::apply_defines_to_modules(&mut modules, &define_map);
         drop(define_span);
     }
 
@@ -974,6 +989,7 @@ pub(crate) fn run_build_with_cache(
                 &config_dir,
                 bundle_options,
                 configuration,
+                &ap.define,
             )?;
             polyfills_filename = Some(bundle.filename);
             output_files.extend(bundle.output_files);

--- a/crates/cli/src/polyfills.rs
+++ b/crates/cli/src/polyfills.rs
@@ -35,12 +35,18 @@ pub struct PolyfillsBundle {
 /// - Relative paths (e.g. `src/polyfills.ts`) are resolved against
 ///   `project_root`, transformed through `ts-transform`, and their imports
 ///   recursively followed (relative or bare).
+///
+/// `user_defines` carries the resolved `define` map from `angular.json`; it
+/// is layered on top of ngc-rs's built-in production flags (in production
+/// builds) and applied to the polyfill graph too, so a user define like
+/// `__BUILD_VERSION__` resolves the same way in polyfill code as in app code.
 pub fn generate_polyfills(
     polyfills: &[String],
     out_dir: &Path,
     project_root: &Path,
     bundle_options: BundleOptions,
     configuration: Option<&str>,
+    user_defines: &std::collections::HashMap<String, String>,
 ) -> NgcResult<PolyfillsBundle> {
     let export_conditions =
         ngc_npm_resolver::package_json::conditions_for_configuration(configuration);
@@ -226,12 +232,21 @@ pub fn generate_polyfills(
 
     // Substitute Angular's build-time flags so any dev-only branches reachable
     // from the polyfill graph (e.g. zone.js' development guards) are dropped
-    // by the minifier.
-    if configuration == Some("production") {
-        ngc_ts_transform::apply_defines_to_modules(
-            &mut modules,
-            &ngc_ts_transform::DefineMap::production_angular(),
-        );
+    // by the minifier. User-supplied `define` entries from `angular.json`
+    // are layered on top so polyfill code sees the same substitutions as
+    // app code.
+    let mut polyfill_defines = if configuration == Some("production") {
+        ngc_ts_transform::DefineMap::production_angular()
+    } else {
+        ngc_ts_transform::DefineMap::new()
+    };
+    if !user_defines.is_empty() {
+        polyfill_defines.merge_overriding(ngc_ts_transform::DefineMap::from_map(
+            user_defines.iter().map(|(k, v)| (k.clone(), v.clone())),
+        ));
+    }
+    if !polyfill_defines.is_empty() {
+        ngc_ts_transform::apply_defines_to_modules(&mut modules, &polyfill_defines);
     }
 
     // Phase 5: bundle. Disable content-hashing inside the bundler — the
@@ -455,6 +470,7 @@ mod tests {
             &project_root,
             BundleOptions::default(),
             None,
+            &HashMap::new(),
         )
         .unwrap();
 
@@ -496,6 +512,7 @@ mod tests {
             &project_root,
             BundleOptions::default(),
             None,
+            &HashMap::new(),
         )
         .unwrap();
 
@@ -552,6 +569,7 @@ mod tests {
             &project_root,
             BundleOptions::default(),
             None,
+            &HashMap::new(),
         )
         .unwrap();
 
@@ -601,6 +619,7 @@ mod tests {
             &project_root,
             opts,
             None,
+            &HashMap::new(),
         )
         .unwrap();
         assert!(result.filename.starts_with("polyfills."));

--- a/crates/cli/tests/define_integration.rs
+++ b/crates/cli/tests/define_integration.rs
@@ -1,0 +1,229 @@
+//! End-to-end test that the `define` map in `angular.json` reaches the
+//! emitted bundle: identifiers are replaced with their JS source-fragment
+//! values verbatim, and per-configuration overrides win over base options.
+//!
+//! Mirrors `@angular/build:application`'s contract for `define`: the
+//! recorded value is treated as raw JavaScript source (so quoted JSON
+//! strings produce string literals, bare numbers produce numeric literals,
+//! and so on).
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn write_fixture(root: &Path, base_define: &str, prod_define: Option<&str>) {
+    let tsconfig = r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}"#;
+    fs::write(root.join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    // The substitutions happen at the IdentifierReference level, so we
+    // write each define as a top-level identifier read.
+    fs::write(
+        src.join("main.ts"),
+        "declare const __APP_API_URL__: string;\n\
+         declare const __BUILD_VERSION__: string;\n\
+         declare const __FEATURE_X__: boolean;\n\
+         declare const __BUILD_NUMBER__: number;\n\
+         console.log(__APP_API_URL__);\n\
+         console.log(__BUILD_VERSION__);\n\
+         console.log(__FEATURE_X__);\n\
+         console.log(__BUILD_NUMBER__);\n",
+    )
+    .expect("write main.ts");
+
+    let prod_block = match prod_define {
+        Some(d) => format!(
+            r#",
+          "configurations": {{
+            "production": {{
+              "define": {d}
+            }}
+          }}"#
+        ),
+        None => String::new(),
+    };
+
+    let angular_json = format!(
+        r#"{{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {{
+    "demo": {{
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "architect": {{
+        "build": {{
+          "builder": "@angular/build:application",
+          "options": {{
+            "browser": "src/main.ts",
+            "tsConfig": "tsconfig.json",
+            "define": {base}
+          }}{prod_block}
+        }}
+      }}
+    }}
+  }}
+}}
+"#,
+        base = base_define,
+        prod_block = prod_block,
+    );
+    fs::write(root.join("angular.json"), angular_json).expect("write angular.json");
+}
+
+fn run_build(root: &Path, out_dir: &Path, configuration: Option<&str>) -> (i32, String, String) {
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let mut cmd = Command::new(bin);
+    cmd.args(["build", "--project"])
+        .arg(root.join("tsconfig.json"))
+        .arg("--out-dir")
+        .arg(out_dir);
+    if let Some(c) = configuration {
+        cmd.args(["-c", c]);
+    }
+    let output = cmd.output().expect("spawn ngc-rs build");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn read_main_bundle(out_dir: &Path) -> String {
+    // The bundler may content-hash filenames in production, so search for
+    // any `main*.js` rather than hard-coding the name.
+    let mut candidates: Vec<_> = fs::read_dir(out_dir)
+        .expect("read out_dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().is_some_and(|ext| ext == "js")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("main"))
+        })
+        .collect();
+    candidates.sort();
+    let path = candidates
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("no main*.js found in {}", out_dir.display()));
+    fs::read_to_string(&path).expect("read bundle")
+}
+
+#[test]
+fn define_string_value_is_substituted_into_bundle() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_fixture(
+        dir.path(),
+        r#"{
+            "__APP_API_URL__": "\"https://api.example.com\"",
+            "__BUILD_VERSION__": "\"1.0.0-ngref\"",
+            "__FEATURE_X__": "true",
+            "__BUILD_NUMBER__": "42"
+        }"#,
+        None,
+    );
+
+    let out_dir = dir.path().join("dist");
+    let (code, stdout, stderr) = run_build(dir.path(), &out_dir, None);
+    assert_eq!(
+        code, 0,
+        "build failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let bundle = read_main_bundle(&out_dir);
+
+    // String literal: the raw value from angular.json is `"\"…\""`, so the
+    // emitted bundle must contain the unescaped JS string literal.
+    assert!(
+        bundle.contains(r#""https://api.example.com""#),
+        "string-literal define missing from bundle:\n{bundle}"
+    );
+    assert!(
+        bundle.contains(r#""1.0.0-ngref""#),
+        "string-literal define missing from bundle:\n{bundle}"
+    );
+    // Boolean literal — the user-defined identifier should be folded to `true`.
+    assert!(
+        !bundle.contains("__FEATURE_X__"),
+        "user-defined identifier `__FEATURE_X__` leaked into bundle:\n{bundle}"
+    );
+    // Numeric literal — substituted in place.
+    assert!(
+        !bundle.contains("__BUILD_NUMBER__"),
+        "user-defined identifier `__BUILD_NUMBER__` leaked into bundle:\n{bundle}"
+    );
+    // Sanity: none of the user-define identifiers should appear in the bundle.
+    assert!(
+        !bundle.contains("__APP_API_URL__"),
+        "user-defined identifier leaked into bundle:\n{bundle}"
+    );
+    assert!(
+        !bundle.contains("__BUILD_VERSION__"),
+        "user-defined identifier leaked into bundle:\n{bundle}"
+    );
+}
+
+#[test]
+fn define_per_configuration_override_wins() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_fixture(
+        dir.path(),
+        r#"{
+            "__APP_API_URL__": "\"https://dev.example.com\"",
+            "__BUILD_VERSION__": "\"dev\"",
+            "__FEATURE_X__": "false",
+            "__BUILD_NUMBER__": "0"
+        }"#,
+        Some(
+            r#"{
+                "__APP_API_URL__": "\"https://prod.example.com\""
+            }"#,
+        ),
+    );
+
+    let out_dir = dir.path().join("dist");
+    let (code, stdout, stderr) = run_build(dir.path(), &out_dir, Some("production"));
+    assert_eq!(
+        code, 0,
+        "build failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let bundle = read_main_bundle(&out_dir);
+
+    // The configuration override wins for collisions. The minifier may
+    // rewrite the string-literal delimiter (`"…"` → `` `…` ``), so assert
+    // on the unquoted payload only.
+    assert!(
+        bundle.contains("https://prod.example.com"),
+        "production override missing:\n{bundle}"
+    );
+    assert!(
+        !bundle.contains("https://dev.example.com"),
+        "base value should be overridden:\n{bundle}"
+    );
+    // Base-only entry survives — the substituted value is the JS literal
+    // `"dev"`, which the minifier may emit as `'dev'`, `"dev"`, or `` `dev` ``.
+    let has_dev_literal =
+        bundle.contains(r#""dev""#) || bundle.contains("'dev'") || bundle.contains("`dev`");
+    assert!(
+        has_dev_literal,
+        "base define `__BUILD_VERSION__` missing:\n{bundle}"
+    );
+    // And the user-defined identifier was substituted, not left bare.
+    assert!(
+        !bundle.contains("__BUILD_VERSION__"),
+        "user-defined identifier leaked into bundle:\n{bundle}"
+    );
+}

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -150,6 +150,12 @@ pub struct RawBuildOptions {
     pub ngsw_config_path: Option<String>,
     /// Per-bundle and per-initial size budgets.
     pub budgets: Option<Vec<RawBudget>>,
+    /// Build-time string-replacement map. Each value is a raw JS source
+    /// fragment (e.g. `"\"https://api.example.com\""` for a string literal,
+    /// `"42"` for a number, `"true"` for a boolean). Mirrors the `define`
+    /// option of `@angular/build:application`, which itself mirrors
+    /// esbuild's `--define`.
+    pub define: Option<HashMap<String, String>>,
 }
 
 /// One entry in `architect.build.options.budgets` (or in a per-configuration
@@ -339,6 +345,10 @@ pub struct RawBuildConfiguration {
     /// Override for `budgets` — typically only set in the `production`
     /// configuration (development builds usually have no size limits).
     pub budgets: Option<Vec<RawBudget>>,
+    /// Override for `define`. Per-configuration entries are layered on top
+    /// of the base `define` map: same-key entries replace the base value,
+    /// keys that appear only in the base are preserved.
+    pub define: Option<HashMap<String, String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -449,6 +459,11 @@ pub struct ResolvedAngularProject {
     /// the active configuration. Honoured by the bundler in production
     /// builds; ignored otherwise.
     pub budgets: Vec<ResolvedBudget>,
+    /// Resolved `define` map (base options merged with the active
+    /// configuration's overrides). Each value is a raw JS source fragment
+    /// — see [`RawBuildOptions::define`] for the encoding. Empty when no
+    /// `define` block is declared.
+    pub define: HashMap<String, String>,
 }
 
 /// Type of a resolved size budget.
@@ -735,6 +750,16 @@ pub fn resolve_angular_project(
         .map(|list| resolve_budgets(list))
         .unwrap_or_default();
 
+    // Merge `define`: start from base options, then layer the active
+    // configuration's overrides on top (same-key entries replace).
+    let mut define: HashMap<String, String> =
+        options.and_then(|o| o.define.clone()).unwrap_or_default();
+    if let Some(overrides) = build_config.and_then(|bc| bc.define.as_ref()) {
+        for (k, v) in overrides {
+            define.insert(k.clone(), v.clone());
+        }
+    }
+
     debug!(
         project = %name,
         output_path = %output_path.display(),
@@ -764,6 +789,7 @@ pub fn resolve_angular_project(
         service_worker,
         ngsw_config_path,
         budgets,
+        define,
     })
 }
 
@@ -1473,6 +1499,97 @@ mod tests {
         assert!(!result.service_worker);
         // Path defaults to <base_dir>/ngsw-config.json even when sw is off.
         assert!(result.ngsw_config_path.ends_with("ngsw-config.json"));
+    }
+
+    #[test]
+    fn test_parse_define_base_options() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "define": {
+                                    "__APP_API_URL__": "\"https://api.example.com\"",
+                                    "__BUILD_VERSION__": "\"1.0.0\""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(
+            result.define.get("__APP_API_URL__").map(String::as_str),
+            Some("\"https://api.example.com\"")
+        );
+        assert_eq!(
+            result.define.get("__BUILD_VERSION__").map(String::as_str),
+            Some("\"1.0.0\"")
+        );
+    }
+
+    #[test]
+    fn test_define_configuration_overrides_base() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "define": {
+                                    "__API__": "\"dev\"",
+                                    "__SHARED__": "true"
+                                }
+                            },
+                            "configurations": {
+                                "production": {
+                                    "define": {
+                                        "__API__": "\"prod\""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, Some("production")).unwrap();
+        // Configuration overrides win for collisions.
+        assert_eq!(
+            result.define.get("__API__").map(String::as_str),
+            Some("\"prod\"")
+        );
+        // Base-only entries are preserved.
+        assert_eq!(
+            result.define.get("__SHARED__").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn test_define_defaults_to_empty_when_absent() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": { "outputPath": "dist", "tsConfig": "tsconfig.json" }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.define.is_empty());
     }
 
     #[test]

--- a/crates/ts-transform/src/defines.rs
+++ b/crates/ts-transform/src/defines.rs
@@ -25,27 +25,76 @@ use rayon::prelude::*;
 /// Map of identifier name → replacement source text.
 ///
 /// Values are raw JavaScript source fragments (typically literals like
-/// `"false"`) spliced verbatim into the output.
+/// `"false"` or `"\"https://api.example.com\""`) spliced verbatim into the
+/// output. The strings are owned so the map can carry user-supplied values
+/// loaded from `angular.json` at runtime, not just `&'static` built-ins.
 #[derive(Debug, Clone, Default)]
 pub struct DefineMap {
-    entries: HashMap<String, &'static str>,
+    entries: HashMap<String, String>,
 }
 
 impl DefineMap {
+    /// Create an empty map.
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn insert(&mut self, name: impl Into<String>, value: &'static str) {
-        self.entries.insert(name.into(), value);
+    /// Insert a single replacement, overwriting any existing entry for `name`.
+    pub fn insert(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.entries.insert(name.into(), value.into());
     }
 
-    pub fn get(&self, name: &str) -> Option<&'static str> {
-        self.entries.get(name).copied()
+    /// Look up the replacement source text for `name`, if any.
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.entries.get(name).map(String::as_str)
     }
 
+    /// Whether the map has no entries (used to short-circuit the substitution
+    /// pass entirely on no-op runs).
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
+    }
+
+    /// Number of entries in the map.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Build a [`DefineMap`] from an arbitrary `name → value` map. Values are
+    /// raw JS source fragments — pass `"42"`, `"true"`, `"\"https://x\""`, or
+    /// `"{\"k\":1}"` rather than the unquoted Rust strings.
+    pub fn from_map<I, K, V>(entries: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut map = Self::new();
+        for (k, v) in entries {
+            map.insert(k, v);
+        }
+        map
+    }
+
+    /// Merge `other` into `self`. Entries in `other` overwrite existing
+    /// entries with the same key; collisions are reported via
+    /// [`tracing::warn`] so an `angular.json` define that shadows one of
+    /// ngc-rs's built-in flags (`ngDevMode`, `ngI18nClosureMode`,
+    /// `ngJitMode`) is visible in the build log.
+    pub fn merge_overriding(&mut self, other: DefineMap) {
+        for (key, value) in other.entries {
+            if let Some(existing) = self.entries.get(&key) {
+                if existing != &value {
+                    tracing::warn!(
+                        define = %key,
+                        builtin = %existing,
+                        user = %value,
+                        "user-supplied `define` overrides ngc-rs built-in flag"
+                    );
+                }
+            }
+            self.entries.insert(key, value);
+        }
     }
 
     /// Defines applied to Angular production builds. Lowering these to literal
@@ -134,7 +183,7 @@ pub fn apply_defines_to_modules(modules: &mut HashMap<PathBuf, String>, defines:
 struct Collector<'a, 'b> {
     scoping: &'b Scoping,
     defines: &'b DefineMap,
-    replacements: Vec<(u32, u32, &'static str)>,
+    replacements: Vec<(u32, u32, &'b str)>,
     _marker: std::marker::PhantomData<&'a ()>,
 }
 
@@ -149,7 +198,7 @@ impl<'a, 'b> Collector<'a, 'b> {
     }
 }
 
-impl<'a> Visit<'a> for Collector<'a, '_> {
+impl<'a, 'b> Visit<'a> for Collector<'a, 'b> {
     fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
         let Some(replacement) = self.defines.get(it.name.as_str()) else {
             return;
@@ -311,5 +360,94 @@ mod tests {
         let defines = defines();
         let c = Collector::new(semantic.scoping(), &defines);
         assert!(c.replacements.is_empty());
+    }
+
+    // ----- User-supplied define support (issue #137) -----
+
+    #[test]
+    fn user_string_literal_value_is_substituted_verbatim() {
+        // `angular.json` value is a JSON string: `"\"https://api.example.com\""`.
+        // The outer quotes are part of the replacement source text so the
+        // resulting JS contains a string literal.
+        let map = DefineMap::from_map([("__APP_API_URL__", "\"https://api.example.com\"")]);
+        let src = "console.log(__APP_API_URL__);\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "console.log(\"https://api.example.com\");\n");
+    }
+
+    #[test]
+    fn user_number_value_is_substituted_verbatim() {
+        let map = DefineMap::from_map([("__BUILD_NUMBER__", "42")]);
+        let src = "const n = __BUILD_NUMBER__;\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "const n = 42;\n");
+    }
+
+    #[test]
+    fn user_boolean_value_is_substituted_verbatim() {
+        let map = DefineMap::from_map([("__FEATURE_X__", "true")]);
+        let src = "if (__FEATURE_X__) {}\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "if (true) {}\n");
+    }
+
+    #[test]
+    fn user_json_object_value_is_substituted_verbatim() {
+        let map = DefineMap::from_map([("__CFG__", "{\"k\":1}")]);
+        let src = "const c = __CFG__;\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "const c = {\"k\":1};\n");
+    }
+
+    #[test]
+    fn merge_overriding_user_value_wins() {
+        // User's `ngDevMode` (= `true`) overrides the production_angular
+        // built-in (= `false`). The collision triggers a tracing warning,
+        // but here we just assert the resulting substitution.
+        let mut map = DefineMap::production_angular();
+        map.merge_overriding(DefineMap::from_map([("ngDevMode", "true")]));
+        let src = "if (ngDevMode) { 'a'; }\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "if (true) { 'a'; }\n");
+    }
+
+    #[test]
+    fn merge_overriding_keeps_unrelated_builtins() {
+        let mut map = DefineMap::production_angular();
+        map.merge_overriding(DefineMap::from_map([("__FOO__", "1")]));
+        // Built-ins still in place.
+        let src = "if (ngI18nClosureMode) {}\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "if (false) {}\n");
+        // User entry took effect too.
+        let src = "const f = __FOO__;\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "const f = 1;\n");
+    }
+
+    #[test]
+    fn merge_overriding_same_value_is_a_noop() {
+        // Re-defining a built-in to the same value shouldn't change behaviour;
+        // (and the warning path checks `existing != value`, so it stays quiet).
+        let mut map = DefineMap::production_angular();
+        map.merge_overriding(DefineMap::from_map([("ngDevMode", "false")]));
+        let src = "if (ngDevMode) {}\n";
+        let out = apply_defines(src, "in.js", &map);
+        assert_eq!(out, "if (false) {}\n");
+    }
+
+    #[test]
+    fn from_map_empty_iterator_is_empty() {
+        let map = DefineMap::from_map(std::iter::empty::<(String, String)>());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn len_reports_entry_count() {
+        let mut map = DefineMap::new();
+        assert_eq!(map.len(), 0);
+        map.insert("A", "1");
+        map.insert("B", "2");
+        assert_eq!(map.len(), 2);
     }
 }

--- a/packages/builder/schemas/application.json
+++ b/packages/builder/schemas/application.json
@@ -217,6 +217,11 @@
         "type": "object"
       }
     },
+    "define": {
+      "type": "object",
+      "description": "Build-time string-replacement map. Each value is a raw JS source fragment (matching esbuild and @angular/build:application semantics): `\"\\\"https://api.example.com\\\"\"` produces a string literal, `\"42\"` a number, `\"true\"` a boolean. Read from angular.json by ngc-rs.",
+      "additionalProperties": { "type": "string" }
+    },
     "externalDependencies": {
       "type": "array",
       "description": "Modules to keep external (not bundled). Accepted for compatibility but currently ignored by ngc-rs.",

--- a/packages/builder/schemas/application.json
+++ b/packages/builder/schemas/application.json
@@ -217,11 +217,6 @@
         "type": "object"
       }
     },
-    "define": {
-      "type": "object",
-      "description": "Build-time string-replacement map. Each value is a raw JS source fragment (matching esbuild and @angular/build:application semantics): `\"\\\"https://api.example.com\\\"\"` produces a string literal, `\"42\"` a number, `\"true\"` a boolean. Read from angular.json by ngc-rs.",
-      "additionalProperties": { "type": "string" }
-    },
     "externalDependencies": {
       "type": "array",
       "description": "Modules to keep external (not bundled). Accepted for compatibility but currently ignored by ngc-rs.",
@@ -299,7 +294,7 @@
     "define": {
       "type": "object",
       "additionalProperties": { "type": "string" },
-      "description": "Build-time global identifier replacement (e.g. `\"process.env.API_URL\": \"\\\"https://...\\\"\"`). Read from angular.json by ngc-rs; engine support is being landed alongside this declaration. Until that lands, values are silently ignored."
+      "description": "Build-time global identifier replacement (e.g. `\"process.env.API_URL\": \"\\\"https://...\\\"\"`). Each value is a raw JS source fragment (matching esbuild and @angular/build:application semantics): `\"\\\"foo\\\"\"` produces a string literal, `\"42\"` a number, `\"true\"` a boolean. Read from angular.json by ngc-rs."
     },
     "conditions": {
       "type": "array",

--- a/packages/builder/src/build/__tests__/options.test.ts
+++ b/packages/builder/src/build/__tests__/options.test.ts
@@ -144,4 +144,21 @@ describe('translateOptions (build)', () => {
     const i = t.args.indexOf('--project');
     expect(t.args[i + 1]).toBe('tsconfig.json');
   });
+
+  it('accepts a `define` map without warnings (passed through via angular.json)', () => {
+    const t = translateOptions(
+      {
+        ...minimal,
+        define: {
+          __APP_API_URL__: '"https://api.example.com"',
+          __BUILD_VERSION__: '"1.0.0"',
+        },
+      },
+      '/ws',
+      null,
+    );
+    expect(t.warnings.some((w) => w.toLowerCase().includes('define'))).toBe(
+      false,
+    );
+  });
 });

--- a/packages/builder/src/build/options.ts
+++ b/packages/builder/src/build/options.ts
@@ -189,11 +189,6 @@ export function translateOptions(
       'Selecting a locale subset via `localize` array is not yet honoured by ngc-rs; all locales declared in `angular.json` `i18n.locales` are emitted.',
     );
   }
-  if (raw.define && Object.keys(raw.define).length > 0) {
-    warnings.push(
-      'The `define` option is accepted for schema compatibility but engine-side substitution is being added in a parallel change; values are silently ignored until that lands.',
-    );
-  }
   if (raw.stylePreprocessorOptions) {
     const opts = raw.stylePreprocessorOptions as json.JsonObject;
     const includePaths = opts['includePaths'];

--- a/packages/builder/src/build/options.ts
+++ b/packages/builder/src/build/options.ts
@@ -31,6 +31,7 @@ export interface ApplicationOptions extends json.JsonObject {
   preserveSymlinks: boolean | null;
   statsJson: boolean | null;
   budgets: json.JsonArray | null;
+  define: json.JsonObject | null;
   externalDependencies: string[] | null;
   allowedCommonJsDependencies: string[] | null;
   extractLicenses: boolean | null;

--- a/packages/builder/src/build/options.ts
+++ b/packages/builder/src/build/options.ts
@@ -31,7 +31,6 @@ export interface ApplicationOptions extends json.JsonObject {
   preserveSymlinks: boolean | null;
   statsJson: boolean | null;
   budgets: json.JsonArray | null;
-  define: json.JsonObject | null;
   externalDependencies: string[] | null;
   allowedCommonJsDependencies: string[] | null;
   extractLicenses: boolean | null;


### PR DESCRIPTION
## Summary

Closes #137. Implements the `define` option from `angular.json`'s
`architect.build.options` so build-time string replacements work the same
way `@angular/build:application` (esbuild) does. Previously the field was
silently ignored; values declared in `angular.json` had no effect on the
emitted bundle.

- `crates/project-resolver/src/angular_json.rs` — adds `define: Option<HashMap<String,String>>` to `RawBuildOptions` and `RawBuildConfiguration`; resolves into `ResolvedAngularProject.define` with per-configuration entries layered on top of base entries (matching the existing merge semantics for `baseHref`/`deployUrl`/etc.).
- `crates/ts-transform/src/defines.rs` — refactors `DefineMap` from `HashMap<String, &'static str>` to owned strings so it can carry user-supplied values loaded at runtime; adds `from_map`/`merge_overriding` constructors. `merge_overriding` emits a `tracing::warn!` on user-vs-built-in collisions.
- `crates/cli/src/main.rs` — at the existing `apply_defines_to_modules` site, seeds the production_angular built-ins (in production builds only), then layers user defines from `angular.json` on top. Non-production builds get only the user-supplied entries, matching the upstream builder.
- `crates/cli/src/polyfills.rs` — applies the same merged map to the polyfill graph so polyfill code sees the same substitutions as app code.

User-supplied values are treated as raw JS source fragments (matching
esbuild/angular semantics): `\"https://api.example.com\"` becomes a JS
string literal, `42` a numeric literal, `true` a boolean, `{\"k\":1}` an
object literal. The substitution still respects scope (locals/imports
that shadow a global identifier are not replaced) and write-position
guards (no `false = x` syntax errors).

## Test plan

- [x] `cargo test --workspace` — 76 + 43 + 242 + … all green; new tests:
  - `ts-transform/src/defines.rs` — string/number/bool/JSON-object substitutions; merge override + override-keeps-unrelated-builtins; `from_map` empty + len reporting (8 new unit tests).
  - `project-resolver/src/angular_json.rs` — base `define` parsing; per-configuration override merge; empty default (3 new unit tests).
  - `cli/tests/define_integration.rs` — end-to-end: drive the full `ngc-rs` binary against a synthetic `angular.json`, assert the substituted literals appear in the emitted bundle (2 new integration tests; production override path validated).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Verified the test-ng-project fixture's pre-existing parse error in two component files reproduces on `main` (unrelated to this change; `inject(...)` + `@for` template-extraction issue, out of scope).