### PR TITLE
feat(bundler,cli): honor `scripts` array (global script injection)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,6 +18,7 @@ mod incremental;
 mod localize;
 mod ngsw;
 mod polyfills;
+mod scripts;
 mod serve_cmd;
 mod watch_cmd;
 
@@ -1014,14 +1015,34 @@ pub(crate) fn run_build_with_cache(
         }
     }
 
+    // Step 10.5: Emit global script bundles. Concatenate each `scripts`
+    // entry's contents per `bundleName` and write `<name>.js` to the
+    // output directory; the index.html step picks the inject flag back
+    // up below.
+    let mut emitted_scripts: Vec<scripts::EmittedScriptBundle> = Vec::new();
+    if let Some(ref ap) = angular_project {
+        if !ap.scripts.is_empty() {
+            let (emitted, paths) =
+                scripts::emit_script_bundles(&ap.scripts, &out_dir, bundle_options)?;
+            emitted_scripts = emitted;
+            output_files.extend(paths);
+        }
+    }
+
     // Step 11: Generate index.html
     if let Some(ref ap) = angular_project {
         if let Some(ref index_path) = ap.index_html {
+            let inject_scripts: Vec<&str> = emitted_scripts
+                .iter()
+                .filter(|s| s.inject)
+                .map(|s| s.filename.as_str())
+                .collect();
             let index_opts = IndexHtmlOptions {
                 base_href: ap.base_href.as_deref(),
                 deploy_url: ap.deploy_url.as_deref(),
                 cross_origin: ap.cross_origin,
                 subresource_integrity: ap.subresource_integrity,
+                scripts: &inject_scripts,
             };
             let path = generate_index_html(
                 index_path,
@@ -1932,6 +1953,12 @@ struct IndexHtmlOptions<'a> {
     /// When true, compute SHA-384 integrity hashes of emitted artifacts and
     /// inject `integrity="sha384-..."` attributes on the tags that load them.
     subresource_integrity: bool,
+    /// Filenames of global script bundles that opted into injection
+    /// (`scripts` entries with `inject: true`). Each entry produces a
+    /// `<script defer src="…">` tag emitted before the application's
+    /// module script so the global runs synchronously on parse and
+    /// finishes before the app boots.
+    scripts: &'a [&'a str],
 }
 
 /// Read source index.html, inject stylesheet and script tags, write to out_dir.
@@ -1985,7 +2012,27 @@ fn generate_index_html(
     }
 
     // Inject script tags before </body>
-    let mut scripts = String::new();
+    let mut script_tags = String::new();
+
+    // Global `scripts` array entries: emitted as `<script defer>` so they
+    // execute in document order before module evaluation, matching
+    // `@angular/build:application`.
+    for script_filename in options.scripts {
+        let src = format!("{deploy_url}{script_filename}");
+        let integrity = if options.subresource_integrity {
+            Some(compute_sri_hash(&out_dir.join(script_filename))?)
+        } else {
+            None
+        };
+        let integrity_attr = integrity
+            .as_deref()
+            .map(|i| format!(" integrity=\"{i}\""))
+            .unwrap_or_default();
+        script_tags.push_str(&format!(
+            "  <script src=\"{src}\" defer{crossorigin_attr}{integrity_attr}></script>\n"
+        ));
+    }
+
     if let Some(polyfills) = polyfills_filename {
         let src = format!("{deploy_url}{polyfills}");
         let integrity = if options.subresource_integrity {
@@ -1997,7 +2044,7 @@ fn generate_index_html(
             .as_deref()
             .map(|i| format!(" integrity=\"{i}\""))
             .unwrap_or_default();
-        scripts.push_str(&format!(
+        script_tags.push_str(&format!(
             "  <script src=\"{src}\" type=\"module\"{crossorigin_attr}{integrity_attr}></script>\n"
         ));
     }
@@ -2012,11 +2059,11 @@ fn generate_index_html(
             .as_deref()
             .map(|i| format!(" integrity=\"{i}\""))
             .unwrap_or_default();
-        scripts.push_str(&format!(
+        script_tags.push_str(&format!(
             "  <script src=\"{src}\" type=\"module\"{crossorigin_attr}{integrity_attr}></script>\n"
         ));
     }
-    html = html.replace("</body>", &format!("{scripts}</body>"));
+    html = html.replace("</body>", &format!("{script_tags}</body>"));
 
     let path = out_dir.join(output_filename);
     std::fs::write(&path, &html).map_err(|e| NgcError::Io {
@@ -2644,6 +2691,47 @@ mod tests {
     }
 
     #[test]
+    fn test_index_html_global_scripts_injected_with_defer() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let index_src = dir.path().join("index.html");
+        std::fs::write(
+            &index_src,
+            "<!doctype html>\n<html>\n<head>\n</head>\n<body>\n  <app-root></app-root>\n</body>\n</html>\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("main.js"), "").unwrap();
+        std::fs::write(dir.path().join("scripts.js"), "").unwrap();
+        std::fs::write(dir.path().join("vitals.js"), "").unwrap();
+        let injected = ["scripts.js", "vitals.js"];
+        let opts = IndexHtmlOptions {
+            scripts: &injected,
+            ..IndexHtmlOptions::default()
+        };
+        let out = generate_index_html(
+            &index_src,
+            "index.html",
+            false,
+            None,
+            dir.path(),
+            "main.js",
+            &opts,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(out).unwrap();
+        assert!(content.contains(r#"<script src="scripts.js" defer></script>"#));
+        assert!(content.contains(r#"<script src="vitals.js" defer></script>"#));
+        assert!(content.contains(r#"<script src="main.js" type="module"></script>"#));
+        // Globals must precede the module entry so they execute first.
+        let globals_pos = content
+            .find(r#"<script src="scripts.js" defer></script>"#)
+            .unwrap();
+        let main_pos = content
+            .find(r#"<script src="main.js" type="module"></script>"#)
+            .unwrap();
+        assert!(globals_pos < main_pos);
+    }
+
+    #[test]
     fn test_index_html_no_styles_no_polyfills() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let index_src = dir.path().join("index.html");
@@ -2834,6 +2922,7 @@ mod tests {
             deploy_url: Some("https://cdn.example.com/"),
             cross_origin: CrossOrigin::Anonymous,
             subresource_integrity: true,
+            ..IndexHtmlOptions::default()
         };
         let out = generate_index_html(
             &index_src,

--- a/crates/cli/src/scripts.rs
+++ b/crates/cli/src/scripts.rs
@@ -1,0 +1,182 @@
+//! Global `scripts` array support — emit one bundle per `bundleName`
+//! by concatenating each entry's contents and writing a single non-module
+//! JS file to `out_dir`.
+//!
+//! Mirrors the semantics of `@angular/build:application`'s `scripts`
+//! option: entries are loaded as plain (non-ES-module) JS in the order
+//! declared, before the application module. Multiple entries that share
+//! a `bundleName` are concatenated into one file; entries with
+//! `inject: false` are written to disk but not referenced from
+//! `index.html`.
+//!
+//! These bundles are intentionally not run through the JS bundler — the
+//! files are typically third-party CDN snippets (analytics, polyfill
+//! shims) that aren't ES modules and would break under module-graph
+//! resolution. Concatenation matches what `@angular/build` does once
+//! its esbuild pass collapses the IIFE wrappers.
+
+use std::path::{Path, PathBuf};
+
+use ngc_bundler::BundleOptions;
+use ngc_diagnostics::{NgcError, NgcResult};
+use ngc_project_resolver::angular_json::ResolvedScriptBundle;
+use sha2::{Digest, Sha256};
+
+/// One emitted script bundle: the on-disk filename (with hash applied
+/// when [`BundleOptions::content_hash`] is set) and whether it should
+/// be referenced from `index.html`.
+#[derive(Debug, Clone)]
+pub(crate) struct EmittedScriptBundle {
+    /// Final filename written to `out_dir`, e.g. `scripts.a1b2c3d4.js`
+    /// in production or `scripts.js` otherwise.
+    pub filename: String,
+    /// Whether to emit a `<script defer src="…">` tag for this bundle
+    /// in the generated `index.html`.
+    pub inject: bool,
+}
+
+/// Concatenate each [`ResolvedScriptBundle`]'s sources into one JS file
+/// and write it to `out_dir`. Returns one [`EmittedScriptBundle`] per
+/// bundle (in the order resolved from `angular.json`) plus the absolute
+/// paths of every file written so the caller can fold them into the
+/// build's `output_files` list.
+pub(crate) fn emit_script_bundles(
+    bundles: &[ResolvedScriptBundle],
+    out_dir: &Path,
+    bundle_options: BundleOptions,
+) -> NgcResult<(Vec<EmittedScriptBundle>, Vec<PathBuf>)> {
+    let mut emitted = Vec::with_capacity(bundles.len());
+    let mut written_paths = Vec::with_capacity(bundles.len());
+    for bundle in bundles {
+        let mut concatenated = String::new();
+        for source in &bundle.sources {
+            let body = std::fs::read_to_string(source).map_err(|e| NgcError::Io {
+                path: source.clone(),
+                source: e,
+            })?;
+            concatenated.push_str(&format!("/* {} */\n", source.display()));
+            concatenated.push_str(&body);
+            if !body.ends_with('\n') {
+                concatenated.push('\n');
+            }
+        }
+        let filename = if bundle_options.content_hash {
+            let hash = content_hash(&concatenated);
+            format!("{}.{hash}.js", bundle.name)
+        } else {
+            format!("{}.js", bundle.name)
+        };
+        let path = out_dir.join(&filename);
+        std::fs::write(&path, &concatenated).map_err(|e| NgcError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        written_paths.push(path);
+        emitted.push(EmittedScriptBundle {
+            filename,
+            inject: bundle.inject,
+        });
+    }
+    Ok((emitted, written_paths))
+}
+
+/// SHA-256 over the concatenated bytes, hex-encoded, truncated to 8
+/// chars — matches the hash length used by the polyfills + main chunks.
+fn content_hash(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let bytes = hasher.finalize();
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    hex[..8].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, body).expect("write fixture");
+        path
+    }
+
+    #[test]
+    fn single_bundle_default_name_no_hash() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src = write_temp_script(dir.path(), "global.js", "window.x = 1;");
+        let bundles = vec![ResolvedScriptBundle {
+            name: "scripts".into(),
+            sources: vec![src],
+            inject: true,
+        }];
+        let (emitted, paths) =
+            emit_script_bundles(&bundles, dir.path(), BundleOptions::default()).unwrap();
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].filename, "scripts.js");
+        assert!(emitted[0].inject);
+        assert_eq!(paths.len(), 1);
+        let written = std::fs::read_to_string(dir.path().join("scripts.js")).unwrap();
+        assert!(written.contains("window.x = 1;"));
+        // Ensure trailing newline is added for files that lack one.
+        assert!(written.ends_with('\n'));
+    }
+
+    #[test]
+    fn multi_entry_bundle_concatenates_in_order() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let a = write_temp_script(dir.path(), "a.js", "var a = 1;\n");
+        let b = write_temp_script(dir.path(), "b.js", "var b = 2;\n");
+        let bundles = vec![ResolvedScriptBundle {
+            name: "scripts".into(),
+            sources: vec![a, b],
+            inject: true,
+        }];
+        let (_, _) = emit_script_bundles(&bundles, dir.path(), BundleOptions::default()).unwrap();
+        let written = std::fs::read_to_string(dir.path().join("scripts.js")).unwrap();
+        let a_pos = written.find("var a = 1;").expect("a present");
+        let b_pos = written.find("var b = 2;").expect("b present");
+        assert!(a_pos < b_pos, "sources should be concatenated in order");
+    }
+
+    #[test]
+    fn content_hash_applied_in_production() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src = write_temp_script(dir.path(), "global.js", "window.x = 1;\n");
+        let bundles = vec![ResolvedScriptBundle {
+            name: "scripts".into(),
+            sources: vec![src],
+            inject: true,
+        }];
+        let opts = BundleOptions {
+            content_hash: true,
+            ..BundleOptions::default()
+        };
+        let (emitted, _) = emit_script_bundles(&bundles, dir.path(), opts).unwrap();
+        assert_eq!(emitted.len(), 1);
+        let filename = &emitted[0].filename;
+        assert!(filename.starts_with("scripts."));
+        assert!(filename.ends_with(".js"));
+        // Hash is exactly 8 hex chars.
+        let hash_part = filename
+            .strip_prefix("scripts.")
+            .and_then(|s| s.strip_suffix(".js"))
+            .unwrap();
+        assert_eq!(hash_part.len(), 8);
+        assert!(hash_part.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn inject_false_propagates() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src = write_temp_script(dir.path(), "lazy.js", "noop();\n");
+        let bundles = vec![ResolvedScriptBundle {
+            name: "lazy".into(),
+            sources: vec![src],
+            inject: false,
+        }];
+        let (emitted, _) =
+            emit_script_bundles(&bundles, dir.path(), BundleOptions::default()).unwrap();
+        assert_eq!(emitted[0].filename, "lazy.js");
+        assert!(!emitted[0].inject);
+    }
+}

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -156,6 +156,10 @@ pub struct RawBuildOptions {
     /// option of `@angular/build:application`, which itself mirrors
     /// esbuild's `--define`.
     pub define: Option<HashMap<String, String>>,
+    /// Global script entries injected into the build (analytics snippets,
+    /// CDN libraries, polyfill shims that don't fit through `polyfills.ts`).
+    /// Each entry is a string path or `{ input, inject, bundleName }` object.
+    pub scripts: Option<Vec<RawScriptEntry>>,
 }
 
 /// One entry in `architect.build.options.budgets` (or in a per-configuration
@@ -299,6 +303,29 @@ pub enum RawStyleEntry {
     },
 }
 
+/// A global script entry: string path or `{ input, inject, bundleName }`
+/// object. Mirrors the `scripts` field accepted by
+/// `@angular/build:application` — entries are concatenated per `bundleName`
+/// (default `"scripts"`) into a single non-module JS file injected into
+/// `index.html` as `<script defer>` when `inject` is true (default).
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum RawScriptEntry {
+    /// Simple string path (e.g. `"src/global.js"`).
+    Simple(String),
+    /// Object form with options.
+    Object {
+        /// Path to the script file.
+        input: String,
+        /// Whether to inject into index.html (default: true).
+        inject: Option<bool>,
+        /// Custom bundle name. Entries that share a bundle name are
+        /// concatenated. Default: `"scripts"`.
+        #[serde(rename = "bundleName")]
+        bundle_name: Option<String>,
+    },
+}
+
 /// An asset entry: string or `{ glob, input, output, ignore }` object.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
@@ -364,6 +391,25 @@ pub struct ResolvedStyle {
     pub inject: bool,
     /// Custom bundle name (None means default `"styles"`).
     pub bundle_name: Option<String>,
+}
+
+/// A resolved global script bundle. Multiple `scripts` entries that share
+/// a `bundleName` are merged into one bundle: their source files are
+/// concatenated (in declaration order) into `<bundle_name>.js` and a single
+/// `<script defer>` tag is emitted when [`Self::inject`] is true.
+#[derive(Debug, Clone)]
+pub struct ResolvedScriptBundle {
+    /// Bundle name (without `.js`). Default `"scripts"` when no entry in
+    /// the group declares one.
+    pub name: String,
+    /// Absolute paths of the source files to concatenate, in declaration
+    /// order from `angular.json`.
+    pub sources: Vec<PathBuf>,
+    /// Whether to inject a `<script defer>` tag for this bundle into the
+    /// emitted `index.html`. Defaults to true; entries that opt out via
+    /// `inject: false` produce a bundle that is written to disk but not
+    /// referenced from the index.
+    pub inject: bool,
 }
 
 /// A resolved asset entry.
@@ -464,6 +510,11 @@ pub struct ResolvedAngularProject {
     /// — see [`RawBuildOptions::define`] for the encoding. Empty when no
     /// `define` block is declared.
     pub define: HashMap<String, String>,
+    /// Resolved global script bundles. Each entry is one emitted JS file
+    /// (`<name>.js`) holding the concatenated contents of every `scripts`
+    /// entry that shares the same `bundleName`. Empty when no `scripts`
+    /// are declared.
+    pub scripts: Vec<ResolvedScriptBundle>,
 }
 
 /// Type of a resolved size budget.
@@ -760,6 +811,11 @@ pub fn resolve_angular_project(
         }
     }
 
+    let scripts = options
+        .and_then(|o| o.scripts.as_ref())
+        .map(|raw_scripts| resolve_scripts(raw_scripts, &base_dir))
+        .unwrap_or_default();
+
     debug!(
         project = %name,
         output_path = %output_path.display(),
@@ -790,6 +846,7 @@ pub fn resolve_angular_project(
         ngsw_config_path,
         budgets,
         define,
+        scripts,
     })
 }
 
@@ -919,6 +976,52 @@ fn resolve_styles(raw: &[RawStyleEntry], base_dir: &Path) -> Vec<ResolvedStyle> 
             },
         })
         .collect()
+}
+
+/// Resolve raw script entries into per-bundle groups with absolute paths.
+///
+/// Entries that share a `bundleName` (default `"scripts"`) are collapsed
+/// into one [`ResolvedScriptBundle`], preserving declaration order so the
+/// concatenation step writes them in the order the user declared. Bundle
+/// order in the returned `Vec` matches the order in which each bundle
+/// name first appeared.
+///
+/// When entries within the same bundle disagree on `inject`, the first
+/// entry wins and a warning is logged — `@angular/build:application`
+/// treats this as undefined behavior, so we pick a deterministic policy
+/// rather than silently merging.
+fn resolve_scripts(raw: &[RawScriptEntry], base_dir: &Path) -> Vec<ResolvedScriptBundle> {
+    let mut bundles: Vec<ResolvedScriptBundle> = Vec::new();
+    for entry in raw {
+        let (input, inject, bundle_name) = match entry {
+            RawScriptEntry::Simple(s) => (s.clone(), true, None),
+            RawScriptEntry::Object {
+                input,
+                inject,
+                bundle_name,
+            } => (input.clone(), inject.unwrap_or(true), bundle_name.clone()),
+        };
+        let name = bundle_name.unwrap_or_else(|| "scripts".to_string());
+        let path = base_dir.join(&input);
+        if let Some(existing) = bundles.iter_mut().find(|b| b.name == name) {
+            if existing.inject != inject {
+                tracing::warn!(
+                    bundle = %name,
+                    "scripts entries in bundle {:?} disagree on `inject`; using first entry's value ({})",
+                    name,
+                    existing.inject
+                );
+            }
+            existing.sources.push(path);
+        } else {
+            bundles.push(ResolvedScriptBundle {
+                name,
+                sources: vec![path],
+                inject,
+            });
+        }
+    }
+    bundles
 }
 
 /// Resolve raw asset entries to absolute paths or glob specs.
@@ -1052,6 +1155,122 @@ mod tests {
         assert!(result.styles[0].inject);
         assert!(!result.styles[1].inject);
         assert_eq!(result.styles[1].bundle_name.as_deref(), Some("theme"));
+    }
+
+    #[test]
+    fn test_parse_scripts_string_form_defaults_inject_and_bundle_name() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "scripts": ["src/global.js"]
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.scripts.len(), 1);
+        let bundle = &result.scripts[0];
+        assert_eq!(bundle.name, "scripts");
+        assert!(bundle.inject);
+        assert_eq!(bundle.sources.len(), 1);
+        assert!(bundle.sources[0].ends_with("src/global.js"));
+    }
+
+    #[test]
+    fn test_parse_scripts_object_form_with_bundle_name_and_inject_false() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "scripts": [
+                                    { "input": "src/lazy.js", "inject": false, "bundleName": "lazy" }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.scripts.len(), 1);
+        let bundle = &result.scripts[0];
+        assert_eq!(bundle.name, "lazy");
+        assert!(!bundle.inject);
+        assert!(bundle.sources[0].ends_with("src/lazy.js"));
+    }
+
+    #[test]
+    fn test_parse_scripts_groups_shared_bundle_name() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json",
+                                "scripts": [
+                                    "src/a.js",
+                                    { "input": "src/b.js", "bundleName": "scripts" },
+                                    { "input": "node_modules/web-vitals/dist/web-vitals.iife.js", "bundleName": "vitals" }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert_eq!(result.scripts.len(), 2);
+        let scripts_bundle = result
+            .scripts
+            .iter()
+            .find(|b| b.name == "scripts")
+            .expect("scripts bundle present");
+        assert_eq!(scripts_bundle.sources.len(), 2);
+        assert!(scripts_bundle.sources[0].ends_with("src/a.js"));
+        assert!(scripts_bundle.sources[1].ends_with("src/b.js"));
+        let vitals = result
+            .scripts
+            .iter()
+            .find(|b| b.name == "vitals")
+            .expect("vitals bundle present");
+        assert_eq!(vitals.sources.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_scripts_omitted_field_yields_empty_vec() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": {
+                            "options": {
+                                "outputPath": "dist",
+                                "tsConfig": "tsconfig.json"
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.scripts.is_empty());
     }
 
     #[test]

--- a/packages/builder/src/build/__tests__/options.test.ts
+++ b/packages/builder/src/build/__tests__/options.test.ts
@@ -65,14 +65,17 @@ describe('translateOptions (build)', () => {
     expect(t.warnings.some((w) => w.includes('locale subset'))).toBe(true);
   });
 
-  it('rejects non-empty scripts arrays', () => {
+  it('accepts non-empty scripts arrays without error', () => {
+    // ngc-rs reads `scripts` directly from angular.json, so the builder
+    // does not need to forward it as a CLI flag — but it must no longer
+    // reject the option (issue #138).
     expect(() =>
       translateOptions(
         { ...minimal, scripts: ['some.js'] as never },
         '/ws',
         null,
       ),
-    ).toThrow(OptionTranslationError);
+    ).not.toThrow();
   });
 
   it('accepts empty scripts arrays without error', () => {

--- a/packages/builder/src/build/options.ts
+++ b/packages/builder/src/build/options.ts
@@ -71,8 +71,8 @@ export interface TranslatedBuildArgs {
 }
 
 /// Thrown when an option is set in a way ngc-rs cannot honor (e.g. SSR
-/// fields, scripts array, watch=true). The builder turns this into a
-/// `BuilderOutput` with `success: false` and surfaces the message.
+/// fields, watch=true). The builder turns this into a `BuilderOutput`
+/// with `success: false` and surfaces the message.
 export class OptionTranslationError extends Error {
   constructor(message: string) {
     super(message);
@@ -94,11 +94,6 @@ export function translateOptions(
   const warnings: string[] = [];
 
   // Hard rejections — anything ngc-rs cannot do at all.
-  if (raw.scripts && Array.isArray(raw.scripts) && raw.scripts.length > 0) {
-    throw new OptionTranslationError(
-      'The `scripts` option (global script entries) is not yet supported by ngc-rs build. Move script imports into your application code, or open an issue to request the feature.',
-    );
-  }
   if (raw.watch === true) {
     throw new OptionTranslationError(
       '`watch: true` on the application builder is not supported. Use the `@ngc-rs/builder:dev-server` builder for incremental rebuilds.',


### PR DESCRIPTION
## Summary

Closes #138.

- `crates/project-resolver/src/angular_json.rs`: parse `scripts` entries (string form `"src/global.js"` and object form `{ input, inject, bundleName }`); resolve into per-`bundleName` groups on `ResolvedAngularProject.scripts`. Entries that share a `bundleName` are concatenated; default name is `"scripts"`, default `inject` is `true`.
- `crates/cli/src/scripts.rs` (new): concatenate each bundle's source files (with file-boundary comments), apply content hashing in production (matching the polyfills/main hash format), and write `<name>.js` to `out_dir`. Plain non-module concat, not run through the JS bundler — these are typically third-party CDN snippets that aren't ES modules.
- `crates/cli/src/main.rs`: new step 10.5 in the build pipeline emits the bundles between asset copy and `index.html` generation. `IndexHtmlOptions` grows a `scripts: &[&str]` field; `generate_index_html` emits `<script src=\"…\" defer></script>` for each `inject: true` entry, before the polyfills/main module scripts so globals execute first. Honors `deployUrl`, `crossOrigin`, and `subresourceIntegrity` consistently with the existing tags.
- `packages/builder/src/build/options.ts`: drop the `OptionTranslationError` for non-empty `scripts` arrays — ngc-rs reads `scripts` directly from `angular.json`, so the builder no longer needs to forward it.

## Test plan
- [x] `cargo test --workspace` (all crates pass; 4 new resolver tests for parsing, 1 new CLI test for index injection, 4 new tests in the `scripts` module for concat + hashing + inject flag)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npx vitest run` in `packages/builder` (58/58 pass; the prior `rejects non-empty scripts arrays` test is converted to `accepts non-empty scripts arrays without error`)
- [x] Behavior verified end-to-end against a minimal fixture exercising all four cases:
  - string-form entry → `dist/scripts.js`
  - object-form with shared `bundleName` → concatenated `dist/vendor.js` (analytics + companion in declaration order)
  - object-form with `inject: false` → `dist/lazy.js` written, no `<script>` tag emitted
  - `--configuration production` → content-hashed filenames flow through to the injected tags