### PR TITLE
feat(bundler): wire BundleOutput.initial_chunks + chunk_kinds for vendor chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.7"
+version = "0.10.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -38,6 +38,22 @@ pub struct ChunkGraph {
     pub chunks: Vec<Chunk>,
     /// Map from dynamic import target path to its chunk filename.
     pub dynamic_import_map: HashMap<PathBuf, String>,
+    /// Map from every module path to the index of the chunk that owns it.
+    /// Built after partition; lets `bundle_chunk` resolve a cross-chunk
+    /// reference's target chunk in O(1) instead of scanning every chunk's
+    /// module list.
+    pub module_to_chunk_idx: HashMap<PathBuf, usize>,
+}
+
+/// Populate `module_to_chunk_idx` from the final chunk list.
+fn build_module_to_chunk_idx(chunks: &[Chunk]) -> HashMap<PathBuf, usize> {
+    let mut map = HashMap::new();
+    for (idx, chunk) in chunks.iter().enumerate() {
+        for module in &chunk.modules {
+            map.insert(module.clone(), idx);
+        }
+    }
+    map
 }
 
 /// Build a chunk graph by partitioning modules into main, lazy, and shared chunks.
@@ -94,14 +110,17 @@ pub fn build_chunk_graph(
             module_count = modules.len(),
             "no dynamic imports, single chunk"
         );
+        let chunks = vec![Chunk {
+            kind: ChunkKind::Main,
+            filename: "main.js".to_string(),
+            modules,
+            entry: entry.clone(),
+        }];
+        let module_to_chunk_idx = build_module_to_chunk_idx(&chunks);
         return Ok(ChunkGraph {
-            chunks: vec![Chunk {
-                kind: ChunkKind::Main,
-                filename: "main.js".to_string(),
-                modules,
-                entry: entry.clone(),
-            }],
+            chunks,
             dynamic_import_map: HashMap::new(),
+            module_to_chunk_idx,
         });
     }
 
@@ -245,9 +264,11 @@ pub fn build_chunk_graph(
         "built chunk graph"
     );
 
+    let module_to_chunk_idx = build_module_to_chunk_idx(&chunks);
     Ok(ChunkGraph {
         chunks,
         dynamic_import_map,
+        module_to_chunk_idx,
     })
 }
 

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -91,6 +91,14 @@ pub struct BundleOutput {
     /// Source maps for each chunk, keyed by the same filename as `chunks`.
     /// Empty when source map generation is disabled.
     pub chunk_source_maps: HashMap<String, SourceMap>,
+    /// Filenames the HTML must inject as `<script type="module">` tags, in
+    /// load order. Always ends with the main chunk; earlier entries are
+    /// eagerly-loaded vendor/shared chunks that main statically imports.
+    pub initial_chunks: Vec<String>,
+    /// Per-chunk kind (Main / Lazy / Shared). Lets downstream tooling
+    /// distinguish vendor chunks from lazy-route chunks without re-parsing
+    /// filenames.
+    pub chunk_kinds: HashMap<String, ChunkKind>,
 }
 
 /// Bundle all modules into one or more ESM chunk files.
@@ -291,16 +299,32 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     }
 
     // Content-hash filenames
-    let main_filename = if input.options.content_hash {
+    let (main_filename, rename_map) = if input.options.content_hash {
         apply_content_hashes(&mut output_chunks, &mut chunk_source_maps)?
     } else {
-        "main.js".to_string()
+        ("main.js".to_string(), HashMap::new())
     };
+
+    // Build per-chunk kind index and the list of initial chunks. With the
+    // pre-vendor partition rule, the only initial chunk is `main`. The field
+    // exists now so future vendor-chunk work can populate it without breaking
+    // the BundleOutput shape.
+    let mut chunk_kinds: HashMap<String, ChunkKind> = HashMap::new();
+    for chunk in &chunk_graph.chunks {
+        let final_filename = rename_map
+            .get(&chunk.filename)
+            .cloned()
+            .unwrap_or_else(|| chunk.filename.clone());
+        chunk_kinds.insert(final_filename, chunk.kind.clone());
+    }
+    let initial_chunks = vec![main_filename.clone()];
 
     Ok(BundleOutput {
         chunks: output_chunks,
         main_filename,
         chunk_source_maps,
+        initial_chunks,
+        chunk_kinds,
     })
 }
 
