### PR TITLE
feat(dev-server): honor servePath for subpath deploys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -222,6 +222,13 @@ enum Commands {
         /// listening.
         #[arg(long)]
         open: bool,
+        /// URL path prefix to mount the dev server under (e.g. `/admin/`).
+        /// Mirrors the `servePath` option of `@angular/build:dev-server` for
+        /// projects deployed behind a subpath. When set without an explicit
+        /// `baseHref` in `angular.json`, the served `index.html` is rewritten
+        /// to use the same value as its `<base href>`.
+        #[arg(long = "serve-path")]
+        serve_path: Option<String>,
     },
     /// Extract translatable messages from every component template in the
     /// project and emit a `messages.xlf` (XLIFF 1.2) file.
@@ -290,8 +297,16 @@ fn main() {
             port,
             host,
             open,
+            serve_path,
         } => {
-            if let Err(e) = serve_cmd::run(&project, Some(&configuration), &host, port, open) {
+            if let Err(e) = serve_cmd::run(
+                &project,
+                Some(&configuration),
+                &host,
+                port,
+                open,
+                serve_path.as_deref(),
+            ) {
                 eprintln!("{} {e}", "Error:".red().bold());
                 process::exit(1);
             }
@@ -416,7 +431,14 @@ fn run_build(
     configuration: Option<&str>,
     localize: bool,
 ) -> NgcResult<BuildResult> {
-    run_build_with_cache(project, out_dir_override, configuration, localize, None)
+    run_build_with_options(
+        project,
+        out_dir_override,
+        configuration,
+        localize,
+        None,
+        None,
+    )
 }
 
 /// Variant of [`run_build`] that consults a [`incremental::BuildCache`] to
@@ -428,7 +450,31 @@ pub(crate) fn run_build_with_cache(
     out_dir_override: Option<&Path>,
     configuration: Option<&str>,
     localize: bool,
+    cache: Option<&mut incremental::BuildCache>,
+) -> NgcResult<BuildResult> {
+    run_build_with_options(
+        project,
+        out_dir_override,
+        configuration,
+        localize,
+        cache,
+        None,
+    )
+}
+
+/// Variant of [`run_build_with_cache`] that additionally accepts an
+/// optional `<base href>` fallback for `index.html` injection. Used by
+/// `ngc-rs serve --serve-path` so that, when `angular.json` does not set
+/// an explicit `baseHref`, the served `index.html` still picks up the
+/// dev-server's URL prefix as its base. When the project resolves a
+/// `baseHref` of its own the override is ignored.
+pub(crate) fn run_build_with_options(
+    project: &Path,
+    out_dir_override: Option<&Path>,
+    configuration: Option<&str>,
+    localize: bool,
     mut cache: Option<&mut incremental::BuildCache>,
+    base_href_override: Option<&str>,
 ) -> NgcResult<BuildResult> {
     let started_at = Instant::now();
 
@@ -1037,8 +1083,13 @@ pub(crate) fn run_build_with_cache(
                 .filter(|s| s.inject)
                 .map(|s| s.filename.as_str())
                 .collect();
+            // angular.json's baseHref wins when present; otherwise fall
+            // back to the dev-server servePath override (for #139) so
+            // subpath-deployed apps still get a correct <base href> in
+            // dev. When neither is set, leave the index untouched.
+            let resolved_base_href = ap.base_href.as_deref().or(base_href_override);
             let index_opts = IndexHtmlOptions {
-                base_href: ap.base_href.as_deref(),
+                base_href: resolved_base_href,
                 deploy_url: ap.deploy_url.as_deref(),
                 cross_origin: ap.cross_origin,
                 subresource_integrity: ap.subresource_integrity,

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -33,8 +33,17 @@ pub fn run(
     host: &str,
     port: u16,
     open: bool,
+    serve_path: Option<&str>,
 ) -> NgcResult<()> {
-    run_with_stop(project, configuration, host, port, open, install_ctrlc)
+    run_with_stop(
+        project,
+        configuration,
+        host,
+        port,
+        open,
+        serve_path,
+        install_ctrlc,
+    )
 }
 
 /// Variant of [`run`] that lets the caller decide how the shutdown flag is
@@ -47,13 +56,25 @@ pub(crate) fn run_with_stop(
     host: &str,
     port: u16,
     open: bool,
+    serve_path: Option<&str>,
     install_stop: impl FnOnce(Arc<AtomicBool>),
 ) -> NgcResult<()> {
     let out_dir = crate::resolve_out_dir(project, None, configuration)?;
     let mut cache = BuildCache::new();
 
-    let initial =
-        crate::run_build_with_cache(project, None, configuration, false, Some(&mut cache))?;
+    // Normalize the user-supplied servePath up-front so the dev server
+    // mount and the index.html `<base href>` fallback agree on the
+    // canonical `/foo/` form (see `ngc_dev_server::normalize_serve_path`).
+    let normalized_serve_path = serve_path.and_then(ngc_dev_server::normalize_serve_path);
+
+    let initial = crate::run_build_with_options(
+        project,
+        None,
+        configuration,
+        false,
+        Some(&mut cache),
+        normalized_serve_path.as_deref(),
+    )?;
     eprintln!(
         "{} {} module(s), {} file(s)",
         "ngc-rs build complete".bold().green(),
@@ -64,9 +85,13 @@ pub(crate) fn run_with_stop(
     let (event_tx, event_rx) = channel::<DevServerEvent>();
     let cfg = DevServerConfig::new(&out_dir)
         .with_host(host.to_string())
-        .with_port(port);
+        .with_port(port)
+        .with_serve_path(normalized_serve_path.as_deref());
     let server = DevServer::start(cfg, event_rx)?;
-    let url = format!("http://{}", server.addr());
+    let url = match server.serve_path() {
+        Some(prefix) => format!("http://{}{}", server.addr(), prefix),
+        None => format!("http://{}", server.addr()),
+    };
     eprintln!(
         "{} {}",
         "ngc-rs serve listening on".bold().green(),
@@ -85,6 +110,7 @@ pub(crate) fn run_with_stop(
     let watcher = Watcher::new(WatcherConfig::new(watch_root(project)));
     let project_path = project.to_path_buf();
     let configuration_owned = configuration.map(|s| s.to_string());
+    let serve_path_owned = normalized_serve_path.clone();
 
     let build_fn = move |dirty: &[PathBuf]| -> NgcResult<()> {
         if dirty.iter().any(|p| !is_ts_path(p)) {
@@ -92,12 +118,13 @@ pub(crate) fn run_with_stop(
         } else {
             cache.invalidate(dirty);
         }
-        let outcome = crate::run_build_with_cache(
+        let outcome = crate::run_build_with_options(
             &project_path,
             None,
             configuration_owned.as_deref(),
             false,
             Some(&mut cache),
+            serve_path_owned.as_deref(),
         );
         match outcome {
             Ok(result) => {

--- a/crates/cli/tests/serve_integration.rs
+++ b/crates/cli/tests/serve_integration.rs
@@ -76,7 +76,14 @@ fn serve_help_lists_all_flags() {
         .expect("spawn ngc-rs serve --help");
     assert!(out.status.success(), "serve --help should exit 0");
     let stdout = String::from_utf8_lossy(&out.stdout);
-    for flag in ["--project", "--configuration", "--port", "--host", "--open"] {
+    for flag in [
+        "--project",
+        "--configuration",
+        "--port",
+        "--host",
+        "--open",
+        "--serve-path",
+    ] {
         assert!(
             stdout.contains(flag),
             "serve --help missing {flag}, got: {stdout}"
@@ -257,6 +264,128 @@ fn serve_lists_index_and_emits_reload() {
         reload_observed,
         "SSE channel should have emitted a reload event after rebuild"
     );
+}
+
+#[test]
+fn serve_path_mounts_under_prefix_and_404s_root() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().canonicalize().expect("canonicalize root");
+    write_fixture(&root);
+
+    let bin = env!("CARGO_BIN_EXE_ngc-rs");
+    let tsconfig = root.join("tsconfig.json");
+
+    let mut child = Command::new(bin)
+        .args(["serve", "--project"])
+        .arg(&tsconfig)
+        .args([
+            "--port",
+            "0",
+            "--host",
+            "127.0.0.1",
+            "--serve-path",
+            "/admin/",
+        ])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn ngc-rs serve");
+
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let reader = BufReader::new(stderr);
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let stderr_handle = std::thread::spawn(move || {
+        for line in reader.lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + TIMEOUT;
+    let ready_line = match wait_for(&rx, READY_MARKER, deadline) {
+        Some(l) => l,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("serve never reported ready within {TIMEOUT:?}");
+        }
+    };
+
+    // The printed URL must include the prefix so users can copy it.
+    assert!(
+        ready_line.contains("/admin/"),
+        "ready line missing servePath, got: {ready_line}"
+    );
+
+    let addr = match extract_addr(&ready_line) {
+        Some(a) => a,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("could not parse address from ready line: {ready_line}");
+        }
+    };
+
+    let dist = root.join("dist");
+    fs::create_dir_all(&dist).expect("create dist");
+    fs::write(
+        dist.join("index.html"),
+        "<!doctype html><html><body><h1>hello</h1></body></html>",
+    )
+    .expect("write index.html");
+
+    let prefixed = http_status(&addr, "/admin/").expect("status under prefix");
+    let body = http_get(&addr, "/admin/").expect("body under prefix");
+    let deep = http_status(&addr, "/admin/users/42").expect("deep link");
+    let root_status = http_status(&addr, "/").expect("status at /");
+    let sse_status = http_status_only(&addr, "/admin/__ngc_reload").expect("SSE under prefix");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = stderr_handle.join();
+
+    assert_eq!(prefixed, 200, "prefix root should serve index");
+    assert!(
+        body.contains("<h1>hello</h1>") && body.contains("'/admin/__ngc_reload'"),
+        "prefix body missing index or rewritten EventSource URL: {body}"
+    );
+    assert_eq!(deep, 200, "deep link should fall back to index");
+    assert_eq!(root_status, 404, "root should 404 when servePath is set");
+    assert_eq!(sse_status, 200, "SSE channel must be mounted under prefix");
+}
+
+/// Issue an HTTP/1.1 GET and return only the response status code.
+fn http_status(addr: &str, path: &str) -> std::io::Result<u16> {
+    let mut stream = TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    let req = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes())?;
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line)?;
+    Ok(status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0))
+}
+
+/// Issue an HTTP/1.1 GET that closes the socket as soon as headers are
+/// drained. Used for SSE checks where waiting for body close would block.
+fn http_status_only(addr: &str, path: &str) -> std::io::Result<u16> {
+    let mut stream = TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    let req = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\n\r\n");
+    stream.write_all(req.as_bytes())?;
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line)?;
+    Ok(status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0))
 }
 
 /// Issue a minimal HTTP/1.1 GET against `addr` and return the response

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -88,6 +88,11 @@ pub struct DevServerConfig {
     /// Port to bind on. Defaults to `4200`. A value of `0` will let the OS
     /// pick an ephemeral port — useful for tests.
     pub port: u16,
+    /// Optional URL prefix the server is mounted under, normalized to the
+    /// `/foo/` form (always leading and trailing `/`). When `None`, the
+    /// server mounts at `/`. Mirrors `@angular/build:dev-server`'s
+    /// `servePath` option for subpath deploys.
+    pub serve_path: Option<String>,
 }
 
 impl DevServerConfig {
@@ -98,6 +103,7 @@ impl DevServerConfig {
             root: root.into(),
             host: "127.0.0.1".to_string(),
             port: 4200,
+            serve_path: None,
         }
     }
 
@@ -112,6 +118,40 @@ impl DevServerConfig {
         self.port = port;
         self
     }
+
+    /// Mount the server under a URL prefix. `None` (or `Some("/")`) keeps
+    /// the default root mount. Any other value is normalized to the
+    /// `/foo/` form so callers don't need to remember to add slashes.
+    pub fn with_serve_path(mut self, serve_path: Option<&str>) -> Self {
+        self.serve_path = serve_path.and_then(normalize_serve_path);
+        self
+    }
+}
+
+/// Normalize a `servePath` string to the canonical `/foo/` form.
+///
+/// Returns `None` when the normalized value is `/` (i.e. the prefix is
+/// effectively empty), so callers can treat a normalized `None` as "no
+/// prefix" without separate boolean tracking. Empty input also returns
+/// `None`.
+pub fn normalize_serve_path(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut out = String::with_capacity(trimmed.len() + 2);
+    if !trimmed.starts_with('/') {
+        out.push('/');
+    }
+    out.push_str(trimmed);
+    if !out.ends_with('/') {
+        out.push('/');
+    }
+    if out == "/" {
+        None
+    } else {
+        Some(out)
+    }
 }
 
 /// Handle to a running dev server.
@@ -122,6 +162,7 @@ pub struct DevServer {
     event_tx: Sender<DevServerEvent>,
     server: Arc<Server>,
     accept_join: Option<JoinHandle<()>>,
+    serve_path: Option<String>,
 }
 
 impl DevServer {
@@ -168,20 +209,23 @@ impl DevServer {
         let request_server = Arc::clone(&server);
         let root = config.root.clone();
         let request_clients = Arc::clone(&clients);
+        let serve_path = config.serve_path.clone();
+        let serve_path_for_loop = serve_path.clone();
         let join = thread::Builder::new()
             .name("ngc-dev-server-accept".into())
-            .spawn(move || serve_loop(request_server, root, request_clients))
+            .spawn(move || serve_loop(request_server, root, request_clients, serve_path_for_loop))
             .map_err(|e| NgcError::ServeError {
                 message: format!("could not spawn accept thread: {e}"),
             })?;
 
-        tracing::info!(addr = %actual_addr, "ngc-rs dev server listening");
+        tracing::info!(addr = %actual_addr, serve_path = ?serve_path, "ngc-rs dev server listening");
 
         Ok(Self {
             addr: actual_addr,
             event_tx: internal_tx,
             server,
             accept_join: Some(join),
+            serve_path,
         })
     }
 
@@ -189,6 +233,12 @@ impl DevServer {
     /// `0` this reflects the ephemeral port chosen by the OS.
     pub fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// URL prefix the server is mounted under, in canonical `/foo/` form,
+    /// or `None` when the server is mounted at `/`.
+    pub fn serve_path(&self) -> Option<&str> {
+        self.serve_path.as_deref()
     }
 
     /// Send a reload event to all connected browsers without going through
@@ -291,19 +341,25 @@ pub fn sse_frame(event: &DevServerEvent) -> String {
     }
 }
 
-fn serve_loop(server: Arc<Server>, root: PathBuf, clients: SseClients) {
+fn serve_loop(server: Arc<Server>, root: PathBuf, clients: SseClients, serve_path: Option<String>) {
     for request in server.incoming_requests() {
         let root = root.clone();
         let clients = Arc::clone(&clients);
+        let serve_path = serve_path.clone();
         thread::spawn(move || {
-            if let Err(e) = handle_request(request, &root, &clients) {
+            if let Err(e) = handle_request(request, &root, &clients, serve_path.as_deref()) {
                 tracing::warn!(error = %e, "dev server request failed");
             }
         });
     }
 }
 
-fn handle_request(request: tiny_http::Request, root: &Path, clients: &SseClients) -> NgcResult<()> {
+fn handle_request(
+    request: tiny_http::Request,
+    root: &Path,
+    clients: &SseClients,
+    serve_path: Option<&str>,
+) -> NgcResult<()> {
     if !matches!(request.method(), Method::Get | Method::Head) {
         let resp = Response::from_string("method not allowed").with_status_code(StatusCode(405));
         return request.respond(resp).map_err(io_err);
@@ -312,11 +368,51 @@ fn handle_request(request: tiny_http::Request, root: &Path, clients: &SseClients
     let url = request.url().to_string();
     let path = url.split('?').next().unwrap_or("/");
 
-    if path == "/__ngc_reload" {
+    let stripped = match strip_serve_path(path, serve_path) {
+        Some(s) => s,
+        None => {
+            let resp = Response::from_string("not found").with_status_code(StatusCode(404));
+            return request.respond(resp).map_err(io_err);
+        }
+    };
+
+    if stripped == "/__ngc_reload" {
         return handle_sse(request, clients);
     }
 
-    serve_static(request, root, path)
+    serve_static(request, root, stripped, serve_path)
+}
+
+/// Strip the `serve_path` prefix from `path`, returning the remainder
+/// (always starting with `/`). Returns `None` when `path` falls outside
+/// the prefix and should be served as 404.
+///
+/// Special case: a request to the prefix without its trailing slash
+/// (e.g. `/admin` for prefix `/admin/`) is accepted and treated as the
+/// prefix root, matching what `@angular/build:dev-server` does for the
+/// servePath base — production deployments behind reverse proxies often
+/// rewrite this anyway, and rejecting it is more surprising than helpful.
+fn strip_serve_path<'a>(path: &'a str, serve_path: Option<&str>) -> Option<&'a str> {
+    let Some(prefix) = serve_path else {
+        return Some(path);
+    };
+    if let Some(rest) = path.strip_prefix(prefix) {
+        if rest.is_empty() {
+            return Some("/");
+        }
+        // strip_prefix leaves the rest without the trailing `/` of the
+        // prefix, so reattach a leading `/` for the downstream router.
+        // SAFETY: rest is a suffix of path; we just need to splice the
+        // leading slash back on.
+        let start = path.len() - rest.len() - 1;
+        return Some(&path[start..]);
+    }
+    // Allow the prefix without its trailing `/`: prefix="/admin/" → "/admin".
+    let prefix_no_slash = prefix.trim_end_matches('/');
+    if path == prefix_no_slash {
+        return Some("/");
+    }
+    None
 }
 
 fn handle_sse(request: tiny_http::Request, clients: &SseClients) -> NgcResult<()> {
@@ -343,7 +439,12 @@ Access-Control-Allow-Origin: *\r\n\
     Ok(())
 }
 
-fn serve_static(request: tiny_http::Request, root: &Path, url_path: &str) -> NgcResult<()> {
+fn serve_static(
+    request: tiny_http::Request,
+    root: &Path,
+    url_path: &str,
+    serve_path: Option<&str>,
+) -> NgcResult<()> {
     let decoded = decode_path(url_path);
     let candidate = match resolve_under_root(root, &decoded) {
         Some(p) => p,
@@ -354,8 +455,8 @@ fn serve_static(request: tiny_http::Request, root: &Path, url_path: &str) -> Ngc
     };
 
     match pick_file(&candidate) {
-        Some(file_path) => respond_with_file(request, &file_path),
-        None => spa_fallback(request, root),
+        Some(file_path) => respond_with_file(request, &file_path, serve_path),
+        None => spa_fallback(request, root, serve_path),
     }
 }
 
@@ -372,17 +473,25 @@ fn pick_file(candidate: &Path) -> Option<PathBuf> {
     None
 }
 
-fn spa_fallback(request: tiny_http::Request, root: &Path) -> NgcResult<()> {
+fn spa_fallback(
+    request: tiny_http::Request,
+    root: &Path,
+    serve_path: Option<&str>,
+) -> NgcResult<()> {
     let index = root.join("index.html");
     if index.is_file() {
-        respond_with_file(request, &index)
+        respond_with_file(request, &index, serve_path)
     } else {
         let resp = Response::from_string("not found").with_status_code(StatusCode(404));
         request.respond(resp).map_err(io_err)
     }
 }
 
-fn respond_with_file(request: tiny_http::Request, path: &Path) -> NgcResult<()> {
+fn respond_with_file(
+    request: tiny_http::Request,
+    path: &Path,
+    serve_path: Option<&str>,
+) -> NgcResult<()> {
     let bytes = std::fs::read(path).map_err(|e| NgcError::Io {
         path: path.to_path_buf(),
         source: e,
@@ -390,7 +499,7 @@ fn respond_with_file(request: tiny_http::Request, path: &Path) -> NgcResult<()> 
     let mime = mime_for(path);
 
     let body = if is_index_html(path) {
-        inject_live_reload_client(&bytes)
+        inject_live_reload_client_with_prefix(&bytes, serve_path)
     } else {
         bytes
     };
@@ -520,29 +629,59 @@ pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs
 /// Insert the live-reload client script into an HTML byte buffer.
 ///
 /// Inserts immediately before the closing `</body>` tag (case-insensitive).
-/// If no `</body>` is present, appends to the end.
+/// If no `</body>` is present, appends to the end. The injected script
+/// subscribes to `/__ngc_reload` (the un-prefixed SSE channel); use
+/// [`inject_live_reload_client_with_prefix`] when the dev server is
+/// mounted under a [`DevServerConfig::serve_path`] prefix.
 pub fn inject_live_reload_client(html: &[u8]) -> Vec<u8> {
+    inject_live_reload_client_with_prefix(html, None)
+}
+
+/// Variant of [`inject_live_reload_client`] that rewrites the SSE
+/// `EventSource` URL in the injected script to be mounted under
+/// `serve_path` when the server is configured with a URL prefix.
+pub fn inject_live_reload_client_with_prefix(html: &[u8], serve_path: Option<&str>) -> Vec<u8> {
+    let script = live_reload_script_for(serve_path);
     let s = match std::str::from_utf8(html) {
         Ok(s) => s,
         Err(_) => {
-            let mut out = Vec::with_capacity(html.len() + LIVE_RELOAD_SCRIPT.len());
+            let mut out = Vec::with_capacity(html.len() + script.len());
             out.extend_from_slice(html);
-            out.extend_from_slice(LIVE_RELOAD_SCRIPT.as_bytes());
+            out.extend_from_slice(script.as_bytes());
             return out;
         }
     };
     let lower = s.to_ascii_lowercase();
     if let Some(idx) = lower.rfind("</body>") {
-        let mut out = String::with_capacity(s.len() + LIVE_RELOAD_SCRIPT.len());
+        let mut out = String::with_capacity(s.len() + script.len());
         out.push_str(&s[..idx]);
-        out.push_str(LIVE_RELOAD_SCRIPT);
+        out.push_str(&script);
         out.push_str(&s[idx..]);
         return out.into_bytes();
     }
-    let mut out = String::with_capacity(s.len() + LIVE_RELOAD_SCRIPT.len());
+    let mut out = String::with_capacity(s.len() + script.len());
     out.push_str(s);
-    out.push_str(LIVE_RELOAD_SCRIPT);
+    out.push_str(&script);
     out.into_bytes()
+}
+
+/// Render the injected live-reload `<script>` for a given mount prefix.
+///
+/// When `serve_path` is `None` (server mounted at `/`), this returns
+/// [`LIVE_RELOAD_SCRIPT`] unchanged. Otherwise, the literal
+/// `'/__ngc_reload'` `EventSource` URL is rewritten to point at the
+/// prefixed channel (e.g. `'/admin/__ngc_reload'`) so the browser
+/// subscribes to the right path under reverse proxies and subpath
+/// deploys.
+pub fn live_reload_script_for(serve_path: Option<&str>) -> String {
+    match serve_path {
+        None => LIVE_RELOAD_SCRIPT.to_string(),
+        Some(prefix) => {
+            let trimmed = prefix.trim_end_matches('/');
+            let new_url = format!("'{trimmed}/__ngc_reload'");
+            LIVE_RELOAD_SCRIPT.replace("'/__ngc_reload'", &new_url)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -760,5 +899,79 @@ mod tests {
         assert!(!LIVE_RELOAD_SCRIPT.contains("http://"));
         assert!(!LIVE_RELOAD_SCRIPT.contains("https://"));
         assert!(!LIVE_RELOAD_SCRIPT.contains("<link"));
+    }
+
+    #[test]
+    fn normalize_serve_path_canonicalizes_to_leading_and_trailing_slash() {
+        assert_eq!(normalize_serve_path("admin").as_deref(), Some("/admin/"));
+        assert_eq!(normalize_serve_path("/admin").as_deref(), Some("/admin/"));
+        assert_eq!(normalize_serve_path("admin/").as_deref(), Some("/admin/"));
+        assert_eq!(normalize_serve_path("/admin/").as_deref(), Some("/admin/"));
+        assert_eq!(normalize_serve_path("/a/b/c").as_deref(), Some("/a/b/c/"));
+    }
+
+    #[test]
+    fn normalize_serve_path_treats_root_and_empty_as_no_prefix() {
+        assert_eq!(normalize_serve_path("").as_deref(), None);
+        assert_eq!(normalize_serve_path("   ").as_deref(), None);
+        assert_eq!(normalize_serve_path("/").as_deref(), None);
+    }
+
+    #[test]
+    fn devserver_config_with_serve_path_normalizes_and_drops_root() {
+        let cfg = DevServerConfig::new("/tmp/dist").with_serve_path(Some("admin"));
+        assert_eq!(cfg.serve_path.as_deref(), Some("/admin/"));
+        let cfg = DevServerConfig::new("/tmp/dist").with_serve_path(Some("/"));
+        assert!(cfg.serve_path.is_none());
+        let cfg = DevServerConfig::new("/tmp/dist").with_serve_path(None);
+        assert!(cfg.serve_path.is_none());
+    }
+
+    #[test]
+    fn strip_serve_path_returns_unchanged_without_prefix() {
+        assert_eq!(strip_serve_path("/main.js", None), Some("/main.js"));
+        assert_eq!(strip_serve_path("/", None), Some("/"));
+    }
+
+    #[test]
+    fn strip_serve_path_strips_matching_prefix() {
+        let p = Some("/admin/");
+        assert_eq!(strip_serve_path("/admin/", p), Some("/"));
+        assert_eq!(strip_serve_path("/admin/main.js", p), Some("/main.js"));
+        assert_eq!(strip_serve_path("/admin/users/42", p), Some("/users/42"));
+        assert_eq!(
+            strip_serve_path("/admin/__ngc_reload", p),
+            Some("/__ngc_reload")
+        );
+    }
+
+    #[test]
+    fn strip_serve_path_accepts_prefix_without_trailing_slash() {
+        assert_eq!(strip_serve_path("/admin", Some("/admin/")), Some("/"));
+    }
+
+    #[test]
+    fn strip_serve_path_rejects_outside_prefix() {
+        let p = Some("/admin/");
+        assert_eq!(strip_serve_path("/", p), None);
+        assert_eq!(strip_serve_path("/main.js", p), None);
+        // No false positive on look-alike segment names.
+        assert_eq!(strip_serve_path("/adminer", p), None);
+        assert_eq!(strip_serve_path("/adminer/foo", p), None);
+    }
+
+    #[test]
+    fn live_reload_script_for_no_prefix_returns_default() {
+        assert_eq!(live_reload_script_for(None), LIVE_RELOAD_SCRIPT);
+    }
+
+    #[test]
+    fn live_reload_script_for_prefix_rewrites_event_source_url() {
+        let script = live_reload_script_for(Some("/admin/"));
+        assert!(script.contains("'/admin/__ngc_reload'"));
+        assert!(!script.contains("'/__ngc_reload'"));
+        // Other behavior is preserved.
+        assert!(script.contains("addEventListener('reload'"));
+        assert!(script.contains("addEventListener('build-failed'"));
     }
 }

--- a/crates/dev-server/tests/integration.rs
+++ b/crates/dev-server/tests/integration.rs
@@ -387,3 +387,89 @@ fn unknown_extension_serves_octet_stream() {
         "application/octet-stream"
     );
 }
+
+fn prefixed_fixture(serve_path: &str) -> Fixture {
+    let root = TempDir::new().expect("tempdir");
+    write_file(
+        root.path(),
+        "index.html",
+        b"<html><body><h1>hi</h1></body></html>",
+    );
+    write_file(root.path(), "main.js", b"console.log('hello');");
+    let cfg = DevServerConfig::new(root.path())
+        .with_port(0)
+        .with_serve_path(Some(serve_path));
+    let (_tx, rx) = channel::<DevServerEvent>();
+    let server = DevServer::start(cfg, rx).expect("start dev server");
+    Fixture {
+        server,
+        _root: root,
+    }
+}
+
+#[test]
+fn prefixed_root_serves_index_html() {
+    let fx = prefixed_fixture("/admin/");
+    let resp = http_get(fx.server.addr(), "/admin/");
+    assert_eq!(resp.status, 200);
+    let body = std::str::from_utf8(&resp.body).expect("utf8 body");
+    assert!(body.contains("<h1>hi</h1>"));
+    // EventSource URL must point to the prefixed SSE channel.
+    assert!(body.contains("'/admin/__ngc_reload'"));
+}
+
+#[test]
+fn prefixed_static_asset_strips_prefix_for_filesystem_lookup() {
+    let fx = prefixed_fixture("/admin/");
+    let resp = http_get(fx.server.addr(), "/admin/main.js");
+    assert_eq!(resp.status, 200);
+    assert_eq!(resp.body, b"console.log('hello');");
+}
+
+#[test]
+fn prefixed_deep_link_falls_back_to_index_html() {
+    let fx = prefixed_fixture("/admin/");
+    let resp = http_get(fx.server.addr(), "/admin/users/42");
+    assert_eq!(resp.status, 200);
+    let body = std::str::from_utf8(&resp.body).expect("utf8 body");
+    assert!(body.contains("<h1>hi</h1>"));
+}
+
+#[test]
+fn unprefixed_request_returns_404_when_serve_path_set() {
+    let fx = prefixed_fixture("/admin/");
+    assert_eq!(http_get(fx.server.addr(), "/").status, 404);
+    assert_eq!(http_get(fx.server.addr(), "/main.js").status, 404);
+    assert_eq!(http_get(fx.server.addr(), "/__ngc_reload").status, 404);
+}
+
+#[test]
+fn prefixed_sse_channel_is_reachable_under_prefix() {
+    let fx = prefixed_fixture("/admin/");
+    let mut stream = TcpStream::connect(fx.server.addr()).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+    let req =
+        "GET /admin/__ngc_reload HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: text/event-stream\r\n\r\n";
+    stream.write_all(req.as_bytes()).expect("write");
+    stream.flush().expect("flush");
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line).expect("status line");
+    assert!(status_line.contains("200"), "got {status_line}");
+
+    let mut saw_event_stream = false;
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).expect("header");
+        if n == 0 || line == "\r\n" {
+            break;
+        }
+        if line.to_ascii_lowercase().contains("text/event-stream") {
+            saw_event_stream = true;
+        }
+    }
+    assert!(saw_event_stream);
+}

--- a/packages/builder/schemas/dev-server.json
+++ b/packages/builder/schemas/dev-server.json
@@ -59,6 +59,10 @@
     "watch": {
       "type": "boolean",
       "description": "Whether the dev server rebuilds on file changes. Always true in `ngc-rs serve`; setting it to false logs a warning."
+    },
+    "servePath": {
+      "type": "string",
+      "description": "URL path prefix to mount the dev server under (e.g. \"/admin/\"). Mirrors @angular/build:dev-server's servePath option for projects deployed behind a subpath. When set, the served index.html is rewritten to use the same value as <base href> unless angular.json already configures one explicitly."
     }
   },
   "additionalProperties": false

--- a/packages/builder/src/serve/__tests__/options.test.ts
+++ b/packages/builder/src/serve/__tests__/options.test.ts
@@ -76,6 +76,30 @@ describe('translateOptions', () => {
     const t = translateOptions({ port: 4200, host: 'localhost' }, '/ws');
     expect(t.args).not.toContain('--configuration');
   });
+
+  it('forwards a normalized servePath as --serve-path', () => {
+    const t = translateOptions({ ...base, servePath: 'admin' }, '/ws');
+    const idx = t.args.indexOf('--serve-path');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(t.args[idx + 1]).toBe('/admin/');
+    expect(t.url).toBe('http://localhost:4200/admin/');
+  });
+
+  it('preserves a fully-qualified servePath unchanged', () => {
+    const t = translateOptions({ ...base, servePath: '/app/' }, '/ws');
+    const idx = t.args.indexOf('--serve-path');
+    expect(t.args[idx + 1]).toBe('/app/');
+    expect(t.url).toBe('http://localhost:4200/app/');
+  });
+
+  it('drops --serve-path when servePath is empty or just a slash', () => {
+    expect(
+      translateOptions({ ...base, servePath: '/' }, '/ws').args,
+    ).not.toContain('--serve-path');
+    expect(
+      translateOptions({ ...base, servePath: '' }, '/ws').args,
+    ).not.toContain('--serve-path');
+  });
 });
 
 describe('formatUrl', () => {
@@ -84,5 +108,10 @@ describe('formatUrl', () => {
   });
   it('keeps custom hostnames untouched', () => {
     expect(formatUrl('app.local', 8080)).toBe('http://app.local:8080/');
+  });
+  it('appends a servePath when provided', () => {
+    expect(formatUrl('localhost', 4200, '/admin/')).toBe(
+      'http://localhost:4200/admin/',
+    );
   });
 });

--- a/packages/builder/src/serve/options.ts
+++ b/packages/builder/src/serve/options.ts
@@ -14,6 +14,7 @@ export interface DevServerOptions extends json.JsonObject {
   ngcRsBinary: string | null;
   define: { [key: string]: string } | null;
   watch: boolean | null;
+  servePath: string | null;
 }
 
 export interface TranslatedServeArgs {
@@ -60,6 +61,7 @@ export function translateOptions(
 
   const configuration = parseConfigurationFromBuildTarget(raw.buildTarget);
   const project = raw.project ?? 'tsconfig.json';
+  const servePath = normalizeServePath(raw.servePath ?? null);
 
   const proxyConfigPath = raw.proxyConfig
     ? path.resolve(workspaceRoot, raw.proxyConfig)
@@ -74,6 +76,9 @@ export function translateOptions(
     args.push('--configuration', configuration);
   }
   args.push('--host', spawnHost, '--port', String(spawnPort));
+  if (servePath) {
+    args.push('--serve-path', servePath);
+  }
 
   return {
     args,
@@ -85,8 +90,28 @@ export function translateOptions(
     proxyPort: userPort,
     proxyConfigPath,
     open,
-    url: formatUrl(userHost, userPort),
+    url: formatUrl(userHost, userPort, servePath),
   };
+}
+
+// Normalize a user-supplied servePath into the canonical `/foo/` form, or
+// return null when the value is empty / a bare `/` (i.e. no prefix). The
+// rust side runs the same normalization (`ngc_dev_server::normalize_serve_path`),
+// but normalizing on this side too lets the printed URL and any downstream
+// proxy rewriting agree without depending on the spawned process.
+function normalizeServePath(raw: string | null | undefined): string | null {
+  if (!raw) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === '/') {
+    return null;
+  }
+  let out = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  if (!out.endsWith('/')) {
+    out = `${out}/`;
+  }
+  return out;
 }
 
 function parseConfigurationFromBuildTarget(buildTarget?: string): string | null {
@@ -100,8 +125,13 @@ function parseConfigurationFromBuildTarget(buildTarget?: string): string | null 
   return null;
 }
 
-export function formatUrl(host: string, port: number): string {
+export function formatUrl(
+  host: string,
+  port: number,
+  servePath: string | null = null,
+): string {
   const isLoopbackName = host === 'localhost' || host === '0.0.0.0';
   const display = isLoopbackName ? 'localhost' : host;
-  return `http://${display}:${port}/`;
+  const suffix = servePath ?? '/';
+  return `http://${display}:${port}${suffix}`;
 }


### PR DESCRIPTION
## Summary

Closes #139.

- `crates/dev-server`: `DevServerConfig` gains `serve_path` plus a `with_serve_path` builder and a public `normalize_serve_path` helper that canonicalizes inputs to the `/foo/` form (empty / `/` collapse to `None`). `handle_request` strips the prefix before routing, returns 404 for off-prefix paths, and the SSE channel moves to `<prefix>/__ngc_reload`. The injected live-reload script's `EventSource` URL is rewritten to match via a new `live_reload_script_for(prefix)` builder; `LIVE_RELOAD_SCRIPT` and `inject_live_reload_client` stay for backward compatibility.
- `crates/cli`: `Serve` subcommand gets `--serve-path`, threaded through `serve_cmd::run` / `run_with_stop`. The new `run_build_with_options` wrapper around `run_build_with_cache` accepts an optional base-href fallback so that, when `angular.json` does not set an explicit `baseHref`, the served `index.html` picks up the dev-server's URL prefix as its `<base href>`. The startup banner prints the prefixed URL.
- `packages/builder`: `dev-server.json` schema and `translateOptions` learn about `servePath`; the option is normalized on the TS side too and forwarded as `--serve-path`. `formatUrl` accepts an optional prefix so the builder's printed URL agrees.
- New tests: 7 dev-server unit tests for normalization, prefix stripping, and script rewriting; 5 dev-server integration tests covering prefixed root, static asset, deep-link SPA fallback, off-prefix 404, and prefixed SSE; one CLI integration test (`serve_path_mounts_under_prefix_and_404s_root`) that spawns the binary end-to-end; vitest cases for `--serve-path` forwarding and `formatUrl` prefix support.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `vitest run` in `packages/builder`
- [x] `tsc -p packages/builder/tsconfig.json --noEmit`
- [x] Spawned end-to-end serve test verifies `/admin/` serves index, `/admin/users/42` falls back, `/` returns 404, `/admin/__ngc_reload` reaches the SSE channel