### PR TITLE
feat(dev-server): /@ng/component endpoint + HMR runtime bus (#145)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -279,6 +279,17 @@ enum Commands {
         /// `@angular/build:dev-server`.
         #[arg(long = "ssl-cert")]
         ssl_cert: Option<PathBuf>,
+        /// Enable Hot Module Replacement: edits to component templates and
+        /// styles (and global stylesheets) are applied in place without a
+        /// full page reload, preserving component and form state. Overrides
+        /// `architect.serve.options.hmr` in `angular.json`. Mirrors the `hmr`
+        /// option of `@angular/build:dev-server`.
+        #[arg(long, conflicts_with = "no_hmr")]
+        hmr: bool,
+        /// Disable Hot Module Replacement, forcing a full page reload on every
+        /// rebuild. Overrides `architect.serve.options.hmr` in `angular.json`.
+        #[arg(long = "no-hmr", conflicts_with = "hmr")]
+        no_hmr: bool,
     },
     /// Extract translatable messages from every component template in the
     /// project and emit a translation file (XLIFF 2.0 by default; XLIFF 1.2
@@ -410,6 +421,8 @@ fn main() {
             ssl,
             ssl_key,
             ssl_cert,
+            hmr,
+            no_hmr,
         } => {
             let parsed_headers = match parse_header_overrides(headers.as_deref()) {
                 Ok(h) => h,
@@ -417,6 +430,15 @@ fn main() {
                     eprintln!("{} {e}", "Error:".red().bold());
                     process::exit(1);
                 }
+            };
+            // CLI flags win over angular.json: `--hmr` → Some(true),
+            // `--no-hmr` → Some(false), neither → None (inherit config).
+            let hmr_override = if hmr {
+                Some(true)
+            } else if no_hmr {
+                Some(false)
+            } else {
+                None
             };
             if let Err(e) = serve_cmd::run(
                 &project,
@@ -430,6 +452,7 @@ fn main() {
                 ssl,
                 ssl_key.as_deref(),
                 ssl_cert.as_deref(),
+                hmr_override,
             ) {
                 eprintln!("{} {e}", "Error:".red().bold());
                 process::exit(1);
@@ -1883,7 +1906,7 @@ pub(crate) fn resolve_out_dir(
 }
 
 /// Try to find angular.json by searching upward from the project file's directory.
-fn find_and_resolve_angular_json(
+pub(crate) fn find_and_resolve_angular_json(
     project: &Path,
     configuration: Option<&str>,
 ) -> NgcResult<Option<ResolvedAngularProject>> {

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -40,6 +40,7 @@ pub fn run(
     ssl: bool,
     ssl_key: Option<&Path>,
     ssl_cert: Option<&Path>,
+    hmr_override: Option<bool>,
 ) -> NgcResult<()> {
     run_with_stop(
         project,
@@ -53,6 +54,7 @@ pub fn run(
         ssl,
         ssl_key,
         ssl_cert,
+        hmr_override,
         install_ctrlc,
     )
 }
@@ -121,12 +123,32 @@ pub(crate) fn run_with_stop(
     ssl: bool,
     ssl_key: Option<&Path>,
     ssl_cert: Option<&Path>,
+    hmr_override: Option<bool>,
     install_stop: impl FnOnce(Arc<AtomicBool>),
 ) -> NgcResult<()> {
     let tls = resolve_tls(ssl, ssl_key, ssl_cert, host)?;
 
     let out_dir = crate::resolve_out_dir(project, None, configuration)?;
     let mut cache = BuildCache::new();
+
+    // Resolve HMR: CLI `--hmr`/`--no-hmr` wins; otherwise inherit
+    // `architect.serve.options.hmr` from angular.json (default `false`).
+    // Also collect the absolute paths of the global stylesheet entries so a
+    // rebuild that touches only those can be classified as a CSS-only update.
+    let resolved = crate::find_and_resolve_angular_json(project, configuration)?;
+    let hmr_enabled = hmr_override.unwrap_or_else(|| resolved.as_ref().map(|p| p.hmr).unwrap_or(false));
+    let global_style_paths: std::collections::HashSet<PathBuf> = resolved
+        .as_ref()
+        .map(|p| {
+            p.styles
+                .iter()
+                .map(|s| canonical_or_owned(&s.path))
+                .collect()
+        })
+        .unwrap_or_default();
+    if hmr_enabled {
+        eprintln!("{}", "ngc-rs HMR enabled".bold().green());
+    }
 
     // Normalize the user-supplied servePath up-front so the dev server
     // mount and the index.html `<base href>` fallback agree on the
@@ -185,6 +207,9 @@ pub(crate) fn run_with_stop(
     let project_path = project.to_path_buf();
     let configuration_owned = configuration.map(|s| s.to_string());
     let serve_path_owned = normalized_serve_path.clone();
+    // Monotonic cache-buster for the swapped `styles.css` href on CSS-only
+    // updates; must change every rebuild so the browser re-fetches.
+    let mut hmr_tick: u64 = 0;
 
     let build_fn = move |dirty: &[PathBuf]| -> NgcResult<()> {
         if dirty.iter().any(|p| !is_ts_path(p)) {
@@ -209,7 +234,19 @@ pub(crate) fn run_with_stop(
                     result.modules_bundled,
                     dirty.len()
                 );
-                if event_tx.send(DevServerEvent::Reload).is_err() {
+                // CSS-only fast path: when HMR is on and every changed file is
+                // a global stylesheet entry, swap `styles.css` in place
+                // instead of reloading (preserving component/form state).
+                let css_only = hmr_enabled && is_global_css_only_change(dirty, &global_style_paths);
+                let event = if css_only {
+                    hmr_tick += 1;
+                    DevServerEvent::CssUpdate {
+                        timestamp: hmr_tick,
+                    }
+                } else {
+                    DevServerEvent::Reload
+                };
+                if event_tx.send(event).is_err() {
                     tracing::debug!("dev server event channel closed");
                 }
                 Ok(())
@@ -247,6 +284,28 @@ pub(crate) fn build_failure_event(err: &NgcError) -> DevServerEvent {
         line,
         column,
     }
+}
+
+/// Canonicalize `path`, falling back to its owned form when canonicalization
+/// fails (e.g. the file was deleted between resolve and compare). Used so the
+/// watcher's emitted paths and the resolved style paths compare equal even
+/// across symlinks.
+fn canonical_or_owned(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// True when a rebuild's `dirty` set is non-empty and every changed file is a
+/// global stylesheet entry — the case where HMR can swap `styles.css` in place
+/// instead of reloading. An empty set (or any non-stylesheet change) returns
+/// `false`, falling back to a full reload.
+fn is_global_css_only_change(
+    dirty: &[PathBuf],
+    global_style_paths: &std::collections::HashSet<PathBuf>,
+) -> bool {
+    !dirty.is_empty()
+        && dirty
+            .iter()
+            .all(|p| global_style_paths.contains(&canonical_or_owned(p)))
 }
 
 fn error_location(err: &NgcError) -> (Option<PathBuf>, Option<u32>, Option<u32>) {
@@ -447,6 +506,48 @@ mod tests {
         )
         .expect_err("missing file should error");
         assert!(matches!(err, NgcError::Io { .. }));
+    }
+
+    #[test]
+    fn css_only_change_classification() {
+        use std::collections::HashSet;
+        let styles: HashSet<PathBuf> = [PathBuf::from("/proj/src/styles.css"), PathBuf::from("/proj/src/theme.scss")]
+            .into_iter()
+            .collect();
+
+        // All dirty files are global stylesheets → CSS-only.
+        assert!(is_global_css_only_change(
+            &[PathBuf::from("/proj/src/styles.css")],
+            &styles
+        ));
+        assert!(is_global_css_only_change(
+            &[
+                PathBuf::from("/proj/src/styles.css"),
+                PathBuf::from("/proj/src/theme.scss")
+            ],
+            &styles
+        ));
+
+        // A non-stylesheet change (or a stylesheet not in the global set)
+        // forces a full reload.
+        assert!(!is_global_css_only_change(
+            &[PathBuf::from("/proj/src/app.component.ts")],
+            &styles
+        ));
+        assert!(!is_global_css_only_change(
+            &[
+                PathBuf::from("/proj/src/styles.css"),
+                PathBuf::from("/proj/src/app.component.ts")
+            ],
+            &styles
+        ));
+        assert!(!is_global_css_only_change(
+            &[PathBuf::from("/proj/src/app.component.css")],
+            &styles
+        ));
+
+        // Empty dirty set never qualifies.
+        assert!(!is_global_css_only_change(&[], &styles));
     }
 
     #[test]

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -17,8 +17,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use colored::Colorize;
-use ngc_dev_server::{DevServer, DevServerConfig, DevServerEvent, TlsConfig};
+use ngc_dev_server::{
+    ComponentUpdates, DevServer, DevServerConfig, DevServerEvent, TlsConfig, HMR_RUNTIME_PRELUDE,
+};
 use ngc_diagnostics::{NgcError, NgcResult};
 use ngc_watch::{Watcher, WatcherConfig};
 
@@ -174,6 +179,17 @@ pub(crate) fn run_with_stop(
         initial.output_files.len(),
     );
 
+    // Shared registry of per-component HMR update modules served at
+    // `/@ng/component`. Empty until the compiler emits update modules; we
+    // share one handle between the dev server and the rebuild callback.
+    let component_updates: ComponentUpdates = Arc::new(Mutex::new(HashMap::new()));
+
+    // When HMR is on, bind `import.meta.hot` inside the entry module so the
+    // per-component initializers can register update handlers.
+    if hmr_enabled {
+        inject_hmr_runtime(&out_dir);
+    }
+
     let (event_tx, event_rx) = channel::<DevServerEvent>();
     let cfg = DevServerConfig::new(&out_dir)
         .with_host(host.to_string())
@@ -181,7 +197,8 @@ pub(crate) fn run_with_stop(
         .with_serve_path(normalized_serve_path.as_deref())
         .with_allowed_hosts(allowed_hosts.iter().cloned())
         .with_headers(headers.iter().cloned())
-        .with_tls(tls);
+        .with_tls(tls)
+        .with_component_updates(Arc::clone(&component_updates));
     let server = DevServer::start(cfg, event_rx)?;
     let scheme = server.scheme();
     let url = match server.serve_path() {
@@ -207,6 +224,7 @@ pub(crate) fn run_with_stop(
     let project_path = project.to_path_buf();
     let configuration_owned = configuration.map(|s| s.to_string());
     let serve_path_owned = normalized_serve_path.clone();
+    let out_dir_owned = out_dir.clone();
     // Monotonic cache-buster for the swapped `styles.css` href on CSS-only
     // updates; must change every rebuild so the browser re-fetches.
     let mut hmr_tick: u64 = 0;
@@ -234,6 +252,10 @@ pub(crate) fn run_with_stop(
                     result.modules_bundled,
                     dirty.len()
                 );
+                // Re-bind `import.meta.hot` in the freshly written entry chunk.
+                if hmr_enabled {
+                    inject_hmr_runtime(&out_dir_owned);
+                }
                 // CSS-only fast path: when HMR is on and every changed file is
                 // a global stylesheet entry, swap `styles.css` in place
                 // instead of reloading (preserving component/form state).
@@ -292,6 +314,33 @@ pub(crate) fn build_failure_event(err: &NgcError) -> DevServerEvent {
 /// across symlinks.
 fn canonical_or_owned(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Prepend the HMR runtime prelude to the entry chunk (`main.js`) so the
+/// per-component HMR initializers can resolve `import.meta.hot`. The build
+/// rewrites `main.js` from scratch each cycle, so this runs after every
+/// successful build. A guard skips the work if the prelude is already present
+/// (defensive — a fresh build never has it). Failures are logged and ignored:
+/// a missing entry chunk just means HMR initializers won't bind, which
+/// degrades to live reload rather than breaking the served app.
+fn inject_hmr_runtime(out_dir: &Path) {
+    let main_js = out_dir.join("main.js");
+    let existing = match std::fs::read_to_string(&main_js) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!(path = %main_js.display(), error = %e, "no entry chunk to inject HMR runtime into");
+            return;
+        }
+    };
+    if existing.starts_with(HMR_RUNTIME_PRELUDE) {
+        return;
+    }
+    let mut patched = String::with_capacity(HMR_RUNTIME_PRELUDE.len() + existing.len());
+    patched.push_str(HMR_RUNTIME_PRELUDE);
+    patched.push_str(&existing);
+    if let Err(e) = std::fs::write(&main_js, patched) {
+        tracing::debug!(path = %main_js.display(), error = %e, "could not inject HMR runtime");
+    }
 }
 
 /// True when a rebuild's `dirty` set is non-empty and every changed file is a

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -46,10 +46,20 @@ use tiny_http::{Header, Method, Response, Server, SslConfig, StatusCode};
 ///
 /// * [`DevServerEvent::Reload`] → `event: reload`
 /// * [`DevServerEvent::BuildFailed`] → `event: build-failed`
+/// * [`DevServerEvent::CssUpdate`] → `event: css-update`
 #[derive(Debug, Clone)]
 pub enum DevServerEvent {
     /// A successful rebuild — connected browsers should refresh the page.
     Reload,
+    /// A successful rebuild that only changed global stylesheet(s). HMR
+    /// clients swap the `styles.css` `<link>` in place (cache-busting with
+    /// `timestamp`) without reloading the page, preserving component and
+    /// form state. Only emitted when HMR is enabled; otherwise a plain
+    /// [`DevServerEvent::Reload`] is sent.
+    CssUpdate {
+        /// Monotonic cache-buster appended to the swapped stylesheet href.
+        timestamp: u64,
+    },
     /// A rebuild failed — connected browsers should display an error
     /// overlay with the message and (when available) the offending file
     /// and source coordinates.
@@ -695,6 +705,9 @@ fn fanout_loop(rx: Receiver<DevServerEvent>, clients: SseClients) {
 pub fn sse_frame(event: &DevServerEvent) -> String {
     match event {
         DevServerEvent::Reload => "event: reload\ndata: rebuild\n\n".to_string(),
+        DevServerEvent::CssUpdate { timestamp } => {
+            format!("event: css-update\ndata: {{\"timestamp\":{timestamp}}}\n\n")
+        }
         DevServerEvent::BuildFailed {
             message,
             file,
@@ -1074,7 +1087,7 @@ pub fn mime_for(path: &Path) -> &'static str {
 /// Malformed `data:` payloads (non-JSON, missing keys) are tolerated and
 /// fall back to a generic "build failed" message rather than crashing the
 /// listener.
-pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);function swapCss(t){var links=document.querySelectorAll('link[rel="stylesheet"]');for(var i=0;i < links.length;i++){(function(link){var href=link.getAttribute('href');if(!href){return;}var base=href.split('?')[0];if(!/(^|\/)styles\.css$/.test(base)){return;}var next=link.cloneNode(false);next.setAttribute('href',base+'?ngcss='+t);next.addEventListener('load',function(){if(link.parentNode){link.parentNode.removeChild(link);}});next.addEventListener('error',function(){if(next.parentNode){next.parentNode.removeChild(next);}});link.parentNode.insertBefore(next,link.nextSibling);})(links[i]);}}var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});s.addEventListener('css-update',function(e){var t=0;try{t=(JSON.parse(e.data)||{}).timestamp||0;}catch(_){}if(!t){t=(new Date()).getTime();}dismiss();swapCss(t);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
 
 /// Insert the live-reload client script into an HTML byte buffer.
 ///
@@ -1243,6 +1256,38 @@ mod tests {
         assert_eq!(
             sse_frame(&DevServerEvent::Reload),
             "event: reload\ndata: rebuild\n\n"
+        );
+    }
+
+    #[test]
+    fn sse_frame_for_css_update_emits_named_event_with_timestamp() {
+        let frame = sse_frame(&DevServerEvent::CssUpdate { timestamp: 7 });
+        assert!(frame.starts_with("event: css-update\n"));
+        let data_line = frame.lines().nth(1).expect("data line");
+        let json: serde_json::Value = serde_json::from_str(
+            data_line.strip_prefix("data: ").expect("data: prefix"),
+        )
+        .expect("css-update payload is JSON");
+        assert_eq!(json["timestamp"], 7);
+        assert!(frame.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn live_reload_script_handles_css_update_in_place() {
+        // The injected client must subscribe to `css-update` and swap the
+        // global styles.css link instead of reloading the page.
+        assert!(LIVE_RELOAD_SCRIPT.contains("addEventListener('css-update'"));
+        assert!(LIVE_RELOAD_SCRIPT.contains("function swapCss"));
+        assert!(LIVE_RELOAD_SCRIPT.contains("styles\\.css"));
+        // CSS updates must not trigger a full reload.
+        let after_css = LIVE_RELOAD_SCRIPT
+            .split("addEventListener('css-update'")
+            .nth(1)
+            .expect("css-update handler present");
+        let handler_body = after_css.split("});").next().unwrap_or("");
+        assert!(
+            !handler_body.contains("location.reload"),
+            "css-update handler must not reload the page"
         );
     }
 

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -27,6 +27,7 @@
 //!   mounts a full-page error overlay (dismissible with `Esc`) showing the
 //!   build error and source location.
 
+use std::collections::HashMap;
 use std::io::Write;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::path::{Path, PathBuf};
@@ -60,6 +61,18 @@ pub enum DevServerEvent {
         /// Monotonic cache-buster appended to the swapped stylesheet href.
         timestamp: u64,
     },
+    /// A successful rebuild that changed only a single component's template
+    /// and/or styles. HMR clients re-fetch that component's update module
+    /// from `/@ng/component?c=<id>&t=<timestamp>` and call
+    /// `ɵɵreplaceMetadata` to swap it in place — no reload, state preserved.
+    /// `id` is the percent-encoded `relpath@ClassName` the compiler embeds in
+    /// the component's HMR initializer. Only emitted when HMR is enabled.
+    ComponentUpdate {
+        /// Percent-encoded component id (`encodeURIComponent("relpath@Class")`).
+        id: String,
+        /// Monotonic cache-buster matching the `t` query param on the fetch.
+        timestamp: u64,
+    },
     /// A rebuild failed — connected browsers should display an error
     /// overlay with the message and (when available) the offending file
     /// and source coordinates.
@@ -87,6 +100,14 @@ impl From<ReloadEvent> for DevServerEvent {
         DevServerEvent::Reload
     }
 }
+
+/// Shared registry of per-component HMR update modules, keyed by the
+/// percent-encoded component id (`encodeURIComponent("relpath@Class")`).
+/// The build pipeline replaces its contents after each rebuild; the
+/// `/@ng/component?c=<id>` endpoint reads it to serve the update module a
+/// running app dynamically imports. Cloning shares the same underlying map
+/// (`Arc`), so the serve loop and the build callback see each other's writes.
+pub type ComponentUpdates = Arc<Mutex<HashMap<String, String>>>;
 
 /// Configuration for [`DevServer`].
 #[derive(Debug, Clone)]
@@ -117,6 +138,10 @@ pub struct DevServerConfig {
     /// the long-lived SSE live-reload stream — is wrapped in TLS. Mirrors
     /// `@angular/build:dev-server`'s `ssl`/`sslKey`/`sslCert` options.
     pub tls: Option<TlsConfig>,
+    /// Registry of per-component HMR update modules served at
+    /// `/@ng/component?c=<id>`. Empty by default (live reload only); the
+    /// `serve` command shares a handle and populates it on each HMR rebuild.
+    pub component_updates: ComponentUpdates,
 }
 
 impl DevServerConfig {
@@ -131,7 +156,16 @@ impl DevServerConfig {
             allowed_hosts: Vec::new(),
             headers: Vec::new(),
             tls: None,
+            component_updates: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Share an external [`ComponentUpdates`] registry so the build pipeline
+    /// can publish per-component HMR update modules the `/@ng/component`
+    /// endpoint then serves. Pass a handle you retain a clone of.
+    pub fn with_component_updates(mut self, updates: ComponentUpdates) -> Self {
+        self.component_updates = updates;
+        self
     }
 
     /// Override the bind host.
@@ -571,6 +605,7 @@ impl DevServer {
         let allowed_hosts = Arc::new(AllowedHosts::resolve(&config.allowed_hosts, &config.host));
         let allowed_hosts_for_loop = Arc::clone(&allowed_hosts);
         let custom_headers = Arc::new(CustomHeaders::resolve(&config.headers));
+        let component_updates = Arc::clone(&config.component_updates);
         let join = thread::Builder::new()
             .name("ngc-dev-server-accept".into())
             .spawn(move || {
@@ -581,6 +616,7 @@ impl DevServer {
                     serve_path_for_loop,
                     allowed_hosts_for_loop,
                     custom_headers,
+                    component_updates,
                 )
             })
             .map_err(|e| NgcError::ServeError {
@@ -708,6 +744,12 @@ pub fn sse_frame(event: &DevServerEvent) -> String {
         DevServerEvent::CssUpdate { timestamp } => {
             format!("event: css-update\ndata: {{\"timestamp\":{timestamp}}}\n\n")
         }
+        DevServerEvent::ComponentUpdate { id, timestamp } => {
+            // `id` is already percent-encoded JS-identifier-safe text, but
+            // route it through serde so any stray quote can't break the JSON.
+            let payload = serde_json::json!({ "id": id, "timestamp": timestamp });
+            format!("event: angular:component-update\ndata: {payload}\n\n")
+        }
         DevServerEvent::BuildFailed {
             message,
             file,
@@ -725,6 +767,7 @@ pub fn sse_frame(event: &DevServerEvent) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn serve_loop(
     server: Arc<Server>,
     root: PathBuf,
@@ -732,6 +775,7 @@ fn serve_loop(
     serve_path: Option<String>,
     allowed_hosts: Arc<AllowedHosts>,
     headers: Arc<CustomHeaders>,
+    component_updates: ComponentUpdates,
 ) {
     for request in server.incoming_requests() {
         let root = root.clone();
@@ -739,6 +783,7 @@ fn serve_loop(
         let serve_path = serve_path.clone();
         let allowed_hosts = Arc::clone(&allowed_hosts);
         let headers = Arc::clone(&headers);
+        let component_updates = Arc::clone(&component_updates);
         thread::spawn(move || {
             if let Err(e) = handle_request(
                 request,
@@ -747,6 +792,7 @@ fn serve_loop(
                 serve_path.as_deref(),
                 &allowed_hosts,
                 &headers,
+                &component_updates,
             ) {
                 tracing::warn!(error = %e, "dev server request failed");
             }
@@ -754,6 +800,7 @@ fn serve_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_request(
     request: tiny_http::Request,
     root: &Path,
@@ -761,6 +808,7 @@ fn handle_request(
     serve_path: Option<&str>,
     allowed_hosts: &AllowedHosts,
     headers: &CustomHeaders,
+    component_updates: &ComponentUpdates,
 ) -> NgcResult<()> {
     if !matches!(request.method(), Method::Get | Method::Head) {
         let resp = Response::from_string("method not allowed").with_status_code(StatusCode(405));
@@ -787,7 +835,54 @@ fn handle_request(
         return handle_sse(request, clients, headers);
     }
 
+    if stripped == "/@ng/component" {
+        return handle_component_update(request, &url, component_updates, headers);
+    }
+
     serve_static(request, root, stripped, serve_path, headers)
+}
+
+/// Serve a per-component HMR update module for `GET /@ng/component?c=<id>`.
+///
+/// The `c` query value is the percent-encoded component id the compiler
+/// embedded in the component's HMR initializer; it's used verbatim as the
+/// registry key (the running app sends exactly what was embedded). When no
+/// module is registered for the id, an empty `200` is returned — the running
+/// app's loader guards on `m.default`, so an empty module is a safe no-op
+/// (mirrors `@angular/build`'s component middleware).
+fn handle_component_update(
+    request: tiny_http::Request,
+    url: &str,
+    component_updates: &ComponentUpdates,
+    headers: &CustomHeaders,
+) -> NgcResult<()> {
+    let Some(id) = query_param(url, "c") else {
+        let resp = Response::from_string("missing c parameter").with_status_code(StatusCode(400));
+        return request.respond(resp).map_err(io_err);
+    };
+    let code = component_updates
+        .lock()
+        .ok()
+        .and_then(|map| map.get(id).cloned())
+        .unwrap_or_default();
+    let mut resp = Response::from_data(code.into_bytes());
+    resp.add_header(header("Content-Type", "text/javascript")?);
+    resp.add_header(header("Cache-Control", "no-cache")?);
+    headers.apply(&mut resp, &["Content-Type", "Cache-Control"]);
+    request.respond(resp).map_err(io_err)
+}
+
+/// Extract a raw (still percent-encoded) query parameter value from a URL.
+///
+/// Returns the substring after `<name>=` up to the next `&`. The value is
+/// **not** percent-decoded: component ids are stored and matched in their
+/// encoded form, so decoding here would break the registry lookup.
+fn query_param<'a>(url: &'a str, name: &str) -> Option<&'a str> {
+    let query = url.split_once('?')?.1;
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == name).then_some(v)
+    })
 }
 
 /// Read the request's `Host:` header value, or return the empty string when
@@ -1087,7 +1182,18 @@ pub fn mime_for(path: &Path) -> &'static str {
 /// Malformed `data:` payloads (non-JSON, missing keys) are tolerated and
 /// fall back to a generic "build failed" message rather than crashing the
 /// listener.
-pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);function swapCss(t){var links=document.querySelectorAll('link[rel="stylesheet"]');for(var i=0;i < links.length;i++){(function(link){var href=link.getAttribute('href');if(!href){return;}var base=href.split('?')[0];if(!/(^|\/)styles\.css$/.test(base)){return;}var next=link.cloneNode(false);next.setAttribute('href',base+'?ngcss='+t);next.addEventListener('load',function(){if(link.parentNode){link.parentNode.removeChild(link);}});next.addEventListener('error',function(){if(next.parentNode){next.parentNode.removeChild(next);}});link.parentNode.insertBefore(next,link.nextSibling);})(links[i]);}}var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});s.addEventListener('css-update',function(e){var t=0;try{t=(JSON.parse(e.data)||{}).timestamp||0;}catch(_){}if(!t){t=(new Date()).getTime();}dismiss();swapCss(t);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);function swapCss(t){var links=document.querySelectorAll('link[rel="stylesheet"]');for(var i=0;i < links.length;i++){(function(link){var href=link.getAttribute('href');if(!href){return;}var base=href.split('?')[0];if(!/(^|\/)styles\.css$/.test(base)){return;}var next=link.cloneNode(false);next.setAttribute('href',base+'?ngcss='+t);next.addEventListener('load',function(){if(link.parentNode){link.parentNode.removeChild(link);}});next.addEventListener('error',function(){if(next.parentNode){next.parentNode.removeChild(next);}});link.parentNode.insertBefore(next,link.nextSibling);})(links[i]);}}var hmrHandlers={};function emitHmr(ev,d){var a=hmrHandlers[ev]||[];for(var i=0;i < a.length;i++){try{a[i](d);}catch(err){console.error('[ngc-rs] hmr handler error',err);}}}window.__ngcHmr={on:function(ev,cb){(hmrHandlers[ev]=hmrHandlers[ev]||[]).push(cb);},off:function(ev,cb){var a=hmrHandlers[ev];if(a){var i=a.indexOf(cb);if(i>=0){a.splice(i,1);}}},send:function(){}};var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});s.addEventListener('css-update',function(e){var t=0;try{t=(JSON.parse(e.data)||{}).timestamp||0;}catch(_){}if(!t){t=(new Date()).getTime();}dismiss();swapCss(t);});s.addEventListener('angular:component-update',function(e){var d={};try{d=JSON.parse(e.data)||{};}catch(_){}dismiss();emitHmr('angular:component-update',d);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+
+/// Module-scope prelude prepended to the entry chunk (`main.js`) when HMR is
+/// enabled. The per-component HMR initializers the compiler emits reference
+/// `import.meta.hot`, which only exists inside a module's `import.meta`; this
+/// binds it to the event bus the injected [`LIVE_RELOAD_SCRIPT`] publishes on
+/// `window.__ngcHmr`. The inline script runs before the deferred module, so
+/// `window.__ngcHmr` is already defined when this line executes. A no-op stub
+/// is used as a fallback so the bundle never throws if live reload failed to
+/// initialise.
+pub const HMR_RUNTIME_PRELUDE: &str =
+    "import.meta.hot=globalThis.__ngcHmr||{on:function(){},off:function(){},send:function(){}};\n";
 
 /// Insert the live-reload client script into an HTML byte buffer.
 ///
@@ -1289,6 +1395,42 @@ mod tests {
             !handler_body.contains("location.reload"),
             "css-update handler must not reload the page"
         );
+    }
+
+    #[test]
+    fn sse_frame_for_component_update_emits_angular_event() {
+        let frame = sse_frame(&DevServerEvent::ComponentUpdate {
+            id: "src%2Fapp%2Fapp.component.ts%40AppComponent".to_string(),
+            timestamp: 42,
+        });
+        assert!(frame.starts_with("event: angular:component-update\n"));
+        let data_line = frame.lines().nth(1).expect("data line");
+        let json: serde_json::Value =
+            serde_json::from_str(data_line.strip_prefix("data: ").expect("data: prefix"))
+                .expect("component-update payload is JSON");
+        assert_eq!(json["id"], "src%2Fapp%2Fapp.component.ts%40AppComponent");
+        assert_eq!(json["timestamp"], 42);
+        assert!(frame.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn query_param_extracts_raw_encoded_value() {
+        let url = "/@ng/component?c=src%2Fapp%40App&t=17";
+        assert_eq!(query_param(url, "c"), Some("src%2Fapp%40App"));
+        assert_eq!(query_param(url, "t"), Some("17"));
+        assert_eq!(query_param(url, "missing"), None);
+        assert_eq!(query_param("/@ng/component", "c"), None);
+    }
+
+    #[test]
+    fn live_reload_script_exposes_hmr_bus() {
+        // The injected client must publish the `__ngcHmr` bus and dispatch
+        // component-update events to registered handlers.
+        assert!(LIVE_RELOAD_SCRIPT.contains("window.__ngcHmr"));
+        assert!(LIVE_RELOAD_SCRIPT.contains("addEventListener('angular:component-update'"));
+        // The runtime prelude binds import.meta.hot to that bus.
+        assert!(HMR_RUNTIME_PRELUDE.contains("import.meta.hot"));
+        assert!(HMR_RUNTIME_PRELUDE.contains("globalThis.__ngcHmr"));
     }
 
     #[test]

--- a/crates/dev-server/tests/integration.rs
+++ b/crates/dev-server/tests/integration.rs
@@ -119,6 +119,45 @@ fn get_root_returns_index_html_with_injected_client() {
 }
 
 #[test]
+fn component_endpoint_serves_registered_update_module() {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    let root = TempDir::new().expect("tempdir");
+    write_file(root.path(), "index.html", b"<html><body></body></html>");
+    let registry: ngc_dev_server::ComponentUpdates = Arc::new(Mutex::new(HashMap::new()));
+    let id = "src%2Fapp%2Fapp.component.ts%40AppComponent";
+    registry
+        .lock()
+        .unwrap()
+        .insert(id.to_string(), "export default function(){}".to_string());
+
+    let cfg = DevServerConfig::new(root.path())
+        .with_port(0)
+        .with_component_updates(Arc::clone(&registry));
+    let (_tx, rx) = channel::<DevServerEvent>();
+    let server = DevServer::start(cfg, rx).expect("start dev server");
+
+    // Registered id → the update module, as text/javascript.
+    let resp = http_get(server.addr(), &format!("/@ng/component?c={id}&t=99"));
+    assert_eq!(resp.status, 200);
+    assert!(resp
+        .header("Content-Type")
+        .expect("content-type")
+        .starts_with("text/javascript"));
+    assert_eq!(resp.body, b"export default function(){}");
+
+    // Unknown id → empty 200 (the running app guards on m.default).
+    let resp = http_get(server.addr(), "/@ng/component?c=nope&t=1");
+    assert_eq!(resp.status, 200);
+    assert!(resp.body.is_empty());
+
+    // Missing `c` → 400.
+    let resp = http_get(server.addr(), "/@ng/component");
+    assert_eq!(resp.status, 400);
+}
+
+#[test]
 fn get_index_html_directly_also_injects_client() {
     let fx = Fixture::new();
     let resp = http_get(fx.server.addr(), "/index.html");

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -93,6 +93,32 @@ pub enum RawLocaleEntry {
 pub struct RawArchitect {
     /// Build target configuration.
     pub build: Option<RawBuildTarget>,
+    /// Serve (dev-server) target configuration. Only the options ngc-rs
+    /// honours are modelled — currently just `hmr`.
+    pub serve: Option<RawServeTarget>,
+}
+
+/// A serve target (`@angular/build:dev-server`) with default options and
+/// named configurations. Only the subset ngc-rs reads is modelled.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RawServeTarget {
+    /// Default serve options.
+    pub options: Option<RawServeOptions>,
+    /// Named configurations (e.g. "production", "development").
+    pub configurations: Option<HashMap<String, RawServeOptions>>,
+    /// Default configuration name used when none is specified.
+    pub default_configuration: Option<String>,
+}
+
+/// Serve options from `architect.serve.options` (or a per-configuration
+/// block). Only `hmr` is honoured today.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RawServeOptions {
+    /// Enable Hot Module Replacement. When absent, ngc-rs defaults to `false`
+    /// (full-reload live reload).
+    pub hmr: Option<bool>,
 }
 
 /// A build target with default options and named configurations.
@@ -532,6 +558,11 @@ pub struct ResolvedAngularProject {
     /// is by exact name or `<name>/...` prefix, mirroring how
     /// `@angular/build:application` (esbuild) treats package externals.
     pub external_dependencies: Vec<String>,
+    /// Resolved `architect.serve.options.hmr` (with the active
+    /// configuration's override layered on top). `false` when absent —
+    /// matching ngc-rs's default of full-reload live reload. The CLI
+    /// `--hmr`/`--no-hmr` flag takes precedence over this value.
+    pub hmr: bool,
 }
 
 /// Type of a resolved size budget.
@@ -840,6 +871,22 @@ pub fn resolve_angular_project(
         .or_else(|| options.and_then(|o| o.external_dependencies.clone()))
         .unwrap_or_default();
 
+    // Resolve serve `hmr`: base serve options, with the active
+    // configuration's serve override layered on top when present. Absent →
+    // `false` (full-reload live reload). The serve target reuses the same
+    // configuration name as the build (matching `ng serve -c <config>`).
+    let serve_target = project.architect.as_ref().and_then(|a| a.serve.as_ref());
+    let serve_options = serve_target.and_then(|st| st.options.as_ref());
+    let serve_config = config_name.as_deref().and_then(|cn| {
+        serve_target
+            .and_then(|st| st.configurations.as_ref())
+            .and_then(|configs| configs.get(cn))
+    });
+    let hmr = serve_config
+        .and_then(|sc| sc.hmr)
+        .or_else(|| serve_options.and_then(|o| o.hmr))
+        .unwrap_or(false);
+
     debug!(
         project = %name,
         output_path = %output_path.display(),
@@ -872,6 +919,7 @@ pub fn resolve_angular_project(
         define,
         scripts,
         external_dependencies,
+        hmr,
     })
 }
 
@@ -1104,6 +1152,61 @@ mod tests {
         assert_eq!(result.project_name, "my-app");
         assert!(result.output_path.ends_with("dist/my-app"));
         assert!(result.ts_config.ends_with("tsconfig.app.json"));
+    }
+
+    #[test]
+    fn test_hmr_defaults_to_false_when_no_serve_target() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": { "options": { "tsConfig": "tsconfig.json" } }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(!result.hmr);
+    }
+
+    #[test]
+    fn test_hmr_read_from_serve_options() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": { "options": { "tsConfig": "tsconfig.json" } },
+                        "serve": { "options": { "hmr": true } }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.hmr);
+    }
+
+    #[test]
+    fn test_hmr_serve_configuration_overrides_base() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": { "options": { "tsConfig": "tsconfig.json" } },
+                        "serve": {
+                            "options": { "hmr": false },
+                            "configurations": { "development": { "hmr": true } }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let base = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(!base.hmr, "base serve options keep hmr false");
+        let dev = resolve_angular_project(f.path(), None, Some("development")).unwrap();
+        assert!(dev.hmr, "development configuration overrides hmr to true");
     }
 
     #[test]


### PR DESCRIPTION
Runtime scaffolding for component-level HMR (#145), ahead of the compiler codegen that populates it. **Stacked on #185.**

## Changes
- **dev-server**: new `DevServerEvent::ComponentUpdate { id, timestamp }` → `event: angular:component-update` SSE frame; a shared `ComponentUpdates` registry (id → update-module source) on `DevServerConfig`, served at `GET /@ng/component?c=<id>` (`text/javascript`, empty `200` for unknown ids, `400` when `c` is absent) — mirrors `@angular/build`'s component middleware.
- **client**: the injected script publishes a `window.__ngcHmr` bus and dispatches `angular:component-update` to registered handlers; new `HMR_RUNTIME_PRELUDE` binds `import.meta.hot` to that bus.
- **serve**: share the registry with the dev server and prepend the runtime prelude to the entry chunk on each HMR build so per-component initializers can resolve `import.meta.hot`.

## Scope
The registry stays empty and component edits still trigger a full reload until the template-compiler emits update modules (next slice, stacked on this branch).

## Tests
- dev-server: `angular:component-update` SSE frame shape; `query_param` raw-encoded extraction; `/@ng/component` endpoint (registered id → module, unknown → empty 200, missing `c` → 400); client exposes the `__ngcHmr` bus + prelude.

Targets the milestone branch via the stack; retarget to it once #185 merges.
