### PR TITLE
feat(i18n): support XLIFF 2.0 (extract + translate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/cli/src/localize/mod.rs
+++ b/crates/cli/src/localize/mod.rs
@@ -1,11 +1,15 @@
 //! Compile-time `$localize` translation substitution.
 //!
-//! Reads XLIFF 1.2 (`.xlf`) translation files into a `{ id → target text }`
-//! map, then rewrites every `$localize\`...\`` tagged template literal in a
+//! Reads XLIFF (`.xlf`) translation files into a `{ id → target text }` map,
+//! then rewrites every `$localize\`...\`` tagged template literal in a
 //! generated JavaScript bundle so that the source-locale text is replaced
 //! with its translation. Messages without an `@@id` marker, or whose id is
 //! not present in the translation map, pass through untouched — at runtime
 //! Angular's `$localize` will fall back to the source string.
+//!
+//! Both XLIFF 1.2 (`<trans-unit>` / `<target>`) and XLIFF 2.0 (`<unit>` /
+//! `<segment>` / `<target>`) are accepted; the parser is selected from the
+//! root element's `version` attribute.
 //!
 //! Currently substitutes only the static text portions; messages containing
 //! `${...}:INTERPOLATION:` placeholders keep the runtime `$localize` shape
@@ -18,71 +22,106 @@ use std::path::Path;
 
 use ngc_diagnostics::{NgcError, NgcResult};
 
+mod xliff_v1;
+mod xliff_v2;
+
 /// Map of message id → translated text. Empty when no XLIFF file is loaded.
 pub type TranslationMap = HashMap<String, String>;
 
-/// Parse an XLIFF 1.2 translation file into a `{ id → target }` map.
+/// Parse an XLIFF translation file into a `{ id → target }` map.
 ///
-/// Recognises `<trans-unit id="...">` entries with a `<target>...</target>`
-/// child. The XLIFF 2.0 (`<unit>` / `<segment>`) format is not yet
-/// supported — extraction emits 1.2 to match Angular's default format.
+/// Detects the schema from the root `<xliff version="...">` attribute and
+/// dispatches to the matching parser:
+///
+/// - `1.2` → [`xliff_v1::parse_xliff_str`] (`<trans-unit id> <target>...`).
+/// - `2.0` → [`xliff_v2::parse_xliff_v2_str`] (`<unit id> <segment> <target>...`).
+///
+/// Other versions (or a missing root element) return an [`NgcError::ConfigError`]
+/// so the user gets a clear diagnostic instead of silently empty translations.
 pub fn parse_xliff(path: &Path) -> NgcResult<TranslationMap> {
     let xml = std::fs::read_to_string(path).map_err(|e| NgcError::Io {
         path: path.to_path_buf(),
         source: e,
     })?;
-    Ok(parse_xliff_str(&xml))
+    parse_xliff_with_path(&xml, Some(path))
 }
 
-/// Internal: parse XLIFF 1.2 from a source string. Tolerant of whitespace
-/// and attribute order; designed to handle the output of Angular's own
-/// `ng extract-i18n` and most third-party translation editors.
-pub fn parse_xliff_str(xml: &str) -> TranslationMap {
-    let mut out: TranslationMap = HashMap::new();
-    // Cursor over `xml`; advance past each `<trans-unit id="...">` block,
-    // grab the inner `<target>...</target>` text, restart from the closing
-    // `</trans-unit>`. Hand-rolled to avoid pulling a full XML parser into
-    // the CLI for what is effectively a flat, well-known schema.
-    let mut cursor = 0;
-    while let Some(open_rel) = xml[cursor..].find("<trans-unit") {
-        let open = cursor + open_rel;
-        let after_tag = match xml[open..].find('>') {
-            Some(p) => open + p + 1,
-            None => break,
-        };
-        let id = extract_attr(&xml[open..after_tag], "id").unwrap_or_default();
-        let close_rel = match xml[after_tag..].find("</trans-unit>") {
-            Some(p) => p,
-            None => break,
-        };
-        let body = &xml[after_tag..after_tag + close_rel];
-        if let Some(target) = extract_inner_text(body, "target") {
-            if !id.is_empty() {
-                out.insert(id, decode_xml_entities(&target));
-            }
-        }
-        cursor = after_tag + close_rel + "</trans-unit>".len();
+fn parse_xliff_with_path(xml: &str, path: Option<&Path>) -> NgcResult<TranslationMap> {
+    match detect_xliff_version(xml) {
+        Some(XliffVersion::V1_2) => Ok(xliff_v1::parse_xliff_str(xml)),
+        Some(XliffVersion::V2_0) => Ok(xliff_v2::parse_xliff_v2_str(xml)),
+        Some(XliffVersion::Other(v)) => Err(NgcError::ConfigError {
+            message: format!(
+                "unsupported XLIFF version {v:?}{}: only 1.2 and 2.0 are supported",
+                path.map(|p| format!(" in {}", p.display()))
+                    .unwrap_or_default()
+            ),
+        }),
+        None => Err(NgcError::ConfigError {
+            message: format!(
+                "no <xliff version=\"...\"> root element found{}",
+                path.map(|p| format!(" in {}", p.display()))
+                    .unwrap_or_default()
+            ),
+        }),
     }
-    out
+}
+
+/// Discriminated value from the root `<xliff version="...">` attribute.
+enum XliffVersion {
+    V1_2,
+    V2_0,
+    Other(String),
+}
+
+/// Locate the root `<xliff ...>` opening tag and return its `version`. The
+/// scan is tolerant of leading XML prologue, comments, and whitespace; it
+/// returns `None` when no `<xliff>` element is present.
+fn detect_xliff_version(xml: &str) -> Option<XliffVersion> {
+    let open = xml.find("<xliff")?;
+    let after = &xml[open..];
+    let close_rel = after.find('>')?;
+    let tag = &after[..close_rel + 1];
+    let version = extract_attr(tag, "version")?;
+    Some(match version.as_str() {
+        "1.2" => XliffVersion::V1_2,
+        "2.0" => XliffVersion::V2_0,
+        _ => XliffVersion::Other(version),
+    })
 }
 
 /// Extract the `name="value"` attribute from a tag opening (single or
 /// double quoted). Returns `None` when the attribute is absent.
-fn extract_attr(tag: &str, name: &str) -> Option<String> {
-    let needle = format!("{name}=");
-    let start = tag.find(&needle)?;
-    let after = &tag[start + needle.len()..];
-    let mut chars = after.chars();
-    let quote = chars.next()?;
-    if quote != '"' && quote != '\'' {
-        return None;
+///
+/// The match is anchored at a whitespace boundary so an attribute named
+/// `lang` does not match `srcLang`.
+pub(crate) fn extract_attr(tag: &str, name: &str) -> Option<String> {
+    let bytes = tag.as_bytes();
+    let needle = name.as_bytes();
+    let mut i = 0;
+    while i + needle.len() < bytes.len() {
+        let prev = bytes[i];
+        let is_boundary = prev == b' ' || prev == b'\t' || prev == b'\n' || prev == b'\r';
+        if is_boundary && bytes[i + 1..].starts_with(needle) {
+            let after_name = i + 1 + needle.len();
+            if bytes.get(after_name) == Some(&b'=') {
+                let after = &tag[after_name + 1..];
+                let mut chars = after.chars();
+                let quote = chars.next()?;
+                if quote != '"' && quote != '\'' {
+                    return None;
+                }
+                let end = after[1..].find(quote)?;
+                return Some(after[1..1 + end].to_string());
+            }
+        }
+        i += 1;
     }
-    let end = after[1..].find(quote)?;
-    Some(after[1..1 + end].to_string())
+    None
 }
 
 /// Extract the text between `<tag>...</tag>`.
-fn extract_inner_text(body: &str, tag: &str) -> Option<String> {
+pub(crate) fn extract_inner_text(body: &str, tag: &str) -> Option<String> {
     let open = format!("<{tag}");
     let close = format!("</{tag}>");
     let start = body.find(&open)?;
@@ -92,7 +131,7 @@ fn extract_inner_text(body: &str, tag: &str) -> Option<String> {
 }
 
 /// Decode the XML entities used in XLIFF target text.
-fn decode_xml_entities(s: &str) -> String {
+pub(crate) fn decode_xml_entities(s: &str) -> String {
     s.replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&quot;", "\"")
@@ -245,7 +284,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_xliff_trans_units() {
+    fn dispatches_to_xliff_1_2_parser() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2">
   <file>
@@ -254,16 +293,44 @@ mod tests {
         <source>Hello</source>
         <target>Hallo</target>
       </trans-unit>
-      <trans-unit id="bye">
-        <source>Bye</source>
-        <target>Tsch&#252;ss</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>"#;
-        let map = parse_xliff_str(xml);
+        let map = parse_xliff_with_path(xml, None).expect("dispatch ok");
         assert_eq!(map.get("intro"), Some(&"Hallo".to_string()));
-        assert_eq!(map.get("bye"), Some(&"Tsch&#252;ss".to_string()));
+    }
+
+    #[test]
+    fn dispatches_to_xliff_2_0_parser() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" srcLang="en-US" trgLang="de" xmlns="urn:oasis:names:tc:xliff:document:2.0">
+  <file id="ngi18n" original="ng.template">
+    <unit id="intro">
+      <segment>
+        <source>Hello</source>
+        <target>Hallo</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_with_path(xml, None).expect("dispatch ok");
+        assert_eq!(map.get("intro"), Some(&"Hallo".to_string()));
+    }
+
+    #[test]
+    fn rejects_unknown_xliff_version() {
+        let xml = r#"<xliff version="1.1"><file/></xliff>"#;
+        let err = parse_xliff_with_path(xml, None).expect_err("should reject");
+        let s = err.to_string();
+        assert!(s.contains("unsupported XLIFF version"), "got: {s}");
+    }
+
+    #[test]
+    fn rejects_missing_root() {
+        let xml = r#"<?xml version="1.0"?><not-xliff/>"#;
+        let err = parse_xliff_with_path(xml, None).expect_err("should reject");
+        let s = err.to_string();
+        assert!(s.contains("no <xliff"), "got: {s}");
     }
 
     #[test]

--- a/crates/cli/src/localize/xliff_v1.rs
+++ b/crates/cli/src/localize/xliff_v1.rs
@@ -1,0 +1,66 @@
+//! XLIFF 1.2 parser — `<trans-unit id="..."> <target>...</target>`.
+//!
+//! Hand-rolled cursor walk to avoid pulling a full XML parser into the CLI
+//! for what is effectively a flat, well-known schema. Tolerant of attribute
+//! order and whitespace; designed to handle both Angular's own
+//! `ng extract-i18n` output and most third-party translation editors.
+
+use super::{decode_xml_entities, extract_attr, extract_inner_text, TranslationMap};
+
+/// Parse an XLIFF 1.2 document from a source string into a `{ id → target }`
+/// map. Entries without an `id` or `<target>` are silently skipped — they
+/// can't be matched to a `$localize` message anyway.
+pub fn parse_xliff_str(xml: &str) -> TranslationMap {
+    let mut out: TranslationMap = TranslationMap::new();
+    // Cursor over `xml`; advance past each `<trans-unit id="...">` block,
+    // grab the inner `<target>...</target>` text, restart from the closing
+    // `</trans-unit>`.
+    let mut cursor = 0;
+    while let Some(open_rel) = xml[cursor..].find("<trans-unit") {
+        let open = cursor + open_rel;
+        let after_tag = match xml[open..].find('>') {
+            Some(p) => open + p + 1,
+            None => break,
+        };
+        let id = extract_attr(&xml[open..after_tag], "id").unwrap_or_default();
+        let close_rel = match xml[after_tag..].find("</trans-unit>") {
+            Some(p) => p,
+            None => break,
+        };
+        let body = &xml[after_tag..after_tag + close_rel];
+        if let Some(target) = extract_inner_text(body, "target") {
+            if !id.is_empty() {
+                out.insert(id, decode_xml_entities(&target));
+            }
+        }
+        cursor = after_tag + close_rel + "</trans-unit>".len();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_xliff_trans_units() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2">
+  <file>
+    <body>
+      <trans-unit id="intro" datatype="html">
+        <source>Hello</source>
+        <target>Hallo</target>
+      </trans-unit>
+      <trans-unit id="bye">
+        <source>Bye</source>
+        <target>Tsch&#252;ss</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_str(xml);
+        assert_eq!(map.get("intro"), Some(&"Hallo".to_string()));
+        assert_eq!(map.get("bye"), Some(&"Tsch&#252;ss".to_string()));
+    }
+}

--- a/crates/cli/src/localize/xliff_v2.rs
+++ b/crates/cli/src/localize/xliff_v2.rs
@@ -1,0 +1,224 @@
+//! XLIFF 2.0 parser — `<unit id="..."> <segment> <target>...</target>`.
+//!
+//! XLIFF 2.0 has been Angular's recommended translation format since v9 and
+//! is the default emitted by `ng extract-i18n` with no `--format` flag. The
+//! schema differs from 1.2 in three ways relevant here:
+//!
+//! - The translation unit element is `<unit>` (not `<trans-unit>`).
+//! - Source and target text live inside one or more `<segment>` children
+//!   rather than directly under the unit.
+//! - The root carries `srcLang` / `trgLang` (camelCased) instead of 1.2's
+//!   `source-language` / `target-language` attributes.
+//!
+//! Same hand-rolled cursor approach as the 1.2 parser — the schema is flat
+//! enough that a full XML dependency would be overkill. When a unit has
+//! multiple segments their `<target>` contents are concatenated in document
+//! order, matching how `@angular/localize` reassembles a translated
+//! message.
+
+use super::{decode_xml_entities, extract_attr, TranslationMap};
+
+/// Parse an XLIFF 2.0 document from a source string into a `{ id → target }`
+/// map. Units without an `id` or without any `<target>` are silently
+/// skipped — they can't be matched to a `$localize` message anyway.
+pub fn parse_xliff_v2_str(xml: &str) -> TranslationMap {
+    let mut out: TranslationMap = TranslationMap::new();
+    let mut cursor = 0;
+    while let Some(open_rel) = find_unit_open(&xml[cursor..]) {
+        let open = cursor + open_rel;
+        // Skip anything that turned out to be `<unitX...>` (rare, but cheap
+        // to be defensive) — `find_unit_open` already requires a delimiter
+        // after `unit`, so this is effectively just the close-bracket scan.
+        let after_tag = match xml[open..].find('>') {
+            Some(p) => open + p + 1,
+            None => break,
+        };
+        let id = extract_attr(&xml[open..after_tag], "id").unwrap_or_default();
+        let close_rel = match xml[after_tag..].find("</unit>") {
+            Some(p) => p,
+            None => break,
+        };
+        let body = &xml[after_tag..after_tag + close_rel];
+        let target = collect_segment_targets(body);
+        if !id.is_empty() && !target.is_empty() {
+            out.insert(id, decode_xml_entities(&target));
+        }
+        cursor = after_tag + close_rel + "</unit>".len();
+    }
+    out
+}
+
+/// Locate the next opening `<unit ...>` tag in `xml`. Returns the byte
+/// offset of the `<` delimiter. Excludes `<unitN>` style tag names — only
+/// `<unit ` / `<unit>` / `<unit\t` / `<unit\n` / `<unit\r` count.
+fn find_unit_open(xml: &str) -> Option<usize> {
+    let bytes = xml.as_bytes();
+    let mut cursor = 0;
+    while let Some(rel) = xml[cursor..].find("<unit") {
+        let pos = cursor + rel;
+        let after = pos + "<unit".len();
+        match bytes.get(after) {
+            Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | Some(b'>') => return Some(pos),
+            _ => cursor = after,
+        }
+    }
+    None
+}
+
+/// Walk every `<segment>` block inside `unit_body` and concatenate the
+/// inner text of the `<target>` element each carries, in document order.
+/// A unit with no segments at all (only `<ignorable>` runs) returns an
+/// empty string; the caller treats that as "no translation available".
+fn collect_segment_targets(unit_body: &str) -> String {
+    let mut out = String::new();
+    let mut cursor = 0;
+    while let Some(open_rel) = unit_body[cursor..].find("<segment") {
+        let open = cursor + open_rel;
+        let after_tag = match unit_body[open..].find('>') {
+            Some(p) => open + p + 1,
+            None => break,
+        };
+        let close_rel = match unit_body[after_tag..].find("</segment>") {
+            Some(p) => p,
+            None => break,
+        };
+        let segment_body = &unit_body[after_tag..after_tag + close_rel];
+        if let Some(target) = extract_target_text(segment_body) {
+            out.push_str(&target);
+        }
+        cursor = after_tag + close_rel + "</segment>".len();
+    }
+    out
+}
+
+/// Extract the inner text of the first `<target>...</target>` element
+/// inside `segment_body`. Returns `None` when a segment carries only a
+/// `<source>` (an untranslated unit, common in freshly-extracted files).
+fn extract_target_text(segment_body: &str) -> Option<String> {
+    let open = segment_body.find("<target")?;
+    let after_open = segment_body[open..].find('>')? + open + 1;
+    let close = segment_body[after_open..].find("</target>")? + after_open;
+    Some(segment_body[after_open..close].trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_segment_unit() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" srcLang="en-US" trgLang="de" xmlns="urn:oasis:names:tc:xliff:document:2.0">
+  <file id="ngi18n" original="ng.template">
+    <unit id="intro">
+      <segment>
+        <source>Hello</source>
+        <target>Hallo</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert_eq!(map.get("intro"), Some(&"Hallo".to_string()));
+    }
+
+    #[test]
+    fn parses_multiple_units() {
+        let xml = r#"<xliff version="2.0" srcLang="en">
+  <file id="f1">
+    <unit id="a"><segment><source>A</source><target>AA</target></segment></unit>
+    <unit id="b"><segment><source>B</source><target>BB</target></segment></unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert_eq!(map.get("a"), Some(&"AA".to_string()));
+        assert_eq!(map.get("b"), Some(&"BB".to_string()));
+    }
+
+    #[test]
+    fn concatenates_multi_segment_target() {
+        // Each segment's <target> text is trimmed (matching the 1.2 parser's
+        // existing whitespace handling), then the trimmed runs are joined
+        // in document order. Angular emits multi-segment units only when an
+        // inline element splits the source, where the surrounding inline
+        // markup carries the whitespace — so the joined text being run
+        // together is the correct shape.
+        let xml = r#"<xliff version="2.0">
+  <file id="f1">
+    <unit id="multi">
+      <segment><source>One.</source><target>Eins.</target></segment>
+      <segment><source>Two.</source><target>Zwei.</target></segment>
+    </unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert_eq!(map.get("multi"), Some(&"Eins.Zwei.".to_string()));
+    }
+
+    #[test]
+    fn skips_unit_with_only_source() {
+        let xml = r#"<xliff version="2.0">
+  <file id="f1">
+    <unit id="untranslated">
+      <segment><source>Pending</source></segment>
+    </unit>
+    <unit id="ok">
+      <segment><source>OK</source><target>Bestätigt</target></segment>
+    </unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert!(!map.contains_key("untranslated"));
+        assert_eq!(map.get("ok"), Some(&"Bestätigt".to_string()));
+    }
+
+    #[test]
+    fn decodes_xml_entities() {
+        let xml = r#"<xliff version="2.0">
+  <file id="f1">
+    <unit id="entities">
+      <segment><source>A &amp; B</source><target>X &amp; Y</target></segment>
+    </unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert_eq!(map.get("entities"), Some(&"X & Y".to_string()));
+    }
+
+    #[test]
+    fn ignores_notes_outside_segment() {
+        let xml = r#"<xliff version="2.0">
+  <file id="f1">
+    <unit id="withnotes">
+      <notes>
+        <note category="description">A description</note>
+      </notes>
+      <segment><source>Src</source><target>Tgt</target></segment>
+    </unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert_eq!(map.get("withnotes"), Some(&"Tgt".to_string()));
+    }
+
+    #[test]
+    fn does_not_match_unit_lookalike() {
+        // `<unitless>` should not be picked up by the unit scanner.
+        let xml = r#"<xliff version="2.0">
+  <file id="f1">
+    <unitless/>
+    <unit id="real"><segment><source>S</source><target>T</target></segment></unit>
+  </file>
+</xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert_eq!(map.get("real"), Some(&"T".to_string()));
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn empty_file_returns_empty_map() {
+        let xml = r#"<xliff version="2.0"><file id="f1"/></xliff>"#;
+        let map = parse_xliff_v2_str(xml);
+        assert!(map.is_empty());
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -237,19 +237,50 @@ enum Commands {
         serve_path: Option<String>,
     },
     /// Extract translatable messages from every component template in the
-    /// project and emit a `messages.xlf` (XLIFF 1.2) file.
+    /// project and emit a translation file (XLIFF 2.0 by default; XLIFF 1.2
+    /// available via `--format xliff`).
     ExtractI18n {
         /// Path to tsconfig.json
         #[arg(long, default_value = "tsconfig.json")]
         project: PathBuf,
-        /// Output file path (defaults to `messages.xlf` in the project dir).
+        /// Output file path. Defaults to `messages.xlf` in the project
+        /// directory regardless of format — Angular tooling tolerates either
+        /// XLIFF dialect under the same `.xlf` extension.
         #[arg(long, short = 'o')]
         out_file: Option<PathBuf>,
-        /// Source locale recorded in the XLIFF `source-language` attribute.
-        /// Defaults to the value from `angular.json` or `"en-US"`.
+        /// Source locale recorded in the XLIFF root attribute (`srcLang`
+        /// for 2.0, `source-language` for 1.2). Defaults to the value from
+        /// `angular.json` or `"en-US"`.
         #[arg(long)]
         source_locale: Option<String>,
+        /// Output format. `xliff2` (the default) matches Angular's
+        /// `ng extract-i18n` default since v9; `xliff` emits the older 1.2
+        /// dialect for projects that haven't migrated their translators.
+        /// `json` and `arb` are accepted for forward-compatibility but
+        /// currently return a clear error.
+        #[arg(long, value_enum, default_value_t = ExtractFormat::Xliff2)]
+        format: ExtractFormat,
     },
+}
+
+/// Output format selector for `extract-i18n`. Matches the `--format` flag
+/// shape of `ng extract-i18n` so downstream tooling can pass through the
+/// same value verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+enum ExtractFormat {
+    /// XLIFF 1.2 — older Angular default, still widely used by translation
+    /// vendors that haven't migrated tooling.
+    Xliff,
+    /// XLIFF 2.0 — Angular's recommended format since v9 and the default
+    /// for `ng extract-i18n` with no `--format` flag.
+    Xliff2,
+    /// JSON — accepted for parity with `ng extract-i18n` but currently
+    /// rejected with a clear error (out of scope for this release).
+    Json,
+    /// ARB (Application Resource Bundle) — accepted for parity but
+    /// currently rejected with a clear error (out of scope for this release).
+    Arb,
 }
 
 fn main() {
@@ -321,7 +352,13 @@ fn main() {
             project,
             out_file,
             source_locale,
-        } => match run_extract_i18n(&project, out_file.as_deref(), source_locale.as_deref()) {
+            format,
+        } => match run_extract_i18n(
+            &project,
+            out_file.as_deref(),
+            source_locale.as_deref(),
+            format,
+        ) {
             Ok(report) => {
                 println!("{}", "ngc-rs i18n extraction complete".bold().green());
                 println!("  {:<16}{}", "Messages:".dimmed(), report.message_count);
@@ -1375,13 +1412,32 @@ struct ExtractI18nReport {
 }
 
 /// Walk every component file reachable from the tsconfig graph, collect
-/// translatable messages, and write a deduplicated `messages.xlf` to
-/// `out_file` (default: `<project_dir>/messages.xlf`).
+/// translatable messages, and write a deduplicated translation file to
+/// `out_file` (default: `<project_dir>/messages.xlf`). The output dialect
+/// is selected by `format` — XLIFF 2.0 (the new default) or XLIFF 1.2.
+/// JSON and ARB are accepted by the flag but rejected at this layer until
+/// emitters land in a follow-up parity:nice-to-have.
 fn run_extract_i18n(
     project: &Path,
     out_file: Option<&Path>,
     source_locale_override: Option<&str>,
+    format: ExtractFormat,
 ) -> NgcResult<ExtractI18nReport> {
+    match format {
+        ExtractFormat::Xliff | ExtractFormat::Xliff2 => {}
+        ExtractFormat::Json => {
+            return Err(NgcError::ConfigError {
+                message: "extract-i18n --format json is not yet supported (parity:nice-to-have)"
+                    .to_string(),
+            });
+        }
+        ExtractFormat::Arb => {
+            return Err(NgcError::ConfigError {
+                message: "extract-i18n --format arb is not yet supported (parity:nice-to-have)"
+                    .to_string(),
+            });
+        }
+    }
     let angular_project = find_and_resolve_angular_json(project, None)?;
     let tsconfig_path = angular_project
         .as_ref()
@@ -1423,7 +1479,12 @@ fn run_extract_i18n(
         })
         .unwrap_or_else(|| "en-US".to_string());
 
-    let xlf = build_xliff(&source_locale, &by_key);
+    let xlf = match format {
+        ExtractFormat::Xliff => build_xliff(&source_locale, &by_key),
+        ExtractFormat::Xliff2 => build_xliff_v2(&source_locale, &by_key),
+        // The Json/Arb arms returned early above; this branch is unreachable.
+        ExtractFormat::Json | ExtractFormat::Arb => unreachable!(),
+    };
 
     let project_dir = project.parent().unwrap_or(Path::new(".")).to_path_buf();
     let out_path = out_file
@@ -1506,6 +1567,63 @@ fn build_xliff(
         s.push_str("      </trans-unit>\n");
     }
     s.push_str("    </body>\n  </file>\n</xliff>\n");
+    s
+}
+
+/// Render a `BTreeMap<id, message>` as an XLIFF 2.0 document. The shape
+/// matches what `@angular/localize`'s own extractor produces — root
+/// `<xliff version="2.0" srcLang="...">`, one `<file id="ngi18n">`, each
+/// message a `<unit>` with optional `<notes>` and a single `<segment>`
+/// containing only `<source>` (translators add the `<target>`).
+fn build_xliff_v2(
+    source_locale: &str,
+    messages: &std::collections::BTreeMap<
+        String,
+        (PathBuf, ngc_template_compiler::i18n::ExtractedI18nMessage),
+    >,
+) -> String {
+    let mut s = String::new();
+    s.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
+    s.push_str(&format!(
+        "<xliff version=\"2.0\" xmlns=\"urn:oasis:names:tc:xliff:document:2.0\" srcLang=\"{}\">\n  <file id=\"ngi18n\" original=\"ng.template\">\n",
+        xml_escape(source_locale)
+    ));
+    for (id, (path, msg)) in messages {
+        s.push_str(&format!("    <unit id=\"{}\">\n", xml_escape(id)));
+        let has_notes =
+            msg.meaning.is_some() || msg.description.is_some() || !path.as_os_str().is_empty();
+        if has_notes {
+            s.push_str("      <notes>\n");
+            // Location note keeps the source-file pointer that 1.2's
+            // `<context-group>` carried; same key (`location`) Angular's
+            // extractor uses so xlf-merge tools recognise it.
+            s.push_str(&format!(
+                "        <note category=\"location\">{}</note>\n",
+                xml_escape(&path.display().to_string())
+            ));
+            if let Some(m) = &msg.meaning {
+                s.push_str(&format!(
+                    "        <note category=\"meaning\">{}</note>\n",
+                    xml_escape(m)
+                ));
+            }
+            if let Some(d) = &msg.description {
+                s.push_str(&format!(
+                    "        <note category=\"description\">{}</note>\n",
+                    xml_escape(d)
+                ));
+            }
+            s.push_str("      </notes>\n");
+        }
+        s.push_str("      <segment>\n");
+        s.push_str(&format!(
+            "        <source>{}</source>\n",
+            xml_escape(&msg.source)
+        ));
+        s.push_str("      </segment>\n");
+        s.push_str("    </unit>\n");
+    }
+    s.push_str("  </file>\n</xliff>\n");
     s
 }
 
@@ -2740,6 +2858,59 @@ fn find_entry_point(entry_points: &[PathBuf]) -> NgcResult<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn xliff_v2_round_trip_extract_translate_apply() {
+        // Round-trip: build a v2 XLIFF document via the same emitter
+        // `extract-i18n --format xliff2` uses, parse it back through the
+        // public dispatcher (the same path `--localize` takes), then apply
+        // the result to a `$localize` call site. Mirrors the DoD flow on
+        // issue #141 without needing the full bundler pipeline.
+        use std::collections::BTreeMap;
+        let mut by_key: BTreeMap<
+            String,
+            (PathBuf, ngc_template_compiler::i18n::ExtractedI18nMessage),
+        > = BTreeMap::new();
+        by_key.insert(
+            "cart.title".to_string(),
+            (
+                PathBuf::from("src/app/cart.component.ts"),
+                ngc_template_compiler::i18n::ExtractedI18nMessage {
+                    id: Some("cart.title".to_string()),
+                    meaning: None,
+                    description: Some("Header above the cart".to_string()),
+                    source: "Your cart".to_string(),
+                },
+            ),
+        );
+        let xlf = build_xliff_v2("en-US", &by_key);
+        assert!(xlf.contains("version=\"2.0\""));
+        assert!(xlf.contains("<unit id=\"cart.title\">"));
+        assert!(xlf.contains("<source>Your cart</source>"));
+
+        // Splice in a German <target> the way a translator would.
+        let translated = xlf.replace(
+            "<source>Your cart</source>\n      </segment>",
+            "<source>Your cart</source><target>Mein Warenkorb</target>\n      </segment>",
+        );
+        let dir = tempfile::tempdir().expect("tempdir");
+        let xlf_path = dir.path().join("messages.de.xlf");
+        std::fs::write(&xlf_path, translated).expect("write xlf");
+
+        let map = localize::parse_xliff(&xlf_path).expect("parse xlf v2 back");
+        assert_eq!(map.get("cart.title"), Some(&"Mein Warenkorb".to_string()));
+
+        let js = "var x = $localize`:Header above the cart@@cart.title:Your cart`;";
+        let out = localize::apply_translations(js, &map);
+        assert!(
+            out.contains("Mein Warenkorb"),
+            "expected translated string in output, got: {out}"
+        );
+        assert!(
+            !out.contains("Your cart"),
+            "source string should be replaced, got: {out}"
+        );
+    }
 
     #[test]
     fn test_format_bytes() {


### PR DESCRIPTION
Closes #141.

## Summary

- New `crates/cli/src/localize/xliff_v2.rs` parser for `<xliff version="2.0">`: walks `<unit id="...">` blocks, concatenates `<target>` text across `<segment>` children, decodes XML entities. Hand-rolled cursor walk, same shape as the existing 1.2 parser.
- `crates/cli/src/localize.rs` becomes a module: `localize/mod.rs` exposes `parse_xliff(path)` which detects the root `<xliff version="...">` attribute and dispatches to either the 1.2 or 2.0 parser. Unknown versions and missing roots return an `NgcError::ConfigError` with a clear message instead of an empty map.
- `extract-i18n` gains `--format <xliff|xliff2|json|arb>` (default `xliff2`, matching `ng extract-i18n` since v9). XLIFF 1.2 stays available via `--format xliff`. `json` and `arb` are accepted by the flag but rejected with a clear error — emitters are out of scope per the issue body.
- New `build_xliff_v2` emitter mirrors the shape `@angular/localize` produces: `<xliff version="2.0" srcLang="..." xmlns="...">` → `<file id="ngi18n">` → `<unit>` with `<notes>` (`location`/`meaning`/`description`) and a single `<segment>` with `<source>`.

## Tests

- Unit tests in `xliff_v2.rs` cover single-segment / multiple units / multi-segment concat / source-only (skip) / entity decoding / `<unitless>` lookalike rejection / empty file.
- Dispatcher tests in `localize/mod.rs` confirm both 1.2 and 2.0 documents reach the right parser, and that bad versions / missing roots error.
- `tests::xliff_v2_round_trip_extract_translate_apply` in `crates/cli/src/main.rs` performs the full DoD round-trip: `build_xliff_v2` → splice in a translator's `<target>` → `parse_xliff` → `apply_translations` over a `\$localize` call site, asserting the German string lands and the source string is gone.
- `cargo test --workspace` (all green), `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean).

## Test plan
- [x] Workspace tests pass
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --check` clean
- [x] `extract-i18n --format xliff2` against `test-ng-project` produces a syntactically-valid XLIFF 2.0 file
- [x] Round-trip extract → splice target → parse → apply translations recovers the translated string

## Out of scope (per issue)
- JSON / ARB emitters — flagged for a separate parity:nice-to-have.
- Full placeholder reordering — the existing 1.2 path's behaviour is preserved verbatim (translators keep placeholder positions identical to the source).