### PR TITLE
fix(template-compiler): strip `; as alias` from `@if` codegen (closes #165)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/template-compiler/src/codegen.rs
+++ b/crates/template-compiler/src/codegen.rs
@@ -3304,14 +3304,14 @@ fn build_conditional_expr(
 ) -> String {
     let mut expr = format!(
         "{} ? {} : ",
-        ctx_expr_with_locals(condition, locals),
+        ctx_expr_with_locals(strip_block_alias(condition), locals),
         if_slot
     );
 
     for (cond, _fn_name, slot) in else_ifs {
         expr.push_str(&format!(
             "{} ? {} : ",
-            ctx_expr_with_locals(cond, locals),
+            ctx_expr_with_locals(strip_block_alias(cond), locals),
             slot
         ));
     }
@@ -3323,6 +3323,75 @@ fn build_conditional_expr(
     }
 
     expr
+}
+
+/// Strip the `; as <alias>` suffix from an `@if` / `@else if` control-flow
+/// expression so the codegen emits valid JavaScript for `ɵɵconditional(...)`.
+///
+/// Angular's grammar allows `@if (expr; as alias) { ... }` to expose the
+/// truthy value of `expr` as `alias` inside the body. The pest grammar
+/// captures the whole `expr; as alias` as a single condition string; without
+/// this strip the codegen emits `ɵɵconditional(expr; as alias ? slot : -1)`
+/// which is not valid JS and causes the bundler's tree-shake parse to fail.
+///
+/// Note: this is a Phase-1 fix that only stops the build from breaking. The
+/// alias binding itself (so `{{ alias.name }}` inside the body actually
+/// resolves at runtime) is tracked as a separate follow-up.
+fn strip_block_alias(condition: &str) -> &str {
+    let trimmed = condition.trim();
+    if let Some(idx) = find_alias_separator(trimmed) {
+        trimmed[..idx].trim()
+    } else {
+        trimmed
+    }
+}
+
+/// Find the byte index of the `;` that introduces an `as <alias>` clause in
+/// a control-flow condition, if one is present. Returns `None` for plain
+/// expressions that contain no alias.
+///
+/// Walks the string tracking string-literal and parenthesis depth so a
+/// semicolon that lives inside `'a; as b'` or `f('x; as y')` is not picked
+/// up. The alias clause only matches at the top level (paren depth 0).
+fn find_alias_separator(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut paren_depth: i32 = 0;
+    let mut in_string: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match in_string {
+            Some(quote) => {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                }
+                if b == quote {
+                    in_string = None;
+                }
+            }
+            None => match b {
+                b'\'' | b'"' | b'`' => in_string = Some(b),
+                b'(' | b'[' | b'{' => paren_depth += 1,
+                b')' | b']' | b'}' => paren_depth -= 1,
+                b';' if paren_depth == 0 => {
+                    let rest = s[i + 1..].trim_start();
+                    if let Some(stripped) = rest.strip_prefix("as") {
+                        if stripped
+                            .chars()
+                            .next()
+                            .is_none_or(|c| c.is_whitespace() || c == '\t')
+                        {
+                            return Some(i);
+                        }
+                    }
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Format static attributes as an array expression.
@@ -3928,6 +3997,41 @@ fn decode_html_entities(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::extract::ExtractedComponent;
+
+    #[test]
+    fn strip_block_alias_handles_plain_expressions() {
+        assert_eq!(strip_block_alias("ctx.x"), "ctx.x");
+        assert_eq!(strip_block_alias("a && b"), "a && b");
+        assert_eq!(strip_block_alias("  state$ | async  "), "state$ | async");
+    }
+
+    #[test]
+    fn strip_block_alias_strips_top_level_alias() {
+        assert_eq!(strip_block_alias("item(); as it"), "item()");
+        assert_eq!(strip_block_alias("state$ | async; as s"), "state$ | async");
+        assert_eq!(strip_block_alias("foo;as bar"), "foo");
+        assert_eq!(strip_block_alias("foo ; as bar"), "foo");
+    }
+
+    #[test]
+    fn strip_block_alias_does_not_strip_alias_inside_strings() {
+        assert_eq!(strip_block_alias("'a; as b'"), "'a; as b'");
+        assert_eq!(strip_block_alias("f(\"; as b\")"), "f(\"; as b\")");
+        assert_eq!(strip_block_alias("`x; as y`"), "`x; as y`");
+    }
+
+    #[test]
+    fn strip_block_alias_does_not_strip_inside_parens() {
+        assert_eq!(strip_block_alias("f(a; as b)"), "f(a; as b)");
+        assert_eq!(strip_block_alias("(a; as b) || c"), "(a; as b) || c");
+    }
+
+    #[test]
+    fn strip_block_alias_only_matches_as_with_word_break() {
+        // `;asfoo` is not an alias clause — the `as` must be followed by
+        // whitespace.
+        assert_eq!(strip_block_alias("foo;ascending"), "foo;ascending");
+    }
 
     fn test_component() -> ExtractedComponent {
         ExtractedComponent {


### PR DESCRIPTION
## Summary

- Fixes the build-blocking parser panic on Angular 21 components that use `@if (expr; as alias) { ... }` (and `@else if` likewise).
- Root cause was **not** in oxc — it was in `crates/template-compiler/src/codegen.rs::build_conditional_expr`. The pest grammar captures the entire `expr; as alias` as one `condition` string, and the codegen embedded it raw into `ɵɵconditional({condition} ? slot : -1)`, producing invalid JavaScript like `ɵɵconditional(item(); as it ? 3 : 4)`. ts-transform's oxc parse then failed; the fallback fed un-transformed source to the bundler's tree-shake parse, which hard-failed with `tree shake parse failed`.
- New helper `strip_block_alias` walks the condition string tracking string-literal and paren depth, so a top-level `; as <alias>` clause gets stripped, while semicolons inside strings or sub-expressions are preserved.
- Five new unit tests in `crates/template-compiler/src/codegen.rs` cover plain expressions, simple alias clauses, alias-like content inside string literals, alias-like content inside parens, and word-boundary handling (so `foo;ascending` is not mistaken for an alias).

## Why this is a v1.0 must-have

`@if (expr; as alias)` is idiomatic in Angular 17+. Any non-trivial Angular 21 production app uses it. Pre-this PR, ngc-rs hard-fails on those components — the build cannot produce a `dist/`. This was filed as #165 (`parity:must-have`) after surfacing during the post-#164 layer-2 verification of the must-have parity PRs (#137–#141). It also blocks the schema-audit work landed in #164 from being end-to-end testable on the canonical fixture.

## Limitation — Phase 1 only (Phase 2 tracked as #166)

This PR is a Phase-1 fix: it makes the build emit valid JS, but does not yet bind the alias correctly at runtime. With this PR alone, references like `{{ alias.name }}` inside the conditional body still resolve against the parent component's context (where there is no field named `alias`), so they evaluate to `undefined` at runtime.

The proper alias binding (Phase 2 — pass the truthy expression as the second arg to `ɵɵconditional`, surface it as the inner template's `_ctx` parameter, rewrite alias references inside the body to that parameter) is filed separately as #166 (`parity:important`). Phase 1 unblocks every other piece of v1.0 parity work; Phase 2 is the runtime-correctness follow-up.

## Test plan

- [x] `cargo test -p ngc-template-compiler --lib strip_block_alias` — 5/5 new unit tests pass.
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` — clean.
- [x] End-to-end: `npx ng build --configuration production` against `test-ng-project` (Angular 21.2 with signals + control-flow templates including `@if (item(); as it)` and `@if (state$ | async; as s)`) — completes successfully:
  ```
  ngc-rs build complete: 46 module(s), 97 file(s), 1.42 MiB, 488 ms
  ```
- [x] Post-build sanity check: `dist/test-ng-project/chunk-detail-component.*.js` contains the minified `r(t.item() ? 3 : 4)` call (i.e. `ɵɵconditional(ctx.item() ? 3 : 4)`) with the `; as it` clause correctly stripped.

## Out of scope

- The runtime alias binding (Phase 2 — tracked in #166).
- Reworking the pest grammar to split the alias at parse time rather than at codegen — a cleaner shape but unnecessary for v1.0 build success.

Closes #165.