@@ -1005,7 +1029,7 @@ fn content_hash(content: &str) -> String {
 fn apply_content_hashes(
     chunks: &mut HashMap<String, String>,
     source_maps: &mut HashMap<String, SourceMap>,
-) -> NgcResult<String> {
+) -> NgcResult<(String, HashMap<String, String>)> {
     // Build rename map: process all chunks, computing hashes
     // First do non-main chunks (lazy/shared), then main
     let filenames: Vec<String> = chunks.keys().cloned().collect();
@@ -1061,7 +1085,7 @@ fn apply_content_hashes(
         .unwrap_or_else(|| "main.js".to_string());
 
     debug!(main = %main_filename, "applied content hashes");
-    Ok(main_filename)
+    Ok((main_filename, rename_map))
 }
 
 /// Insert a content hash into a filename: `chunk-foo.js` → `chunk-foo.a1b2c3d4.js`.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1169,7 +1169,7 @@ pub(crate) fn run_build_with_options(
                 !ap.styles.is_empty(),
                 polyfills_filename.as_deref(),
                 &out_dir,
-                &bundle_output.main_filename,
+                &bundle_output.initial_chunks,
                 &index_opts,
             )?;
             output_files.push(path);
@@ -2173,7 +2173,7 @@ fn generate_index_html(
     has_styles: bool,
     polyfills_filename: Option<&str>,
     out_dir: &Path,
-    main_filename: &str,
+    initial_chunks: &[String],
     options: &IndexHtmlOptions,
 ) -> NgcResult<PathBuf> {
     let mut html = std::fs::read_to_string(index_source).map_err(|e| NgcError::Io {
@@ -2248,10 +2248,10 @@ fn generate_index_html(
             "  <script src=\"{src}\" type=\"module\"{crossorigin_attr}{integrity_attr}></script>\n"
         ));
     }
-    {
-        let src = format!("{deploy_url}{main_filename}");
+    for chunk_filename in initial_chunks {
+        let src = format!("{deploy_url}{chunk_filename}");
         let integrity = if options.subresource_integrity {
-            Some(compute_sri_hash(&out_dir.join(main_filename))?)
+            Some(compute_sri_hash(&out_dir.join(chunk_filename))?)
         } else {
             None
         };
@@ -2939,7 +2939,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &IndexHtmlOptions::default(),
         )
         .unwrap();
@@ -2972,7 +2972,7 @@ mod tests {
             false,
             None,
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3002,7 +3002,7 @@ mod tests {
             false,
             None,
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &IndexHtmlOptions::default(),
         )
         .unwrap();
@@ -3041,7 +3041,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3069,7 +3069,7 @@ mod tests {
             false,
             None,
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3092,7 +3092,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3115,7 +3115,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3136,7 +3136,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3165,7 +3165,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();
@@ -3189,7 +3189,7 @@ mod tests {
             true,
             Some("polyfills.js"),
             dir.path(),
-            "main.js",
+            &["main.js".to_string()],
             &opts,
         )
         .unwrap();


### PR DESCRIPTION
## Summary

Lays the API surface that issue #131's vendor-chunk splitting will populate, without changing today's bundler behavior. This is **PR-1 of 2** on the `feat/vendor-chunks` milestone branch — a no-op refactor that lands the new \`BundleOutput\` shape and HTML-injector wiring. The algorithm flip + vendor partition + content-hashed chunk names land in PR-2.

Refs #131.

## What changes

- \`ChunkGraph\` gains \`module_to_chunk_idx: HashMap<PathBuf, usize>\` (built post-partition) so PR-2's cross-chunk import emission can resolve a target module's owning chunk in O(1).
- \`BundleOutput\` gains:
  - \`initial_chunks: Vec<String>\` — the load order for \`<script type=\"module\">\` tags. Always ends with main; PR-2 will prepend eager vendor chunks.
  - \`chunk_kinds: HashMap<String, ChunkKind>\` — lets downstream tooling (license generation, service-worker manifest) distinguish vendor chunks from lazy-route chunks without re-parsing filenames.
- \`apply_content_hashes\` now returns the rename map so \`chunk_kinds\` stays keyed by the post-hash filename.
- \`generate_index_html\` accepts \`initial_chunks: &[String]\` instead of \`main_filename: &str\` and loops to emit one \`<script type=\"module\">\` per entry. With today's partition (only main is initial), output is byte-identical to before.

## Test plan

- [x] \`cargo test -p ngc-bundler\` passes (chunk + bundler integration)
- [x] \`cargo test -p ngc-rs\` passes (CLI + index.html injection tests)
- [x] Workspace \`cargo check\` clean
- [x] No behavioral change: bundler emits identical bytes; index.html emits identical script tags