### PR TITLE
feat(bundler): vendor chunk splitting for shared npm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-bundler"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-dev-server"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "ngc-diagnostics",
  "serde_json",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-diagnostics"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-linker"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "dashmap",
  "insta",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-npm-resolver"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "dashmap",
  "ngc-diagnostics",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-project-resolver"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "dashmap",
  "glob",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-rs"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "base64",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-template-compiler"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "insta",
  "ngc-diagnostics",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-ts-transform"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "ngc-diagnostics",
  "oxc_allocator",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ngc-watch"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "ngc-diagnostics",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/diagnostics", "crates/project-resolver", "crates/ts-transform", "crates/bundler", "crates/template-compiler", "crates/npm-resolver", "crates/linker", "crates/watch", "crates/dev-server"]
 
 [workspace.package]
-version = "0.10.8"
+version = "0.10.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["lukekania"]

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -163,10 +163,7 @@ pub fn build_chunk_graph(
     // that statically reach it.
     let mut importer_set: HashMap<NodeIndex, BTreeSet<u32>> = HashMap::new();
     for &node in &main_reach {
-        importer_set
-            .entry(node)
-            .or_default()
-            .insert(MAIN_CHUNK_ID);
+        importer_set.entry(node).or_default().insert(MAIN_CHUNK_ID);
     }
     for (&sp, reachable) in &lazy_reach {
         let id = lazy_id_of[&sp];
@@ -605,7 +602,10 @@ fn scc_emit_deps_first(
 /// invalidation behavior.
 fn vendor_chunk_filename(modules: &[PathBuf]) -> String {
     use sha2::{Digest, Sha256};
-    let mut paths: Vec<String> = modules.iter().map(|p| p.to_string_lossy().into_owned()).collect();
+    let mut paths: Vec<String> = modules
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
     paths.sort();
     let mut hasher = Sha256::new();
     for p in &paths {
@@ -1059,12 +1059,10 @@ mod tests {
             );
         }
         // Main has no npm here either.
-        assert!(
-            !result.chunks[0]
-                .modules
-                .iter()
-                .any(|m| m.to_string_lossy().contains("node_modules"))
-        );
+        assert!(!result.chunks[0]
+            .modules
+            .iter()
+            .any(|m| m.to_string_lossy().contains("node_modules")));
     }
 
     /// Per issue #131: an npm module reachable from Main AND ≥1 lazy chunk
@@ -1105,12 +1103,10 @@ mod tests {
             .iter()
             .find(|c| c.kind == ChunkKind::Shared)
             .expect("should have a vendor chunk");
-        assert!(
-            vendor
-                .modules
-                .iter()
-                .any(|m| m.to_string_lossy().contains("core.mjs"))
-        );
+        assert!(vendor
+            .modules
+            .iter()
+            .any(|m| m.to_string_lossy().contains("core.mjs")));
     }
 
     /// Two npm modules with the same importer-set fold into the same vendor
@@ -1145,8 +1141,14 @@ mod tests {
             .collect();
         assert_eq!(vendor_chunks.len(), 1, "expected one vendor chunk");
         let vendor = vendor_chunks[0];
-        assert!(vendor.modules.iter().any(|m| m.to_string_lossy().contains("pkg-a")));
-        assert!(vendor.modules.iter().any(|m| m.to_string_lossy().contains("pkg-b")));
+        assert!(vendor
+            .modules
+            .iter()
+            .any(|m| m.to_string_lossy().contains("pkg-a")));
+        assert!(vendor
+            .modules
+            .iter()
+            .any(|m| m.to_string_lossy().contains("pkg-b")));
     }
 
     /// Two npm modules with DIFFERENT importer-sets split into two distinct
@@ -1184,7 +1186,11 @@ mod tests {
             .iter()
             .filter(|c| c.kind == ChunkKind::Shared)
             .collect();
-        assert_eq!(vendor_chunks.len(), 2, "expected two distinct vendor chunks");
+        assert_eq!(
+            vendor_chunks.len(),
+            2,
+            "expected two distinct vendor chunks"
+        );
     }
 
     /// Filename regex: `chunk-<8hex>.js`.

--- a/crates/bundler/src/chunk.rs
+++ b/crates/bundler/src/chunk.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use ngc_diagnostics::{NgcError, NgcResult};
@@ -124,68 +124,104 @@ pub fn build_chunk_graph(
         });
     }
 
-    // Step 2: Compute static-only reachability from main entry
-    let mut main_reachable = static_reachable(graph, *entry_idx);
+    // Partition into worker vs non-worker split points. Workers run in a
+    // separate ESM realm and can't import from non-worker chunks, so they
+    // must remain self-contained — they inline every module they statically
+    // reach, even if non-worker chunks also reach the same npm module. As
+    // a result workers do NOT participate in vendor-chunk grouping.
+    let non_worker_split_points: Vec<NodeIndex> = split_points
+        .iter()
+        .copied()
+        .filter(|sp| !worker_split_points.contains(sp))
+        .collect();
+    let worker_split_points_ordered: Vec<NodeIndex> = split_points
+        .iter()
+        .copied()
+        .filter(|sp| worker_split_points.contains(sp))
+        .collect();
 
-    // Force npm modules that are reachable from ANY entry point (main or split)
-    // into the main chunk.  The bundler's IIFE wrapping and namespace system
-    // only operates on the main chunk — npm modules that end up in lazy/shared
-    // chunks would be silently omitted, producing missing cross-chunk exports.
-    // We compute full reachability (all edge types) from the main entry to find
-    // all npm modules the app actually uses, excluding unreachable npm modules
-    // (e.g. test-only packages discovered by scanning non-entry files).
-    let all_reachable = all_reachable(graph, *entry_idx);
-    for idx in all_reachable {
-        if graph[idx]
-            .components()
-            .any(|c| c.as_os_str() == "node_modules")
-        {
-            main_reachable.insert(idx);
-        }
+    // Stable, deterministic ChunkId numbering for non-worker chunks: Main
+    // is always 0, non-worker lazies are 1..=N in `split_points` order.
+    // ChunkId is used as the key for importer-set grouping; small integers
+    // (rather than NodeIndex) keep keys cheap and independent of graph
+    // layout.
+    const MAIN_CHUNK_ID: u32 = 0;
+    let mut lazy_id_of: HashMap<NodeIndex, u32> = HashMap::new();
+    for (i, sp) in non_worker_split_points.iter().enumerate() {
+        lazy_id_of.insert(*sp, (i + 1) as u32);
     }
 
-    // Step 3: Compute static-only reachability from each split point
-    let mut split_reachable: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::new();
-    for &sp in &split_points {
-        split_reachable.insert(sp, static_reachable(graph, sp));
+    // Compute static reachability from main + every non-worker split point.
+    // Workers are computed separately further down.
+    let main_reach = static_reachable(graph, *entry_idx);
+    let mut lazy_reach: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::new();
+    for &sp in &non_worker_split_points {
+        lazy_reach.insert(sp, static_reachable(graph, sp));
     }
 
-    // Step 4: Assign modules to chunks
-    // - Module in main_reachable → main chunk
-    // - Module reachable from exactly 1 split point (not in main) → that lazy chunk
-    // - Module reachable from 2+ split points (not in main) → shared chunk
-
-    // For each non-main module, track which split points can reach it
-    let mut module_consumers: HashMap<NodeIndex, BTreeSet<NodeIndex>> = HashMap::new();
-    for (&sp, reachable) in &split_reachable {
+    // Invert: each non-worker-reachable module → set of non-worker chunks
+    // that statically reach it.
+    let mut importer_set: HashMap<NodeIndex, BTreeSet<u32>> = HashMap::new();
+    for &node in &main_reach {
+        importer_set
+            .entry(node)
+            .or_default()
+            .insert(MAIN_CHUNK_ID);
+    }
+    for (&sp, reachable) in &lazy_reach {
+        let id = lazy_id_of[&sp];
         for &node in reachable {
-            if !main_reachable.contains(&node) {
-                module_consumers.entry(node).or_default().insert(sp);
-            }
+            importer_set.entry(node).or_default().insert(id);
         }
     }
 
-    // Group shared modules by their consumer set
-    let shared_groups: HashMap<BTreeSet<NodeIndex>, Vec<NodeIndex>> = HashMap::new();
+    // Classify each non-worker-reachable module. Per issue #131:
+    //
+    //   npm modules:
+    //     |set| == 1 && set == {Main}    → main
+    //     |set| == 1 && set == {Lazy(x)} → chunk x  (NEW — used to be forced into main)
+    //     |set| >= 2                     → vendor chunk grouped by importer-set
+    //
+    //   non-npm modules (scope deliberately conservative — issue #131 only
+    //   asks for npm vendor splitting):
+    //     Main ∈ set                     → main (preserves "statically reachable from main")
+    //     |set| == 1 && set == {Lazy(x)} → chunk x
+    //     |set| >= 2 (no Main)           → main (folded back, same as today)
+    let mut main_nodes: HashSet<NodeIndex> = HashSet::new();
     let mut lazy_exclusive: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
-
-    for (&module, consumers) in &module_consumers {
-        if consumers.len() == 1 {
-            let sp = *consumers.iter().next().expect("consumer set is non-empty");
-            lazy_exclusive.entry(sp).or_default().push(module);
+    let mut vendor_groups: BTreeMap<BTreeSet<u32>, Vec<NodeIndex>> = BTreeMap::new();
+    for (&node, set) in &importer_set {
+        let is_npm = graph[node]
+            .components()
+            .any(|c| c.as_os_str() == "node_modules");
+        if is_npm {
+            if set.len() == 1 {
+                let only = *set.iter().next().expect("set non-empty");
+                if only == MAIN_CHUNK_ID {
+                    main_nodes.insert(node);
+                } else {
+                    let sp = non_worker_split_points[(only - 1) as usize];
+                    lazy_exclusive.entry(sp).or_default().push(node);
+                }
+            } else {
+                vendor_groups.entry(set.clone()).or_default().push(node);
+            }
+        } else if set.contains(&MAIN_CHUNK_ID) {
+            main_nodes.insert(node);
+        } else if set.len() == 1 {
+            let only = *set.iter().next().expect("set non-empty");
+            let sp = non_worker_split_points[(only - 1) as usize];
+            lazy_exclusive.entry(sp).or_default().push(node);
         } else {
-            // Modules needed by multiple lazy chunks go to the main chunk
-            // so they can be exported via `./main.js` cross-chunk imports.
-            // Putting them in separate shared chunks would require cross-chunk
-            // import resolution between non-main chunks, which isn't supported yet.
-            main_reachable.insert(module);
+            // Multi-consumer non-npm without Main: fold to main, same as
+            // pre-vendor behavior. Lifting this is out of scope for #131.
+            main_nodes.insert(node);
         }
     }
 
-    // Step 5: Build chunks with topological ordering
+    // Step 5: Build chunks with topological ordering.
 
-    // Main chunk
-    let main_ordered = toposort_subset(graph, *entry_idx, &main_reachable)?;
+    let main_ordered = toposort_subset(graph, *entry_idx, &main_nodes)?;
     let main_modules: Vec<PathBuf> = main_ordered.iter().map(|idx| graph[*idx].clone()).collect();
 
     let mut chunks = vec![Chunk {
@@ -197,22 +233,18 @@ pub fn build_chunk_graph(
 
     let mut dynamic_import_map: HashMap<PathBuf, String> = HashMap::new();
 
-    // Lazy chunks
-    for &sp in &split_points {
+    // Non-worker lazy chunks.
+    for &sp in &non_worker_split_points {
         let sp_path = graph[sp].clone();
 
-        // If the split point is in main_reachable, it stays in main — no lazy chunk
-        if main_reachable.contains(&sp) {
+        // If the split point itself was statically reachable from main, it
+        // stayed in `main_nodes` — no separate lazy chunk for it.
+        if main_nodes.contains(&sp) {
             continue;
         }
 
-        let filename = if worker_split_points.contains(&sp) {
-            worker_chunk_filename_from_path(&sp_path, root_dir)
-        } else {
-            chunk_filename_from_path(&sp_path, root_dir)
-        };
+        let filename = chunk_filename_from_path(&sp_path, root_dir);
 
-        // Modules exclusive to this lazy chunk + the split point itself
         let mut chunk_nodes: HashSet<NodeIndex> = HashSet::new();
         chunk_nodes.insert(sp);
         if let Some(exclusive) = lazy_exclusive.get(&sp) {
@@ -234,33 +266,58 @@ pub fn build_chunk_graph(
         });
     }
 
-    // Shared chunks
-    let mut shared_index = 0;
-    for nodes in shared_groups.values() {
-        let filename = format!("chunk-shared-{shared_index}.js");
-        shared_index += 1;
-
+    // Vendor (shared) chunks: one per unique importer-set.
+    // BTreeMap iteration is deterministic, and we hash the sorted module
+    // path set to produce a stable `chunk-<8hex>.js` filename.
+    let vendor_count = vendor_groups.len();
+    for (_set_key, nodes) in vendor_groups {
         let node_set: HashSet<NodeIndex> = nodes.iter().copied().collect();
-        // Pick any node as "entry" for toposort — use the first in the set
-        let first_node = *nodes.first().expect("shared group is non-empty");
-        let ordered = toposort_subset(graph, first_node, &node_set)?;
+        // Pick the lexicographically smallest module path as the chunk's
+        // toposort root and `entry` field — `toposort_subset_with_cycles`
+        // ignores the root argument and just sorts the subgraph, so any
+        // deterministic choice works.
+        let entry_node = *nodes
+            .iter()
+            .min_by_key(|n| graph[**n].to_string_lossy().to_string())
+            .expect("vendor group is non-empty");
+        let ordered = toposort_subset(graph, entry_node, &node_set)?;
         let modules: Vec<PathBuf> = ordered.iter().map(|idx| graph[*idx].clone()).collect();
-
-        // Use the first module as the chunk entry
-        let chunk_entry = modules.first().cloned().unwrap_or_default();
+        let entry_path = graph[entry_node].clone();
+        let filename = vendor_chunk_filename(&modules);
 
         chunks.push(Chunk {
             kind: ChunkKind::Shared,
             filename,
             modules,
-            entry: chunk_entry,
+            entry: entry_path,
+        });
+    }
+
+    // Worker chunks: inline every statically-reachable module. Workers do
+    // not participate in vendor extraction because they can't import
+    // non-worker chunks (separate ESM realm).
+    for &sp in &worker_split_points_ordered {
+        let sp_path = graph[sp].clone();
+        let filename = worker_chunk_filename_from_path(&sp_path, root_dir);
+        let reach = static_reachable(graph, sp);
+        let ordered = toposort_subset(graph, sp, &reach)?;
+        let modules: Vec<PathBuf> = ordered.iter().map(|idx| graph[*idx].clone()).collect();
+
+        dynamic_import_map.insert(sp_path.clone(), filename.clone());
+
+        chunks.push(Chunk {
+            kind: ChunkKind::Lazy,
+            filename,
+            modules,
+            entry: sp_path,
         });
     }
 
     debug!(
         chunk_count = chunks.len(),
-        lazy_count = split_points.len(),
-        shared_count = shared_index,
+        lazy_count = non_worker_split_points.len(),
+        worker_count = worker_split_points_ordered.len(),
+        vendor_count = vendor_count,
         "built chunk graph"
     );
 
@@ -270,23 +327,6 @@ pub fn build_chunk_graph(
         dynamic_import_map,
         module_to_chunk_idx,
     })
-}
-
-/// Compute the set of nodes reachable from `start` following all edge types.
-fn all_reachable(graph: &DiGraph<PathBuf, ImportKind>, start: NodeIndex) -> HashSet<NodeIndex> {
-    let mut visited = HashSet::new();
-    let mut stack = vec![start];
-
-    while let Some(node) = stack.pop() {
-        if !visited.insert(node) {
-            continue;
-        }
-        for neighbor in graph.neighbors(node) {
-            stack.push(neighbor);
-        }
-    }
-
-    visited
 }
 
 /// Compute the set of nodes reachable from `start` following only static edges.
@@ -551,6 +591,32 @@ fn scc_emit_deps_first(
     if emitted.insert(node) {
         order.push(node);
     }
+}
+
+/// Derive a vendor (shared) chunk filename `chunk-<8hex>.js`.
+///
+/// Hashes the sorted set of canonical module paths in the chunk with
+/// SHA-256, takes the first 8 hex characters. We hash module paths rather
+/// than chunk content because the content depends on the filenames of
+/// OTHER chunks the vendor imports from (cross-chunk `import { x } from
+/// './chunk-aaaa1111.js'`) — bytewise hashing would be circular. Path-set
+/// hashing is stable, deterministic, and only invalidates the filename
+/// when module membership changes, which matches `ng build`'s observed
+/// invalidation behavior.
+fn vendor_chunk_filename(modules: &[PathBuf]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut paths: Vec<String> = modules.iter().map(|p| p.to_string_lossy().into_owned()).collect();
+    paths.sort();
+    let mut hasher = Sha256::new();
+    for p in &paths {
+        hasher.update(p.as_bytes());
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize();
+    format!(
+        "chunk-{:02x}{:02x}{:02x}{:02x}.js",
+        digest[0], digest[1], digest[2], digest[3]
+    )
 }
 
 /// Derive a worker chunk filename from a worker entry's file path.
@@ -891,11 +957,11 @@ mod tests {
         );
     }
 
+    /// Per issue #131: an npm module reachable from exactly one lazy chunk
+    /// (not from main) inlines into that lazy chunk. Previous behavior forced
+    /// it into main; the vendor-chunk algorithm fixes that.
     #[test]
-    fn test_npm_modules_forced_to_main_chunk() {
-        // main --dynamic--> lazy_component --static--> node_modules/cdk/overlay.mjs
-        // The npm module is only reachable via a dynamic import, but it must
-        // still end up in the main chunk for IIFE wrapping and cross-chunk exports.
+    fn test_npm_module_used_only_by_single_lazy_chunk_inlines() {
         let mut graph = DiGraph::new();
         let npm_mod = graph.add_node(make_path(
             "/root/node_modules/@angular/cdk/fesm2022/overlay.mjs",
@@ -913,25 +979,293 @@ mod tests {
         )
         .expect("should build chunk graph");
 
-        // npm module must be in the main chunk
+        // npm module must NOT be in main
         let main_chunk = &result.chunks[0];
         assert!(
-            main_chunk
+            !main_chunk
                 .modules
                 .iter()
                 .any(|m| m.to_string_lossy().contains("node_modules")),
-            "npm module should be in main chunk"
+            "npm module should NOT be in main (reachable only via lazy chunk)"
         );
+        // npm module must be in the single lazy chunk
+        let lazy_chunk = result
+            .chunks
+            .iter()
+            .find(|c| c.kind == ChunkKind::Lazy)
+            .expect("should have a lazy chunk");
+        assert!(
+            lazy_chunk
+                .modules
+                .iter()
+                .any(|m| m.to_string_lossy().contains("node_modules")),
+            "npm module should be in lazy chunk"
+        );
+        // No vendor chunk for a single-consumer npm.
+        assert!(
+            !result.chunks.iter().any(|c| c.kind == ChunkKind::Shared),
+            "no vendor chunk expected when |importer_set| == 1"
+        );
+    }
 
-        // Lazy chunk must NOT contain the npm module
+    /// Per issue #131: an npm module reachable from ≥2 chunks (no Main)
+    /// moves into a `chunk-<8hex>.js` vendor chunk shared between them.
+    #[test]
+    fn test_npm_module_used_by_two_lazy_chunks_creates_vendor_chunk() {
+        let mut graph = DiGraph::new();
+        let npm_mod = graph.add_node(make_path(
+            "/root/node_modules/@angular/cdk/fesm2022/overlay.mjs",
+        ));
+        let lazy_a = graph.add_node(make_path("/root/src/a/a.component.ts"));
+        let lazy_b = graph.add_node(make_path("/root/src/b/b.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, lazy_a, ImportKind::Dynamic);
+        graph.add_edge(entry, lazy_b, ImportKind::Dynamic);
+        graph.add_edge(lazy_a, npm_mod, ImportKind::Static);
+        graph.add_edge(lazy_b, npm_mod, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        // Expect: main + 2 lazy + 1 vendor = 4 chunks
+        assert_eq!(result.chunks.len(), 4);
+
+        let vendor = result
+            .chunks
+            .iter()
+            .find(|c| c.kind == ChunkKind::Shared)
+            .expect("should have a vendor chunk for the shared npm module");
+        assert!(
+            vendor
+                .modules
+                .iter()
+                .any(|m| m.to_string_lossy().contains("overlay.mjs")),
+            "vendor chunk should contain the shared npm module"
+        );
+        // Lazy chunks must NOT contain the npm module (it lives in vendor)
         for chunk in result.chunks.iter().filter(|c| c.kind == ChunkKind::Lazy) {
             assert!(
                 !chunk
                     .modules
                     .iter()
                     .any(|m| m.to_string_lossy().contains("node_modules")),
-                "npm module should NOT be in lazy chunk"
+                "npm module should NOT be in lazy chunk {}",
+                chunk.filename
             );
         }
+        // Main has no npm here either.
+        assert!(
+            !result.chunks[0]
+                .modules
+                .iter()
+                .any(|m| m.to_string_lossy().contains("node_modules"))
+        );
+    }
+
+    /// Per issue #131: an npm module reachable from Main AND ≥1 lazy chunk
+    /// moves OUT of main into an eager vendor chunk that main statically
+    /// imports. This is the case the HTML script-tag injector must surface
+    /// — main can't bootstrap until the vendor chunk has loaded.
+    #[test]
+    fn test_npm_module_used_by_main_and_lazy_creates_eager_vendor_chunk() {
+        let mut graph = DiGraph::new();
+        let npm_mod = graph.add_node(make_path(
+            "/root/node_modules/@angular/core/fesm2022/core.mjs",
+        ));
+        let lazy = graph.add_node(make_path("/root/src/admin/admin.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, npm_mod, ImportKind::Static);
+        graph.add_edge(entry, lazy, ImportKind::Dynamic);
+        graph.add_edge(lazy, npm_mod, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        // Main must NOT include npm; it's been hoisted to a vendor chunk.
+        let main_chunk = &result.chunks[0];
+        assert!(
+            !main_chunk
+                .modules
+                .iter()
+                .any(|m| m.to_string_lossy().contains("node_modules")),
+            "main should not contain npm — extracted to vendor"
+        );
+        let vendor = result
+            .chunks
+            .iter()
+            .find(|c| c.kind == ChunkKind::Shared)
+            .expect("should have a vendor chunk");
+        assert!(
+            vendor
+                .modules
+                .iter()
+                .any(|m| m.to_string_lossy().contains("core.mjs"))
+        );
+    }
+
+    /// Two npm modules with the same importer-set fold into the same vendor
+    /// chunk, not two separate chunks.
+    #[test]
+    fn test_npm_modules_with_identical_importer_set_grouped() {
+        let mut graph = DiGraph::new();
+        let pkg_a = graph.add_node(make_path("/root/node_modules/pkg-a/index.mjs"));
+        let pkg_b = graph.add_node(make_path("/root/node_modules/pkg-b/index.mjs"));
+        let lazy_a = graph.add_node(make_path("/root/src/a/a.component.ts"));
+        let lazy_b = graph.add_node(make_path("/root/src/b/b.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, lazy_a, ImportKind::Dynamic);
+        graph.add_edge(entry, lazy_b, ImportKind::Dynamic);
+        graph.add_edge(lazy_a, pkg_a, ImportKind::Static);
+        graph.add_edge(lazy_a, pkg_b, ImportKind::Static);
+        graph.add_edge(lazy_b, pkg_a, ImportKind::Static);
+        graph.add_edge(lazy_b, pkg_b, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        let vendor_chunks: Vec<&Chunk> = result
+            .chunks
+            .iter()
+            .filter(|c| c.kind == ChunkKind::Shared)
+            .collect();
+        assert_eq!(vendor_chunks.len(), 1, "expected one vendor chunk");
+        let vendor = vendor_chunks[0];
+        assert!(vendor.modules.iter().any(|m| m.to_string_lossy().contains("pkg-a")));
+        assert!(vendor.modules.iter().any(|m| m.to_string_lossy().contains("pkg-b")));
+    }
+
+    /// Two npm modules with DIFFERENT importer-sets split into two distinct
+    /// vendor chunks — the partition matches webpack's "split point analysis"
+    /// shape and produces ~12 chunks on real Angular apps.
+    #[test]
+    fn test_npm_modules_with_different_importer_sets_split() {
+        let mut graph = DiGraph::new();
+        let pkg_a = graph.add_node(make_path("/root/node_modules/pkg-a/index.mjs"));
+        let pkg_b = graph.add_node(make_path("/root/node_modules/pkg-b/index.mjs"));
+        let lazy_a = graph.add_node(make_path("/root/src/a/a.component.ts"));
+        let lazy_b = graph.add_node(make_path("/root/src/b/b.component.ts"));
+        let lazy_c = graph.add_node(make_path("/root/src/c/c.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+
+        graph.add_edge(entry, lazy_a, ImportKind::Dynamic);
+        graph.add_edge(entry, lazy_b, ImportKind::Dynamic);
+        graph.add_edge(entry, lazy_c, ImportKind::Dynamic);
+        // pkg-a is used by a + b
+        graph.add_edge(lazy_a, pkg_a, ImportKind::Static);
+        graph.add_edge(lazy_b, pkg_a, ImportKind::Static);
+        // pkg-b is used by a + c
+        graph.add_edge(lazy_a, pkg_b, ImportKind::Static);
+        graph.add_edge(lazy_c, pkg_b, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        let vendor_chunks: Vec<&Chunk> = result
+            .chunks
+            .iter()
+            .filter(|c| c.kind == ChunkKind::Shared)
+            .collect();
+        assert_eq!(vendor_chunks.len(), 2, "expected two distinct vendor chunks");
+    }
+
+    /// Filename regex: `chunk-<8hex>.js`.
+    #[test]
+    fn test_vendor_chunk_filename_is_chunk_8hex() {
+        let mut graph = DiGraph::new();
+        let pkg = graph.add_node(make_path("/root/node_modules/pkg/index.mjs"));
+        let lazy_a = graph.add_node(make_path("/root/src/a/a.component.ts"));
+        let lazy_b = graph.add_node(make_path("/root/src/b/b.component.ts"));
+        let entry = graph.add_node(make_path("/root/src/main.ts"));
+        graph.add_edge(entry, lazy_a, ImportKind::Dynamic);
+        graph.add_edge(entry, lazy_b, ImportKind::Dynamic);
+        graph.add_edge(lazy_a, pkg, ImportKind::Static);
+        graph.add_edge(lazy_b, pkg, ImportKind::Static);
+
+        let result = build_chunk_graph(
+            &graph,
+            &make_path("/root/src/main.ts"),
+            Path::new("/root/src"),
+        )
+        .expect("should build chunk graph");
+
+        let vendor = result
+            .chunks
+            .iter()
+            .find(|c| c.kind == ChunkKind::Shared)
+            .expect("vendor chunk");
+        let name = &vendor.filename;
+        assert!(
+            name.starts_with("chunk-")
+                && name.ends_with(".js")
+                && name.len() == "chunk-".len() + 8 + ".js".len(),
+            "expected chunk-<8hex>.js, got {name}"
+        );
+        // Hex digits only.
+        let hex = &name["chunk-".len().."chunk-".len() + 8];
+        assert!(
+            hex.chars().all(|c| c.is_ascii_hexdigit()),
+            "expected 8 hex chars, got {hex}"
+        );
+    }
+
+    /// Determinism: same input → same filenames + module ordering.
+    #[test]
+    fn test_vendor_chunk_partition_is_deterministic() {
+        fn build() -> ChunkGraph {
+            let mut graph = DiGraph::new();
+            let pkg_a = graph.add_node(make_path("/root/node_modules/pkg-a/index.mjs"));
+            let pkg_b = graph.add_node(make_path("/root/node_modules/pkg-b/index.mjs"));
+            let lazy_a = graph.add_node(make_path("/root/src/a/a.component.ts"));
+            let lazy_b = graph.add_node(make_path("/root/src/b/b.component.ts"));
+            let entry = graph.add_node(make_path("/root/src/main.ts"));
+            graph.add_edge(entry, lazy_a, ImportKind::Dynamic);
+            graph.add_edge(entry, lazy_b, ImportKind::Dynamic);
+            graph.add_edge(lazy_a, pkg_a, ImportKind::Static);
+            graph.add_edge(lazy_a, pkg_b, ImportKind::Static);
+            graph.add_edge(lazy_b, pkg_a, ImportKind::Static);
+            graph.add_edge(lazy_b, pkg_b, ImportKind::Static);
+            build_chunk_graph(
+                &graph,
+                &make_path("/root/src/main.ts"),
+                Path::new("/root/src"),
+            )
+            .expect("should build chunk graph")
+        }
+
+        let a = build();
+        let b = build();
+
+        let vendor_a: Vec<&str> = a
+            .chunks
+            .iter()
+            .filter(|c| c.kind == ChunkKind::Shared)
+            .map(|c| c.filename.as_str())
+            .collect();
+        let vendor_b: Vec<&str> = b
+            .chunks
+            .iter()
+            .filter(|c| c.kind == ChunkKind::Shared)
+            .map(|c| c.filename.as_str())
+            .collect();
+        assert_eq!(vendor_a, vendor_b);
     }
 }

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -349,7 +349,10 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     let mut initial: BTreeSet<String> = BTreeSet::new();
     for (owner, consumers) in &consumers_by_owner {
         if consumers.contains(&pre_main) {
-            let renamed = rename_map.get(owner).cloned().unwrap_or_else(|| owner.clone());
+            let renamed = rename_map
+                .get(owner)
+                .cloned()
+                .unwrap_or_else(|| owner.clone());
             initial.insert(renamed);
         }
     }
@@ -431,7 +434,11 @@ fn compute_global_namespace_maps(
         }
     }
 
-    (all_file_to_ns, namespace_to_chunk_idx, specifier_to_namespace)
+    (
+        all_file_to_ns,
+        namespace_to_chunk_idx,
+        specifier_to_namespace,
+    )
 }
 
 /// Build a mapping from raw import specifiers (as they appear in source) to chunk filenames.
@@ -1076,12 +1083,10 @@ fn wire_cross_chunk_namespace_imports(
     // full character set so we don't miss namespaces whose underlying
     // file path contains uppercase characters.
     let ns_re = Regex::new(r"\b__ns_[A-Za-z0-9_]+\b").expect("regex compiles");
-    let var_decl_re =
-        Regex::new(r"var\s+(__ns_[A-Za-z0-9_]+)\s*=").expect("regex compiles");
+    let var_decl_re = Regex::new(r"var\s+(__ns_[A-Za-z0-9_]+)\s*=").expect("regex compiles");
 
     // imports_by_chunk[consumer_filename][owner_filename] = set of __ns_X
-    let mut imports_by_chunk: HashMap<String, HashMap<String, BTreeSet<String>>> =
-        HashMap::new();
+    let mut imports_by_chunk: HashMap<String, HashMap<String, BTreeSet<String>>> = HashMap::new();
 
     for (filename, code) in chunks.iter() {
         let mut used: HashSet<String> = HashSet::new();

--- a/crates/bundler/src/concat.rs
+++ b/crates/bundler/src/concat.rs
@@ -132,18 +132,27 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         export_conditions: &condition_refs,
     });
 
-    // Pre-compute the main chunk's npm namespace map up front so lazy chunks
-    // no longer have to wait for the main chunk's bundle_chunk pass to finish
-    // before they can resolve cross-chunk npm references. With this break in
-    // the data dependency, every chunk can be fanned out into one par_iter
-    // instead of running main as a serial tail.
-    let (main_file_to_ns, main_spec_to_ns) = compute_main_namespace_maps(
-        &main_chunk.modules,
-        &input.bundled_specifiers,
-        &input.root_dir,
-        &condition_refs,
-        &canon_cache,
-    );
+    // Pre-compute namespace maps covering every npm module across all
+    // chunks. Vendor splitting may place an npm module in a chunk other
+    // than main; every consumer chunk needs to resolve the canonical
+    // namespace name AND know which chunk owns it (for cross-chunk import
+    // emission).
+    let (all_file_to_ns, namespace_to_chunk_idx, specifier_to_namespace) =
+        compute_global_namespace_maps(
+            &chunk_graph,
+            &input.bundled_specifiers,
+            &input.root_dir,
+            &condition_refs,
+            &canon_cache,
+        );
+
+    // chunk index → final filename. Filled with pre-hash names; post-hash
+    // renames are applied later via apply_content_hashes' rename map.
+    let chunk_filename_by_idx: Vec<String> = chunk_graph
+        .chunks
+        .iter()
+        .map(|c| c.filename.clone())
+        .collect();
 
     // Lazy chunks consume symbols from main cross-chunk; those consumptions
     // are invisible to the per-chunk shake analysis. Precompute the union
@@ -209,8 +218,11 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
                 chunk_entry: &chunk.entry,
                 chunk_kind: &chunk.kind,
                 chunk_module_set: &chunk_module_set,
-                main_file_to_ns: &main_file_to_ns,
+                all_file_to_ns: &all_file_to_ns,
+                namespace_to_chunk_idx: &namespace_to_chunk_idx,
+                specifier_to_namespace_global: &specifier_to_namespace,
                 main_chunk_module_set: &main_module_set,
+                chunk_idx: idx,
                 canon_cache: &canon_cache,
                 export_conditions: &condition_refs,
             })?;
@@ -262,7 +274,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     let reexport_code = if !all_needed_npm.is_empty() || !all_needed_project.is_empty() {
         Some(generate_cross_chunk_exports(
             &all_needed_npm,
-            &main_spec_to_ns,
+            &specifier_to_namespace,
             &all_needed_project,
         ))
     } else {
@@ -298,6 +310,16 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         }
     }
 
+    // Wire cross-chunk `__ns_*` references: scan each chunk for unresolved
+    // namespace identifiers, emit `import { __ns_X } from './<owner>.js'`
+    // at the top, `export { __ns_X };` at the bottom. Returns the owner →
+    // consumers map so we can identify eagerly-loaded vendor chunks below.
+    let consumers_by_owner = wire_cross_chunk_namespace_imports(
+        &mut output_chunks,
+        &namespace_to_chunk_idx,
+        &chunk_filename_by_idx,
+    )?;
+
     // Content-hash filenames
     let (main_filename, rename_map) = if input.options.content_hash {
         apply_content_hashes(&mut output_chunks, &mut chunk_source_maps)?
@@ -305,10 +327,7 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
         ("main.js".to_string(), HashMap::new())
     };
 
-    // Build per-chunk kind index and the list of initial chunks. With the
-    // pre-vendor partition rule, the only initial chunk is `main`. The field
-    // exists now so future vendor-chunk work can populate it without breaking
-    // the BundleOutput shape.
+    // Build per-chunk kind index keyed by post-hash filename.
     let mut chunk_kinds: HashMap<String, ChunkKind> = HashMap::new();
     for chunk in &chunk_graph.chunks {
         let final_filename = rename_map
@@ -317,7 +336,26 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
             .unwrap_or_else(|| chunk.filename.clone());
         chunk_kinds.insert(final_filename, chunk.kind.clone());
     }
-    let initial_chunks = vec![main_filename.clone()];
+
+    // `initial_chunks` = every chunk main statically imports from, plus
+    // main itself. Vendor chunks consumed by main are eager (the HTML must
+    // inject a `<script type="module">` tag for each); lazy-only vendor
+    // chunks load transitively through the lazy chunks that consume them.
+    // Lookup goes through the rename map so we report post-hash filenames.
+    let pre_main = chunk_filename_by_idx
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "main.js".to_string());
+    let mut initial: BTreeSet<String> = BTreeSet::new();
+    for (owner, consumers) in &consumers_by_owner {
+        if consumers.contains(&pre_main) {
+            let renamed = rename_map.get(owner).cloned().unwrap_or_else(|| owner.clone());
+            initial.insert(renamed);
+        }
+    }
+    // Deterministic order: sorted vendor filenames first, then main last.
+    let mut initial_chunks: Vec<String> = initial.into_iter().collect();
+    initial_chunks.push(main_filename.clone());
 
     Ok(BundleOutput {
         chunks: output_chunks,
@@ -328,35 +366,46 @@ pub fn bundle(input: &BundleInput) -> NgcResult<BundleOutput> {
     })
 }
 
-/// Pre-compute the main chunk's npm namespace maps.
+/// Pre-compute namespace maps covering EVERY npm module across ALL chunks.
 ///
-/// Mirrors the logic that `bundle_chunk` runs internally for the main chunk,
-/// but extracted so it can run before the per-chunk fan-out. Lazy chunks
-/// reach into these maps via `classify_lazy_externals` to resolve cross-chunk
-/// npm references; cross-chunk export generation reads `specifier_to_namespace`
-/// after every chunk has been bundled. Computing them up front breaks the
-/// data dependency from main → lazy and lets all chunks fan out together.
-fn compute_main_namespace_maps(
-    main_module_paths: &[PathBuf],
+/// Lifts the previous "all npm modules live in main" assumption — under
+/// vendor splitting an npm module may live in a vendor chunk, and chunks
+/// that reference it need to know both the canonical namespace name AND
+/// the filename of the chunk that owns it (for cross-chunk imports).
+///
+/// Returns:
+/// - `all_file_to_ns`: canonical npm module path → `__ns_*` name.
+/// - `namespace_to_chunk_idx`: `__ns_*` name → owning chunk index.
+/// - `specifier_to_namespace`: bare bundled specifier → `__ns_*` name.
+fn compute_global_namespace_maps(
+    chunk_graph: &crate::chunk::ChunkGraph,
     bundled_specifiers: &HashSet<String>,
     root_dir: &Path,
     export_conditions: &[&str],
     canon_cache: &CanonCache,
-) -> (HashMap<PathBuf, String>, HashMap<String, String>) {
+) -> (
+    HashMap<PathBuf, String>,
+    HashMap<String, usize>,
+    HashMap<String, String>,
+) {
     let node_modules_dir = root_dir.join("node_modules");
-    let mut file_to_namespace: HashMap<PathBuf, String> = HashMap::new();
-    let mut specifier_to_namespace: HashMap<String, String> = HashMap::new();
+    let mut all_file_to_ns: HashMap<PathBuf, String> = HashMap::new();
+    let mut namespace_to_chunk_idx: HashMap<String, usize> = HashMap::new();
 
-    for module_path in main_module_paths {
-        let is_npm = module_path
-            .components()
-            .any(|c| c.as_os_str() == "node_modules");
-        if is_npm {
-            let ns = crate::npm_wrap::namespace_from_path(module_path, &node_modules_dir);
-            file_to_namespace.insert(module_path.clone(), ns);
+    for (idx, chunk) in chunk_graph.chunks.iter().enumerate() {
+        for module_path in &chunk.modules {
+            let is_npm = module_path
+                .components()
+                .any(|c| c.as_os_str() == "node_modules");
+            if is_npm {
+                let ns = crate::npm_wrap::namespace_from_path(module_path, &node_modules_dir);
+                all_file_to_ns.insert(module_path.clone(), ns.clone());
+                namespace_to_chunk_idx.insert(ns, idx);
+            }
         }
     }
 
+    let mut specifier_to_namespace: HashMap<String, String> = HashMap::new();
     for spec in bundled_specifiers {
         if let Ok(entry_path) = ngc_npm_resolver::resolve::resolve_bare_specifier(
             spec,
@@ -364,16 +413,16 @@ fn compute_main_namespace_maps(
             export_conditions,
         ) {
             let canonical = cached_canonicalize(canon_cache, &entry_path).unwrap_or(entry_path);
-            if let Some(ns) = file_to_namespace.get(&canonical) {
+            if let Some(ns) = all_file_to_ns.get(&canonical) {
                 specifier_to_namespace.insert(spec.clone(), ns.clone());
                 continue;
             }
         }
         // Fallback: for vendored/synthetic modules (e.g.
         // @oxc-project/runtime/helpers/decorate) that don't have a
-        // package.json, match by path suffix in the file_to_namespace map.
+        // package.json, match by path suffix.
         let spec_path_suffix = spec.replace('/', std::path::MAIN_SEPARATOR_STR);
-        for (path, ns) in &file_to_namespace {
+        for (path, ns) in &all_file_to_ns {
             let path_str = path.to_string_lossy();
             if path_str.contains(&spec_path_suffix) {
                 specifier_to_namespace.insert(spec.clone(), ns.clone());
@@ -382,7 +431,7 @@ fn compute_main_namespace_maps(
         }
     }
 
-    (file_to_namespace, specifier_to_namespace)
+    (all_file_to_ns, namespace_to_chunk_idx, specifier_to_namespace)
 }
 
 /// Build a mapping from raw import specifiers (as they appear in source) to chunk filenames.
@@ -487,10 +536,22 @@ struct ChunkBundleParams<'a> {
     chunk_kind: &'a ChunkKind,
     /// Set of canonical module paths in this chunk (for cross-chunk import detection).
     chunk_module_set: &'a HashSet<PathBuf>,
-    /// Main chunk's file path → namespace mapping (for resolving npm cross-chunk imports).
-    main_file_to_ns: &'a HashMap<PathBuf, String>,
+    /// Every npm module across every chunk → its `__ns_*` name. Used by the
+    /// IIFE wrap closure to resolve relative cross-chunk npm references.
+    all_file_to_ns: &'a HashMap<PathBuf, String>,
+    /// `__ns_*` name → chunk index that owns it. Built before fan-out;
+    /// the post-process pass (`wire_cross_chunk_namespace_imports`) uses
+    /// it to resolve cross-chunk namespace refs, but `bundle_chunk`
+    /// itself doesn't read it.
+    #[allow(dead_code)]
+    namespace_to_chunk_idx: &'a HashMap<String, usize>,
+    /// Bundled bare specifier → `__ns_*` name (chunk-agnostic).
+    specifier_to_namespace_global: &'a HashMap<String, String>,
     /// Set of canonical module paths in the main chunk.
     main_chunk_module_set: &'a HashSet<PathBuf>,
+    /// This chunk's own index into `chunk_graph.chunks`. Used together with
+    /// `namespace_to_chunk_idx` to detect cross-chunk vs in-chunk refs.
+    chunk_idx: usize,
     /// Shared cache of `canonicalize()` results across all per-chunk work.
     canon_cache: &'a CanonCache,
     /// Active `exports` conditions, forwarded to the npm resolver.
@@ -516,69 +577,30 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
     let mut all_externals: Vec<ExternalImport> = Vec::new();
     let mut sections: Vec<ModuleSection> = Vec::new();
 
-    // Build namespace map: npm file path → namespace variable name
-    // and specifier → namespace for project code imports.
-    // Only needed for the main chunk — lazy chunks import npm symbols from main.
-    let node_modules_dir = p.root_dir.join("node_modules");
+    // Build the chunk-local npm namespace map — every npm module IN THIS
+    // CHUNK gets an entry, regardless of chunk kind. Vendor and lazy
+    // chunks may own npm modules under the new partition rule, and those
+    // modules must be IIFE-wrapped exactly the way main did historically.
+    // Cross-chunk relative imports (an npm module in this chunk referring
+    // to one in a sibling chunk) fall back to `p.all_file_to_ns`.
     let mut file_to_namespace: HashMap<PathBuf, String> = HashMap::new();
-    let mut specifier_to_namespace: HashMap<String, String> = HashMap::new();
-
-    if !is_lazy {
-        // First pass: assign namespaces to all npm modules in this chunk
-        for module_path in p.module_paths {
-            let is_npm = module_path
-                .components()
-                .any(|c| c.as_os_str() == "node_modules");
-            if is_npm {
-                let ns = crate::npm_wrap::namespace_from_path(module_path, &node_modules_dir);
-                debug!(path = %module_path.display(), namespace = %ns, "assigned npm namespace");
-                file_to_namespace.insert(module_path.clone(), ns);
-            }
-        }
-        debug!(
-            npm_module_count = file_to_namespace.len(),
-            total_modules = p.module_paths.len(),
-            "npm namespace assignment complete"
-        );
-
-        // Build specifier → namespace mapping for project code and npm cross-references.
-        // Resolve each bare specifier to its actual entry file path and look up the namespace.
-        for spec in p.bundled_specifiers.iter() {
-            // Try to resolve the specifier to its entry file using the npm resolver
-            if let Ok(entry_path) = ngc_npm_resolver::resolve::resolve_bare_specifier(
-                spec,
-                node_modules_dir.parent().unwrap_or(&node_modules_dir),
-                p.export_conditions,
-            ) {
-                let canonical =
-                    cached_canonicalize(p.canon_cache, &entry_path).unwrap_or(entry_path);
-                if let Some(ns) = file_to_namespace.get(&canonical) {
-                    specifier_to_namespace.insert(spec.clone(), ns.clone());
-                    continue;
-                }
-            }
-            // Fallback: for vendored/synthetic modules (e.g., @oxc-project/runtime/helpers/decorate)
-            // that don't have a package.json, match by path suffix in the file_to_namespace map.
-            let spec_path_suffix = spec.replace('/', std::path::MAIN_SEPARATOR_STR);
-            for (path, ns) in &file_to_namespace {
-                let path_str = path.to_string_lossy();
-                if path_str.contains(&spec_path_suffix) {
-                    specifier_to_namespace.insert(spec.clone(), ns.clone());
-                    break;
-                }
-            }
+    for module_path in p.module_paths {
+        if let Some(ns) = p.all_file_to_ns.get(module_path) {
+            file_to_namespace.insert(module_path.clone(), ns.clone());
         }
     }
+    debug!(
+        chunk_idx = p.chunk_idx,
+        npm_module_count = file_to_namespace.len(),
+        total_modules = p.module_paths.len(),
+        "npm namespace assignment complete"
+    );
 
     // Per-module work is independent: each module only reads immutable
     // pre-built maps (`file_to_namespace`, `specifier_to_namespace`, chunk
     // params) plus its own source code, and emits an optional ModuleSection
     // plus zero or more ExternalImports. Fan out across rayon workers and
     // merge the results back into `sections` / `all_externals` afterwards.
-    let empty_specifiers: HashSet<String> = HashSet::new();
-    let empty_ns_map: HashMap<String, String> = HashMap::new();
-    let empty_prefixes: Vec<&str> = Vec::new();
-
     let per_module: Vec<(Option<ModuleSection>, Vec<ExternalImport>)> = p
         .module_paths
         .par_iter()
@@ -599,6 +621,10 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
 
                 if is_npm {
                     // NPM module: wrap in IIFE with namespace isolation.
+                    // The wrap closure resolves to canonical `__ns_*` names
+                    // regardless of whether the target lives in this chunk
+                    // or another — cross-chunk refs become imports at the
+                    // chunk's top, emitted in the post-process pass.
                     let namespace = &file_to_namespace[module_path];
                     let wrapped = crate::npm_wrap::wrap_npm_module(
                         js_code,
@@ -618,14 +644,14 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
                                     if let Some(canonical) =
                                         cached_canonicalize(p.canon_cache, candidate)
                                     {
-                                        if let Some(ns) = file_to_namespace.get(&canonical) {
+                                        if let Some(ns) = p.all_file_to_ns.get(&canonical) {
                                             return Some(ns.clone());
                                         }
                                     }
                                 }
                                 None
                             } else {
-                                specifier_to_namespace.get(specifier).cloned()
+                                p.specifier_to_namespace_global.get(specifier).cloned()
                             }
                         },
                     )?;
@@ -633,15 +659,24 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
                     let section = build_section(&wrapped.wrapped_code, module_path, p.root_dir);
                     Ok((section, Vec::new()))
                 } else {
-                    // Project module: use existing rewriter with namespace map.
-                    // For lazy/shared chunks, pass empty prefixes/bundled so ALL
-                    // imports are collected as external (for cross-chunk
-                    // resolution).
-                    let (effective_prefixes, effective_bundled, effective_ns_map) = if is_lazy {
-                        (empty_prefixes.as_slice(), &empty_specifiers, &empty_ns_map)
-                    } else {
-                        (p.prefix_refs, p.bundled_specifiers, &specifier_to_namespace)
-                    };
+                    // Project module: rewrite bare specifiers to `var X =
+                    // __ns_Y.X;` references using the global namespace map,
+                    // regardless of chunk kind. Same behavior in lazy and
+                    // vendor chunks as main — cross-chunk `__ns_*` refs are
+                    // detected and imported by the post-process pass.
+                    //
+                    // Previously lazy chunks used `empty_ns_map`, which
+                    // forced every bare import to become a hoisted external
+                    // routed through `./main.js`. With vendor splitting that
+                    // created cycles (main has to re-export bare names
+                    // backed by an `__ns_*` it has to import from a vendor
+                    // chunk), eagerly loading lazy chunks via main's static
+                    // import graph.
+                    let (effective_prefixes, effective_bundled, effective_ns_map) = (
+                        p.prefix_refs,
+                        p.bundled_specifiers,
+                        p.specifier_to_namespace_global,
+                    );
 
                     let module_unused = p.unused_exports.get(module_path);
                     let is_chunk_entry = module_path == p.chunk_entry;
@@ -676,9 +711,14 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
         all_externals.extend(externals);
     }
 
-    // For lazy/shared chunks, all remaining externals are cross-chunk imports
-    // (same-chunk imports were already filtered in the per-module loop above).
-    // Merge them all into a single import from ./main.js.
+    // For lazy/shared chunks, remaining externals are cross-chunk imports.
+    // Project symbols (bare-named exports of main) still route through
+    // `./main.js`. NPM bare-named symbols ALSO route through `./main.js`
+    // — main re-exports them from whatever vendor chunk owns the
+    // namespace (the post-process pass wires main's vendor imports).
+    // Vendor chunks' direct `__ns_*` references are not collected here;
+    // the post-process pass scans the emitted code and emits cross-chunk
+    // imports for them.
     let mut npm_externals: Vec<ExternalImport> = Vec::new();
     let mut project_cross_chunk_symbols: BTreeSet<String> = BTreeSet::new();
     if is_lazy {
@@ -686,8 +726,6 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
         let mut main_js_default = None;
 
         for ext in all_externals {
-            // Classify: npm externals go through namespace lookup, project externals
-            // are already top-level declarations in main.js.
             let is_from_npm = ext.source.starts_with("__resolved_ns__")
                 || ext.source.starts_with("__npm_")
                 || p.bundled_specifiers.contains(&ext.source)
@@ -697,7 +735,6 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
             if is_from_npm {
                 npm_externals.push(ext.clone());
             } else {
-                // Project symbol — already in main chunk scope
                 for name in &ext.named_imports {
                     let local = name.strip_prefix("* as ").unwrap_or(name);
                     project_cross_chunk_symbols.insert(local.to_string());
@@ -707,7 +744,6 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
                 }
             }
 
-            // Collect all symbols for the ./main.js import
             for name in &ext.named_imports {
                 if let Some(local) = name.strip_prefix("* as ") {
                     main_js_named.insert(local.to_string());
@@ -722,9 +758,6 @@ fn bundle_chunk(p: &ChunkBundleParams<'_>) -> NgcResult<ChunkBundleResult> {
 
         all_externals = Vec::new();
 
-        // Merge all cross-chunk imports into a single import from ./main.js.
-        // Convert default imports to named imports because main.js uses
-        // `export { sym }` (named), not `export default`.
         if let Some(default_name) = main_js_default {
             main_js_named.insert(default_name);
         }
@@ -892,7 +925,7 @@ fn classify_lazy_externals(
                         target.join("index.mjs"),
                     ] {
                         if let Some(canon) = cached_canonicalize(p.canon_cache, c) {
-                            if let Some(ns) = p.main_file_to_ns.get(&canon) {
+                            if let Some(ns) = p.all_file_to_ns.get(&canon) {
                                 resolved_ext.source = format!("__resolved_ns__{ns}");
                                 break;
                             }
@@ -1011,6 +1044,144 @@ fn generate_cross_chunk_exports(
     code
 }
 
+/// Wire cross-chunk `__ns_*` namespace references between chunks.
+///
+/// Each chunk's emitted code references `__ns_X` namespace identifiers
+/// from any npm module the chunk reaches. With vendor splitting an
+/// `__ns_X` is declared in exactly one chunk; consumer chunks must import
+/// it via static ESM. Owner chunks must export it.
+///
+/// We do this as a regex post-process pass over the already-emitted code
+/// (rather than threading "what references did we make?" through the
+/// per-module rewriter), which is correctness-equivalent: every
+/// `__ns_*` identifier in the bundle was generated by the bundler from
+/// `namespace_from_path`, so the regex matches exactly the universe of
+/// names we care about. Local declarations are recognised by the `var
+/// __ns_X = {};` line the IIFE wrapper always emits — `analyze_unused_exports`
+/// never removes those because the `var` is referenced by the surrounding
+/// IIFE's `(...)( __ns_X )` invocation.
+///
+/// Returns: for each owner chunk filename, the set of consumer chunk
+/// filenames. Used by the caller to populate `BundleOutput.initial_chunks`
+/// (any vendor chunk consumed by main is eagerly loaded).
+fn wire_cross_chunk_namespace_imports(
+    chunks: &mut HashMap<String, String>,
+    namespace_to_chunk_idx: &HashMap<String, usize>,
+    chunk_filename_by_idx: &[String],
+) -> NgcResult<HashMap<String, BTreeSet<String>>> {
+    use regex::Regex;
+
+    // The bundler's `__ns_*` names sanitize the relative path with
+    // `[A-Za-z0-9_]` (see `npm_wrap::namespace_from_path`). Match the
+    // full character set so we don't miss namespaces whose underlying
+    // file path contains uppercase characters.
+    let ns_re = Regex::new(r"\b__ns_[A-Za-z0-9_]+\b").expect("regex compiles");
+    let var_decl_re =
+        Regex::new(r"var\s+(__ns_[A-Za-z0-9_]+)\s*=").expect("regex compiles");
+
+    // imports_by_chunk[consumer_filename][owner_filename] = set of __ns_X
+    let mut imports_by_chunk: HashMap<String, HashMap<String, BTreeSet<String>>> =
+        HashMap::new();
+
+    for (filename, code) in chunks.iter() {
+        let mut used: HashSet<String> = HashSet::new();
+        for cap in ns_re.find_iter(code) {
+            used.insert(cap.as_str().to_string());
+        }
+        let mut declared: HashSet<String> = HashSet::new();
+        for cap in var_decl_re.captures_iter(code) {
+            if let Some(m) = cap.get(1) {
+                declared.insert(m.as_str().to_string());
+            }
+        }
+
+        for ns in &used {
+            if declared.contains(ns) {
+                continue;
+            }
+            let Some(&owner_idx) = namespace_to_chunk_idx.get(ns) else {
+                continue;
+            };
+            let owner_filename = &chunk_filename_by_idx[owner_idx];
+            if owner_filename == filename {
+                continue;
+            }
+            imports_by_chunk
+                .entry(filename.clone())
+                .or_default()
+                .entry(owner_filename.clone())
+                .or_default()
+                .insert(ns.clone());
+        }
+    }
+
+    // owner → set of consumers
+    let mut consumers_by_owner: HashMap<String, BTreeSet<String>> = HashMap::new();
+    // owner → union of all __ns_* names consumers need from it
+    let mut exported_ns_by_owner: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for (consumer, owners) in &imports_by_chunk {
+        for (owner, ns_set) in owners {
+            consumers_by_owner
+                .entry(owner.clone())
+                .or_default()
+                .insert(consumer.clone());
+            exported_ns_by_owner
+                .entry(owner.clone())
+                .or_default()
+                .extend(ns_set.iter().cloned());
+        }
+    }
+
+    // Prepend imports to each consumer.
+    for (consumer_filename, owners) in &imports_by_chunk {
+        let Some(code) = chunks.get_mut(consumer_filename) else {
+            continue;
+        };
+        let mut owner_filenames: Vec<&String> = owners.keys().collect();
+        owner_filenames.sort();
+        let mut imports = String::new();
+        for owner_filename in owner_filenames {
+            let ns_set = &owners[owner_filename];
+            let names: Vec<&str> = ns_set.iter().map(|s| s.as_str()).collect();
+            imports.push_str(&format!(
+                "import {{ {} }} from './{}';\n",
+                names.join(", "),
+                owner_filename
+            ));
+        }
+        let mut new_code = imports;
+        new_code.push_str(code);
+        *code = new_code;
+    }
+
+    // Append exports to each owner.
+    for (owner_filename, ns_set) in &exported_ns_by_owner {
+        let Some(code) = chunks.get_mut(owner_filename) else {
+            continue;
+        };
+        let names: Vec<&str> = ns_set.iter().map(|s| s.as_str()).collect();
+        if !code.ends_with('\n') {
+            code.push('\n');
+        }
+        code.push_str(&format!("export {{ {} }};\n", names.join(", ")));
+    }
+
+    Ok(consumers_by_owner)
+}
+
+/// Recognise the `chunk-<8hex>.js` vendor filename shape produced by
+/// `chunk::vendor_chunk_filename` so we can skip content-hashing those —
+/// they already carry a stable path-derived hash.
+fn is_vendor_chunk_filename(filename: &str) -> bool {
+    let Some(rest) = filename.strip_prefix("chunk-") else {
+        return false;
+    };
+    let Some(hex) = rest.strip_suffix(".js") else {
+        return false;
+    };
+    hex.len() == 8 && hex.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 /// Compute a truncated SHA-256 content hash (8 hex characters).
 fn content_hash(content: &str) -> String {
     use sha2::{Digest, Sha256};
@@ -1035,9 +1206,18 @@ fn apply_content_hashes(
     let filenames: Vec<String> = chunks.keys().cloned().collect();
     let mut rename_map: HashMap<String, String> = HashMap::new();
 
-    // Process non-main chunks first (they might be referenced by main)
+    // Process non-main chunks first (they might be referenced by main).
+    // Vendor chunks (`chunk-<8hex>.js` per `vendor_chunk_filename`) are
+    // already path-hashed and stable across builds; rehashing them would
+    // make the filename depend on cross-chunk-import emission order (since
+    // their content includes `import { __ns_X } from './chunk-YYYY.js'`
+    // lines whose filenames could change). Skip them so the path-derived
+    // hash remains the canonical identifier.
     for filename in &filenames {
         if filename == "main.js" {
+            continue;
+        }
+        if is_vendor_chunk_filename(filename) {
             continue;
         }
         let code = chunks.get(filename).ok_or_else(|| NgcError::BundleError {

--- a/crates/bundler/tests/vendor_chunk_splitting_integration.rs
+++ b/crates/bundler/tests/vendor_chunk_splitting_integration.rs
@@ -1,0 +1,303 @@
+//! End-to-end integration for vendor (shared) chunk splitting — issue #131.
+//!
+//! Drives the full `resolve_project` → `resolve_npm_dependencies` → `bundle`
+//! pipeline against a synthetic project where an npm package is imported by
+//! multiple lazy routes. Asserts that:
+//!
+//! 1. The npm package is extracted into a `chunk-<8hex>.js` vendor chunk
+//!    (rather than being duplicated across consumers or folded into main).
+//! 2. Both lazy chunks reference the vendor chunk via static ESM cross-chunk
+//!    imports.
+//! 3. The vendor chunk exports its `__ns_*` namespace.
+//! 4. The vendor chunk filename is deterministic across builds (same module
+//!    membership → same filename).
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use ngc_bundler::{bundle, BundleInput, BundleOptions, ChunkKind};
+use ngc_npm_resolver::package_json::DEVELOPMENT_BROWSER_CONDITIONS;
+use ngc_npm_resolver::resolve_npm_dependencies;
+use ngc_project_resolver::resolve_project;
+use tempfile::tempdir;
+
+/// Build the BundleInput for a synthetic project whose two lazy routes both
+/// statically import `shared-pkg`. Returns `(input, root_dir)`.
+fn build_two_lazy_routes_sharing_npm(root: &std::path::Path) -> BundleInput {
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.ts"], "exclude": [] }"#,
+    )
+    .expect("write tsconfig");
+
+    fs::write(
+        root.join("package.json"),
+        r#"{ "name": "vendor-fixture", "dependencies": { "shared-pkg": "1.0.0" } }"#,
+    )
+    .expect("write package.json");
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("create src");
+
+    // main.ts — dynamically imports both routes.
+    fs::write(
+        src.join("main.ts"),
+        "function loadA(){return import('./route-a');}\n\
+         function loadB(){return import('./route-b');}\n\
+         console.log(loadA, loadB);\n",
+    )
+    .expect("write main.ts");
+
+    // Both lazy routes statically import `shared-pkg`.
+    fs::write(
+        src.join("route-a.ts"),
+        "import { shared } from 'shared-pkg';\n\
+         export const A = () => shared('a');\n",
+    )
+    .expect("write route-a.ts");
+
+    fs::write(
+        src.join("route-b.ts"),
+        "import { shared } from 'shared-pkg';\n\
+         export const B = () => shared('b');\n",
+    )
+    .expect("write route-b.ts");
+
+    // The npm package's entry — an ESM module exporting `shared`.
+    let pkg_dir = root.join("node_modules").join("shared-pkg");
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "shared-pkg", "version": "1.0.0", "main": "index.mjs" }"#,
+    )
+    .expect("write pkg package.json");
+    fs::write(
+        pkg_dir.join("index.mjs"),
+        "export const shared = (x) => `shared:${x}`;\n",
+    )
+    .expect("write pkg index.mjs");
+
+    let file_graph = resolve_project(&root.join("tsconfig.json")).expect("resolve project");
+    let entry = file_graph
+        .entry_points
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "main.ts"))
+        .cloned()
+        .expect("main.ts should be an entry point");
+
+    let bare_specs: Vec<String> = file_graph.npm_import_sites.keys().cloned().collect();
+    let npm = resolve_npm_dependencies(&bare_specs, root, DEVELOPMENT_BROWSER_CONDITIONS)
+        .expect("npm resolution");
+
+    let mut graph = file_graph.graph;
+    let mut path_index = file_graph.path_index;
+    for path in npm.modules.keys() {
+        if !path_index.contains_key(path) {
+            let idx = graph.add_node(path.clone());
+            path_index.insert(path.clone(), idx);
+        }
+    }
+    // Wire bare specifier imports as static edges.
+    for (spec, sites) in &file_graph.npm_import_sites {
+        if let Some(target_path) = npm
+            .modules
+            .keys()
+            .find(|p| p.to_string_lossy().contains(&format!("/{spec}/")))
+        {
+            let to_idx = path_index[target_path];
+            for (from_file, kind) in sites {
+                if let Some(&from_idx) = path_index.get(from_file) {
+                    graph.add_edge(from_idx, to_idx, *kind);
+                }
+            }
+        }
+    }
+
+    let mut modules: HashMap<PathBuf, String> = HashMap::new();
+    for idx in graph.node_indices() {
+        let path = &graph[idx];
+        let source = npm
+            .modules
+            .get(path)
+            .cloned()
+            .or_else(|| fs::read_to_string(path).ok())
+            .unwrap_or_else(|| panic!("source missing for {}", path.display()));
+        modules.insert(path.clone(), source);
+    }
+
+    BundleInput {
+        modules,
+        graph,
+        entry,
+        local_prefixes: vec![".".to_string()],
+        root_dir: root.to_path_buf(),
+        options: BundleOptions::default(),
+        per_module_maps: HashMap::new(),
+        bundled_specifiers: npm.resolved_specifiers.clone(),
+        export_conditions: Vec::new(),
+    }
+}
+
+/// An npm module reached only by lazy chunks (≥2) is extracted into a vendor
+/// chunk named `chunk-<8hex>.js`. Main contains none of the npm module's code.
+#[test]
+fn shared_npm_across_lazy_routes_creates_vendor_chunk() {
+    let temp = tempdir().expect("create temp dir");
+    let input = build_two_lazy_routes_sharing_npm(temp.path());
+
+    let output = bundle(&input).expect("bundle succeeds");
+
+    // Locate the vendor chunk by ChunkKind::Shared.
+    let vendor_filenames: Vec<&String> = output
+        .chunk_kinds
+        .iter()
+        .filter(|(_, kind)| **kind == ChunkKind::Shared)
+        .map(|(name, _)| name)
+        .collect();
+    assert_eq!(
+        vendor_filenames.len(),
+        1,
+        "expected exactly one vendor chunk, got chunks={:?} kinds={:?}",
+        output.chunks.keys().collect::<Vec<_>>(),
+        output.chunk_kinds,
+    );
+    let vendor_name = vendor_filenames[0];
+
+    // Vendor chunk filename shape: `chunk-<8hex>.js`.
+    let hex = &vendor_name["chunk-".len().."chunk-".len() + 8];
+    assert!(
+        vendor_name.starts_with("chunk-")
+            && vendor_name.ends_with(".js")
+            && hex.chars().all(|c| c.is_ascii_hexdigit()),
+        "vendor filename should be chunk-<8hex>.js, got {vendor_name}"
+    );
+
+    // Vendor chunk contains the npm module's body.
+    let vendor_code = &output.chunks[vendor_name];
+    assert!(
+        vendor_code.contains("shared:"),
+        "vendor chunk should inline the npm module body: {vendor_code}"
+    );
+
+    // Main has none of the npm module.
+    let main_code = &output.chunks[&output.main_filename];
+    assert!(
+        !main_code.contains("shared:"),
+        "main should not contain the npm module body: {main_code}"
+    );
+}
+
+/// Vendor chunks have an `export { __ns_X };` block at the end and consumer
+/// chunks have a matching `import { __ns_X } from './chunk-XXXX.js';` block
+/// at the top. This is what makes the chunks actually link at module-load
+/// time in the browser.
+#[test]
+fn vendor_chunk_exports_namespace_and_consumers_import_it() {
+    let temp = tempdir().expect("create temp dir");
+    let input = build_two_lazy_routes_sharing_npm(temp.path());
+    let output = bundle(&input).expect("bundle succeeds");
+
+    let vendor_name = output
+        .chunk_kinds
+        .iter()
+        .find(|(_, k)| **k == ChunkKind::Shared)
+        .map(|(n, _)| n.clone())
+        .expect("vendor chunk");
+
+    let vendor_code = &output.chunks[&vendor_name];
+    assert!(
+        vendor_code.contains("export { __ns_"),
+        "vendor should export its __ns_* identifier: {vendor_code}"
+    );
+
+    // Consumer chunks (lazy routes) static-import from the vendor.
+    let lazy_filenames: Vec<&String> = output
+        .chunk_kinds
+        .iter()
+        .filter(|(_, k)| **k == ChunkKind::Lazy)
+        .map(|(n, _)| n)
+        .collect();
+    let mut at_least_one_consumer = false;
+    for lazy_name in &lazy_filenames {
+        let lazy_code = &output.chunks[*lazy_name];
+        if lazy_code.contains(&format!("from './{vendor_name}'")) {
+            at_least_one_consumer = true;
+        }
+    }
+    assert!(
+        at_least_one_consumer,
+        "at least one lazy chunk should statically import from the vendor chunk; \
+         vendor={vendor_name} lazy_filenames={lazy_filenames:?}"
+    );
+}
+
+/// Vendor chunks consumed only by lazy chunks (not by main) load
+/// transitively when the lazy chunk evaluates — they should NOT be in
+/// `BundleOutput.initial_chunks`.
+#[test]
+fn lazy_only_vendor_chunk_is_not_initial() {
+    let temp = tempdir().expect("create temp dir");
+    let input = build_two_lazy_routes_sharing_npm(temp.path());
+    let output = bundle(&input).expect("bundle succeeds");
+
+    let vendor_name = output
+        .chunk_kinds
+        .iter()
+        .find(|(_, k)| **k == ChunkKind::Shared)
+        .map(|(n, _)| n.clone())
+        .expect("vendor chunk");
+
+    // main + zero eager vendor = just main in initial_chunks.
+    assert_eq!(
+        output.initial_chunks,
+        vec![output.main_filename.clone()],
+        "lazy-only vendor should not be in initial_chunks; got {:?}",
+        output.initial_chunks
+    );
+    assert!(
+        !output.initial_chunks.contains(&vendor_name),
+        "vendor chunk {vendor_name} should not be eagerly loaded"
+    );
+}
+
+/// Determinism: bundling the same input twice produces byte-identical chunk
+/// filenames + content. Vendor naming hashes absolute module paths, so we
+/// build twice in the same temp directory (real builds have a stable project
+/// root). Path-hash-based naming + the deterministic toposort + BTreeMap
+/// iteration combine to guarantee this.
+#[test]
+fn vendor_chunk_partition_is_deterministic_across_builds() {
+    let temp = tempdir().expect("temp dir");
+    let input_a = build_two_lazy_routes_sharing_npm(temp.path());
+    let input_b = build_two_lazy_routes_sharing_npm(temp.path());
+
+    let out_a = bundle(&input_a).expect("bundle a");
+    let out_b = bundle(&input_b).expect("bundle b");
+
+    let mut vendors_a: Vec<&String> = out_a
+        .chunk_kinds
+        .iter()
+        .filter(|(_, k)| **k == ChunkKind::Shared)
+        .map(|(n, _)| n)
+        .collect();
+    let mut vendors_b: Vec<&String> = out_b
+        .chunk_kinds
+        .iter()
+        .filter(|(_, k)| **k == ChunkKind::Shared)
+        .map(|(n, _)| n)
+        .collect();
+    vendors_a.sort();
+    vendors_b.sort();
+    assert_eq!(
+        vendors_a, vendors_b,
+        "vendor chunk filenames should be deterministic across builds"
+    );
+
+    // Vendor chunk bodies should be byte-identical too.
+    for (name, _) in out_a.chunk_kinds.iter().filter(|(_, k)| **k == ChunkKind::Shared) {
+        let a_code = out_a.chunks.get(name).expect("vendor in out_a");
+        let b_code = out_b.chunks.get(name).expect("vendor in out_b");
+        assert_eq!(a_code, b_code, "vendor chunk {name} should be byte-stable");
+    }
+}

--- a/crates/bundler/tests/vendor_chunk_splitting_integration.rs
+++ b/crates/bundler/tests/vendor_chunk_splitting_integration.rs
@@ -295,7 +295,11 @@ fn vendor_chunk_partition_is_deterministic_across_builds() {
     );
 
     // Vendor chunk bodies should be byte-identical too.
-    for (name, _) in out_a.chunk_kinds.iter().filter(|(_, k)| **k == ChunkKind::Shared) {
+    for (name, _) in out_a
+        .chunk_kinds
+        .iter()
+        .filter(|(_, k)| **k == ChunkKind::Shared)
+    {
         let a_code = out_a.chunks.get(name).expect("vendor in out_a");
         let b_code = out_b.chunks.get(name).expect("vendor in out_b");
         assert_eq!(a_code, b_code, "vendor chunk {name} should be byte-stable");


### PR DESCRIPTION
## Summary

Implements vendor chunk splitting per the issue's spec: extract npm modules referenced by 2+ chunks into content-hashed `chunk-<8hex>.js` vendor chunks. Closes #131. **PR-2 of 2** on the `feat/vendor-chunks` milestone; stacked on top of #168.

## Results on test-ng-project (production build)

|                  | before    | after     | target            |
|------------------|-----------|-----------|-------------------|
| `main.js`        | 1.5 MB    | **83 KB** | < 200 KB ✅       |
| Initial total    | ~1.7 MB   | **885 KB**| within 20% of \`ng build\`'s 917 KB ✅ (96.5%) |
| Build time       | 536 ms    | **477 ms**| within 10% of v1.0.0's 536 ms ✅ |
| Initial chunks   | 1 (main)  | 7         | match \`ng build\` shape ✅ |
| Lazy-only vendor | 0         | 2         | (loaded transitively) |

## What changes

### Partition rule (chunk.rs)

For each npm module, compute its importer-set: the set of chunk roots (Main + each non-worker Lazy) that statically reach it.

  - \`|set| == 1, {Main}\`     → main.js
  - \`|set| == 1, {Lazy(x)}\`  → chunk x (inline — new; used to force into main)
  - \`|set| >= 2\`             → vendor chunk grouped by identical importer-set

Project (non-npm) modules with ≥2 consumers keep today's fold-to-main behavior — the issue scopes vendor splitting to \`node_modules/\` only. Workers stay self-contained (separate ESM realm; can't import non-worker chunks).

Vendor chunks are named \`chunk-<8hex>.js\`, where the hex is the first 8 characters of SHA-256 over the sorted set of canonical module paths.

### Cross-chunk wiring (concat.rs)

\`bundle_chunk\` now IIFE-wraps npm modules in every chunk (not just main). After per-chunk fan-out, a post-process pass scans each chunk's code for \`__ns_*\` identifiers, looks up each one's owning chunk, and emits:

  - \`import { __ns_X } from './<owner>.js';\` at the top of consumers
  - \`export { __ns_X };\` at the bottom of owners

The project-module rewriter now uses the global \`specifier_to_namespace\` map for lazy chunks too. Previously lazy chunks routed bare npm symbols through \`./main.js\`, which under vendor splitting created a main↔vendor cycle that eagerly loaded lazy chunks via main's static import graph. The new uniform behavior breaks the cycle.

### Initial chunks + HTML injection

\`BundleOutput.initial_chunks\` now lists main + every eager vendor chunk (those whose importer-set contains Main). \`generate_index_html\` emits \`<script type=\"module\">\` per entry. Lazy-only vendor chunks load transitively through their lazy consumers.

\`apply_content_hashes\` skips vendor chunks — their \`chunk-<8hex>.js\` names are already path-derived and stable.

## Tests

- [x] 7 new \`chunk.rs\` unit tests covering single-lazy inline, 2-lazy vendor, main+lazy eager vendor, importer-set grouping, filename regex, determinism
- [x] 4 new \`vendor_chunk_splitting_integration.rs\` tests driving the full \`resolve_project\` → \`resolve_npm_dependencies\` → \`bundle\` pipeline with a synthetic npm package shared between two lazy routes
- [x] All existing \`defer\` / \`worker\` / \`subpath\` / \`chunk\` / \`concat\` / \`shake\` tests stay green
- [x] Manual end-to-end build of test-ng-project at \`/Users/lukaskania/Coding/Private/test/test-ng-project\` — \`dist/\` matches \`ng build\` chunk shape, app loads, main.js < 200 KB

## Follow-up

Per-provider tree-shake for vendor chunks is deferred. Vendor chunks currently emit every export of every npm module they contain — \`@angular/core\` + \`rxjs\` together hit ~444 KB in the largest vendor chunk. A per-provider \`externally_used\` union (extension of today's main-only \`collect_cross_chunk_used_names\`) would shrink vendor chunks further. Not blocking the issue's targets.