### PR TITLE
feat(template-compiler): --strict-templates flag for hard JIT-fallback errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -179,6 +179,12 @@ enum Commands {
         /// `<out_dir>/<sourceLocale>/`.
         #[arg(long)]
         localize: bool,
+        /// Treat any template that would fall back to JIT compilation as a
+        /// hard error. Mirrors `@angular/build:application`, which has no
+        /// JIT fallback. Defaults to on for `--configuration production` and
+        /// off otherwise; pass `--strict-templates` to force on.
+        #[arg(long)]
+        strict_templates: bool,
     },
     /// Watch the project's input files and rebuild incrementally on every
     /// save. The first rebuild does a full pipeline run; subsequent rebuilds
@@ -332,13 +338,20 @@ fn main() {
             configuration,
             output_json,
             localize,
+            strict_templates,
         } => {
             let started = Instant::now();
+            // Default `strict_templates` to on for production, off otherwise —
+            // matches `@angular/build:application`'s lack of JIT fallback.
+            // An explicit `--strict-templates` always forces on.
+            let strict_templates =
+                strict_templates || configuration.as_deref() == Some("production");
             match run_build(
                 &project,
                 out_dir.as_deref(),
                 configuration.as_deref(),
                 localize,
+                strict_templates,
             ) {
                 Ok(result) => {
                     if output_json {
@@ -430,12 +443,14 @@ fn run_build(
     out_dir_override: Option<&Path>,
     configuration: Option<&str>,
     localize: bool,
+    strict_templates: bool,
 ) -> NgcResult<BuildResult> {
     run_build_with_options(
         project,
         out_dir_override,
         configuration,
         localize,
+        strict_templates,
         None,
         None,
     )
@@ -445,6 +460,10 @@ fn run_build(
 /// skip template compilation and TypeScript transformation for source files
 /// whose bytes haven't changed since the last successful build. Used by the
 /// `watch` subcommand; one-shot `build` callers pass `None`.
+///
+/// Always disables `strict_templates`: `watch` is a dev workflow, so JIT
+/// fallback warnings must not be escalated into a build error that would
+/// block iteration.
 pub(crate) fn run_build_with_cache(
     project: &Path,
     out_dir_override: Option<&Path>,
@@ -457,6 +476,7 @@ pub(crate) fn run_build_with_cache(
         out_dir_override,
         configuration,
         localize,
+        false,
         cache,
         None,
     )
@@ -468,11 +488,16 @@ pub(crate) fn run_build_with_cache(
 /// an explicit `baseHref`, the served `index.html` still picks up the
 /// dev-server's URL prefix as its base. When the project resolves a
 /// `baseHref` of its own the override is ignored.
+///
+/// `strict_templates` mirrors the `--strict-templates` build flag: when
+/// true, any template that would otherwise fall back to JIT compilation
+/// produces an [`NgcError::TemplateCompileError`] instead.
 pub(crate) fn run_build_with_options(
     project: &Path,
     out_dir_override: Option<&Path>,
     configuration: Option<&str>,
     localize: bool,
+    strict_templates: bool,
     mut cache: Option<&mut incremental::BuildCache>,
     base_href_override: Option<&str>,
 ) -> NgcResult<BuildResult> {
@@ -543,8 +568,14 @@ pub(crate) fn run_build_with_options(
         .iter()
         .filter_map(|p| incremental::BuildCache::hash_file(p).map(|h| (p.clone(), h)))
         .collect();
-    let (compiled, transform_cache_seed) =
-        compile_decorators_cached(&files, &style_ctx, cache.as_deref_mut(), &file_hashes)?;
+    let compile_opts = ngc_template_compiler::CompileOptions { strict_templates };
+    let (compiled, transform_cache_seed) = compile_decorators_cached(
+        &files,
+        &style_ctx,
+        &compile_opts,
+        cache.as_deref_mut(),
+        &file_hashes,
+    )?;
     drop(templates_span);
 
     // Report any JIT fallbacks. Each fallback also goes into
@@ -2464,6 +2495,7 @@ type CompileWithHashes = (
 fn compile_decorators_cached(
     files: &[PathBuf],
     style_ctx: &ngc_template_compiler::StyleContext,
+    compile_opts: &ngc_template_compiler::CompileOptions,
     mut cache: Option<&mut incremental::BuildCache>,
     file_hashes: &HashMap<PathBuf, [u8; 32]>,
 ) -> NgcResult<CompileWithHashes> {
@@ -2490,7 +2522,12 @@ fn compile_decorators_cached(
             path: file.clone(),
             source: e,
         })?;
-        let cf = ngc_template_compiler::compile_file_with_styles(&source, file, style_ctx)?;
+        let cf = ngc_template_compiler::compile_file_with_options(
+            &source,
+            file,
+            style_ctx,
+            compile_opts,
+        )?;
         if cache_present {
             // Recompute hash if pre-hashing missed (file changed under us).
             let h = hash.unwrap_or_else(|| incremental::BuildCache::hash_bytes(source.as_bytes()));

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -67,10 +67,14 @@ pub(crate) fn run_with_stop(
     // canonical `/foo/` form (see `ngc_dev_server::normalize_serve_path`).
     let normalized_serve_path = serve_path.and_then(ngc_dev_server::normalize_serve_path);
 
+    // `serve` is dev-only; pass `strict_templates: false` so JIT fallback
+    // warnings are not escalated into a build error that would block dev
+    // iteration on transient template-compile gaps.
     let initial = crate::run_build_with_options(
         project,
         None,
         configuration,
+        false,
         false,
         Some(&mut cache),
         normalized_serve_path.as_deref(),
@@ -122,6 +126,7 @@ pub(crate) fn run_with_stop(
             &project_path,
             None,
             configuration_owned.as_deref(),
+            false,
             false,
             Some(&mut cache),
             serve_path_owned.as_deref(),

--- a/crates/cli/src/watch_cmd.rs
+++ b/crates/cli/src/watch_cmd.rs
@@ -31,7 +31,10 @@ pub fn run(
 ) -> NgcResult<()> {
     let mut cache = BuildCache::new();
 
-    // Initial build to populate the cache.
+    // Initial build to populate the cache. `run_build_with_cache` always
+    // disables `strict_templates` — `watch` is a dev workflow, so JIT
+    // fallback warnings must not be escalated into a build error that would
+    // block iteration on transient template-compile gaps.
     let initial = crate::run_build_with_cache(
         project,
         out_dir_override,

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -57,6 +57,24 @@ impl Default for StyleContext {
     }
 }
 
+/// Knobs that change template-compile behaviour without affecting style
+/// preprocessing.
+///
+/// Threaded alongside [`StyleContext`] so the two concerns stay separable:
+/// `StyleContext` carries inputs the preprocessor needs, while `CompileOptions`
+/// controls how strict the compiler is about constructs it can't yet emit
+/// natively. Keeping them split lets call sites that only care about one
+/// concern leave the other at its default.
+#[derive(Debug, Clone, Default)]
+pub struct CompileOptions {
+    /// When `true`, any component whose template would otherwise fall back to
+    /// JIT (because it uses a construct the native compiler doesn't recognise)
+    /// produces an [`NgcError::TemplateCompileError`] instead. Mirrors
+    /// `@angular/build:application`'s `strictTemplates` behaviour, which has
+    /// no JIT fallback.
+    pub strict_templates: bool,
+}
+
 /// Lightweight metadata for template compilation without `ExtractedComponent`.
 ///
 /// Used by the Angular linker to compile templates from `ɵɵngDeclareComponent`
@@ -259,6 +277,21 @@ pub fn compile_all_decorators_with_styles(
     files: &[PathBuf],
     style_ctx: &StyleContext,
 ) -> NgcResult<Vec<CompiledFile>> {
+    compile_all_decorators_with_options(files, style_ctx, &CompileOptions::default())
+}
+
+/// Variant of [`compile_all_decorators_with_styles`] that also takes
+/// [`CompileOptions`].
+///
+/// Used by callers that need to enable strict template compilation
+/// (`strict_templates: true`), which converts JIT-fallback events into
+/// [`NgcError::TemplateCompileError`] so production builds fail loudly
+/// instead of silently shipping a JIT-compiled component.
+pub fn compile_all_decorators_with_options(
+    files: &[PathBuf],
+    style_ctx: &StyleContext,
+    compile_opts: &CompileOptions,
+) -> NgcResult<Vec<CompiledFile>> {
     let results: Vec<NgcResult<CompiledFile>> = files
         .par_iter()
         .map(|file_path| {
@@ -267,7 +300,7 @@ pub fn compile_all_decorators_with_styles(
                 source: e,
             })?;
 
-            compile_file(&source, file_path, style_ctx)
+            compile_file(&source, file_path, style_ctx, compile_opts)
         })
         .collect();
 
@@ -292,7 +325,21 @@ pub fn compile_file_with_styles(
     file_path: &Path,
     style_ctx: &StyleContext,
 ) -> NgcResult<CompiledFile> {
-    compile_file(source, file_path, style_ctx)
+    compile_file(source, file_path, style_ctx, &CompileOptions::default())
+}
+
+/// Variant of [`compile_file_with_styles`] that also takes [`CompileOptions`].
+///
+/// When `compile_opts.strict_templates` is true, a component that would
+/// normally fall back to JIT instead returns
+/// [`NgcError::TemplateCompileError`] so the caller can fail the build.
+pub fn compile_file_with_options(
+    source: &str,
+    file_path: &Path,
+    style_ctx: &StyleContext,
+    compile_opts: &CompileOptions,
+) -> NgcResult<CompiledFile> {
+    compile_file(source, file_path, style_ctx, compile_opts)
 }
 
 /// Compile a single TypeScript source file, handling all Angular decorator types.
@@ -309,14 +356,15 @@ fn compile_file(
     source: &str,
     file_path: &Path,
     style_ctx: &StyleContext,
+    compile_opts: &CompileOptions,
 ) -> NgcResult<CompiledFile> {
     #[cfg(feature = "ast-reuse")]
     {
-        compile_file_dispatch(source, file_path, style_ctx)
+        compile_file_dispatch(source, file_path, style_ctx, compile_opts)
     }
     #[cfg(not(feature = "ast-reuse"))]
     {
-        compile_file_fallthrough(source, file_path, style_ctx)
+        compile_file_fallthrough(source, file_path, style_ctx, compile_opts)
     }
 }
 
@@ -325,9 +373,11 @@ fn compile_file_fallthrough(
     source: &str,
     file_path: &Path,
     style_ctx: &StyleContext,
+    compile_opts: &CompileOptions,
 ) -> NgcResult<CompiledFile> {
     // Try @Component first (most complex, has template compilation)
-    let component_result = compile_component_with_styles(source, file_path, style_ctx)?;
+    let component_result =
+        compile_component_with_options(source, file_path, style_ctx, compile_opts)?;
     if component_result.compiled || component_result.jit_fallback {
         return Ok(component_result);
     }
@@ -371,6 +421,7 @@ fn compile_file_dispatch(
     source: &str,
     file_path: &Path,
     style_ctx: &StyleContext,
+    compile_opts: &CompileOptions,
 ) -> NgcResult<CompiledFile> {
     let has_component = source.contains("@Component");
     let has_injectable = source.contains("@Injectable");
@@ -388,7 +439,7 @@ fn compile_file_dispatch(
     }
 
     if has_component {
-        let r = compile_component_with_styles(source, file_path, style_ctx)?;
+        let r = compile_component_with_options(source, file_path, style_ctx, compile_opts)?;
         if r.compiled || r.jit_fallback {
             return Ok(r);
         }
@@ -611,6 +662,22 @@ pub fn compile_component_with_styles(
     file_path: &Path,
     style_ctx: &StyleContext,
 ) -> NgcResult<CompiledFile> {
+    compile_component_with_options(source, file_path, style_ctx, &CompileOptions::default())
+}
+
+/// Variant of [`compile_component_with_styles`] that also takes
+/// [`CompileOptions`].
+///
+/// When `compile_opts.strict_templates` is true, a template that would
+/// normally fall back to JIT is reported as an
+/// [`NgcError::TemplateCompileError`] instead, matching
+/// `@angular/build:application`'s behaviour of having no JIT fallback.
+pub fn compile_component_with_options(
+    source: &str,
+    file_path: &Path,
+    style_ctx: &StyleContext,
+    compile_opts: &CompileOptions,
+) -> NgcResult<CompiledFile> {
     let mut extracted = match extract::extract_component(source, file_path)? {
         Some(ext) => ext,
         None => {
@@ -625,6 +692,16 @@ pub fn compile_component_with_styles(
 
     // Check for JIT fallback triggers
     if extracted.needs_jit_fallback() {
+        if compile_opts.strict_templates {
+            return Err(NgcError::TemplateCompileError {
+                path: file_path.to_path_buf(),
+                message: "template contains constructs the AOT compiler does not yet support; \
+                          JIT fallback is disabled by --strict-templates"
+                    .to_string(),
+                line: None,
+                column: None,
+            });
+        }
         tracing::warn!(
             path = %file_path.display(),
             "template contains unsupported constructs, using JIT fallback"
@@ -709,6 +786,32 @@ export class XComponent {}
         let ids: Vec<&str> = messages.iter().filter_map(|m| m.id.as_deref()).collect();
         assert!(ids.contains(&"intro"));
         assert!(ids.contains(&"alt"));
+    }
+
+    #[test]
+    fn test_strict_templates_does_not_break_valid_components() {
+        // Regression guard: strict mode must not turn fully-AOT-compilable
+        // components into errors. The strict→Err branch only fires for
+        // components whose template would otherwise fall back to JIT.
+        let source = "import { Component } from '@angular/core';\n\n@Component({\n  selector: 'app-x',\n  standalone: true,\n  template: '<div>{{ name }}</div>',\n})\nexport class XComponent { name = 'world'; }\n";
+        let path = PathBuf::from("x.component.ts");
+        let style_ctx = StyleContext::default();
+        let strict = CompileOptions {
+            strict_templates: true,
+        };
+        let lenient = CompileOptions::default();
+
+        let r_strict = compile_component_with_options(source, &path, &style_ctx, &strict)
+            .expect("strict compile should succeed on valid component");
+        assert!(r_strict.compiled, "strict-mode build should AOT-compile");
+        assert!(
+            !r_strict.jit_fallback,
+            "no jit_fallback on a valid component"
+        );
+
+        let r_lenient = compile_component_with_options(source, &path, &style_ctx, &lenient)
+            .expect("lenient compile should also succeed");
+        assert!(r_lenient.compiled);
     }
 
     #[test]
@@ -903,7 +1006,13 @@ export class SidenavComponent implements OnInit {
 }
 "#;
         let path = PathBuf::from("test.component.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled, "should be compiled");
         assert!(
             !result.source.contains("@Component"),
@@ -932,7 +1041,13 @@ export class AuthService {
 }
 "#;
         let path = PathBuf::from("auth.service.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled, "should be compiled");
         assert!(result.source.contains("\u{0275}prov"));
         assert!(result.source.contains("\u{0275}\u{0275}defineInjectable"));
@@ -959,7 +1074,13 @@ export class DataService {
 }
 "#;
         let path = PathBuf::from("data.service.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}\u{0275}inject(HttpClient)"));
         assert!(result.source.contains("\u{0275}\u{0275}inject(Router)"));
@@ -994,7 +1115,13 @@ export class HostDirective {
 }
 "#;
         let path = PathBuf::from("host.directive.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled, "should be compiled");
         let out = &result.source;
 
@@ -1058,7 +1185,13 @@ export class PortfolioComponent {
 }
 "#;
         let path = PathBuf::from("portfolio.component.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         let out = &result.source;
         assert!(
@@ -1103,7 +1236,13 @@ export class ChildDirective {}
 export class HostComponent {}
 "#;
         let path = PathBuf::from("host.component.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         let out = &result.source;
         assert!(
@@ -1156,7 +1295,13 @@ import { ChildDir } from './child.directive';
 export class HostDir {}
 "#;
         let path = PathBuf::from("host.directive.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         let out = &result.source;
         assert!(
@@ -1178,7 +1323,13 @@ export class HighlightDirective {
 }
 "#;
         let path = PathBuf::from("highlight.directive.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}dir"));
         assert!(result.source.contains("\u{0275}\u{0275}defineDirective"));
@@ -1207,7 +1358,13 @@ export class DateFormatPipe implements PipeTransform {
 }
 "#;
         let path = PathBuf::from("date-format.pipe.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}pipe"));
         assert!(result.source.contains("\u{0275}\u{0275}definePipe"));
@@ -1235,7 +1392,13 @@ export class DateFormatPipe implements PipeTransform {
 export class AppModule {}
 "#;
         let path = PathBuf::from("app.module.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled);
         assert!(result.source.contains("\u{0275}mod"));
         assert!(result.source.contains("\u{0275}inj"));
@@ -1256,7 +1419,13 @@ export class AppModule {}
     fn test_plain_class_unchanged() {
         let source = "export class PlainClass { x = 1; }\n";
         let path = PathBuf::from("plain.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(!result.compiled);
         assert_eq!(result.source, source);
     }
@@ -1445,7 +1614,13 @@ export class TestComponent {
 export class IconComponent {}
 "#;
         let path = PathBuf::from("icon.component.ts");
-        let result = compile_file(source, &path, &StyleContext::default()).expect("should compile");
+        let result = compile_file(
+            source,
+            &path,
+            &StyleContext::default(),
+            &CompileOptions::default(),
+        )
+        .expect("should compile");
         assert!(result.compiled, "should be compiled");
 
         let out = &result.source;

--- a/packages/builder/schemas/application.json
+++ b/packages/builder/schemas/application.json
@@ -346,6 +346,10 @@
     "webWorkerTsConfig": {
       "type": "string",
       "description": "Separate tsconfig for `new Worker(...)` bundles. NOT yet supported by ngc-rs (web workers are not detected by the bundler). Setting this fails the build."
+    },
+    "strictTemplates": {
+      "type": "boolean",
+      "description": "When true, ngc-rs is invoked with `--strict-templates` and any template that would otherwise fall back to JIT compilation is reported as a hard build error. Mirrors `@angular/build:application`, which has no JIT fallback. ngc-rs also enables this automatically for production configurations."
     }
   },
   "additionalProperties": false

--- a/packages/builder/src/build/__tests__/options.test.ts
+++ b/packages/builder/src/build/__tests__/options.test.ts
@@ -55,6 +55,27 @@ describe('translateOptions (build)', () => {
     expect(t.args).toContain('--localize');
   });
 
+  it('appends --strict-templates when strictTemplates is true', () => {
+    const t = translateOptions(
+      { ...minimal, strictTemplates: true },
+      '/ws',
+      null,
+    );
+    expect(t.args).toContain('--strict-templates');
+  });
+
+  it('omits --strict-templates when strictTemplates is false or unset', () => {
+    const off = translateOptions(
+      { ...minimal, strictTemplates: false },
+      '/ws',
+      null,
+    );
+    expect(off.args).not.toContain('--strict-templates');
+
+    const unset = translateOptions(minimal, '/ws', null);
+    expect(unset.args).not.toContain('--strict-templates');
+  });
+
   it('appends --localize and warns when localize is an array (subset not yet honoured)', () => {
     const t = translateOptions(
       { ...minimal, localize: ['en', 'de'] },

--- a/packages/builder/src/build/options.ts
+++ b/packages/builder/src/build/options.ts
@@ -56,6 +56,7 @@ export interface ApplicationOptions extends json.JsonObject {
   security: json.JsonObject | null;
   appShell: boolean | json.JsonObject | null;
   webWorkerTsConfig: string | null;
+  strictTemplates: boolean | null;
 }
 
 /// Result of translating raw [`ApplicationOptions`] into a CLI invocation.
@@ -238,6 +239,9 @@ export function translateOptions(
   }
   if (localize) {
     args.push('--localize');
+  }
+  if (raw.strictTemplates === true) {
+    args.push('--strict-templates');
   }
 
   return { args, configuration, warnings };


### PR DESCRIPTION
Closes #140.

## Summary

Adds a `--strict-templates` flag to `ngc-rs build` that converts what would
otherwise be a JIT-fallback warning into an `NgcError::TemplateCompileError`,
matching `@angular/build:application`'s behaviour of having no JIT path.

- New `CompileOptions { strict_templates }` threaded through the
  template-compiler API alongside `StyleContext`. Keeping the two structs
  separate so style-preprocessing concerns don't entangle with strictness
  knobs.
- `compile_component_with_options` returns `Err(TemplateCompileError)` at
  the existing JIT-fallback site (`crates/template-compiler/src/lib.rs:627`)
  when strict mode is on, instead of setting `CompiledFile.jit_fallback = true`.
- CLI: `--strict-templates` on `Build`. Auto-enabled for
  `--configuration production` (mirrors `@angular/build:application`); off in
  dev so iteration isn't blocked. `serve` and `watch` always pass `false` —
  they're dev workflows.
- Builder shim: `strictTemplates: boolean | null` on `ApplicationOptions`,
  mirrored in `schemas/application.json`. Forwards `--strict-templates` when
  set to `true`. Errors already surface via `BuilderContext.logger.error`
  through the existing `--output-json` diagnostic plumbing, so no
  `builder.ts` change is needed.

## Notes

- `ExtractedComponent::needs_jit_fallback()` currently returns `false`
  unconditionally — every modern Angular construct compiles to AOT today —
  so the strict→Err branch is wired up but won't fire on a real component
  in this codebase. The wiring is what unblocks v1: future template-compiler
  changes that detect a new unsupported construct will gain a hard-error
  knob automatically.

## Test plan

- [x] `cargo test --workspace` (all 30 test files green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `npm test` in `packages/builder` (60 tests, including new
      `appends --strict-templates when strictTemplates is true` and
      `omits --strict-templates when strictTemplates is false or unset`)
- [x] Smoke test: minimal `@Component` fixture builds successfully both with
      and without `--strict-templates`; `--help` lists the new flag.
