### PR TITLE
feat(hmr): component template & style hot module replacement (#145)

### DIFF
--- a/crates/cli/src/incremental.rs
+++ b/crates/cli/src/incremental.rs
@@ -40,6 +40,11 @@ pub struct CachedModule {
     pub transformed_code: String,
     /// Optional source map for the transformed JS.
     pub transformed_map: Option<SourceMap>,
+    /// HMR artifacts captured during the original compile (when `--hmr` is
+    /// active). Reused on a cache hit so an unchanged component still
+    /// contributes its update module to the dev server's registry. `None`
+    /// for non-HMR builds.
+    pub hmr: Option<ngc_template_compiler::HmrArtifacts>,
 }
 
 /// Per-build-pipeline module cache.
@@ -135,6 +140,7 @@ mod tests {
             jit_fallback: false,
             transformed_code: "// transformed".to_string(),
             transformed_map: None,
+            hmr: None,
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -279,6 +279,17 @@ enum Commands {
         /// `@angular/build:dev-server`.
         #[arg(long = "ssl-cert")]
         ssl_cert: Option<PathBuf>,
+        /// Enable Hot Module Replacement: edits to component templates and
+        /// styles (and global stylesheets) are applied in place without a
+        /// full page reload, preserving component and form state. Overrides
+        /// `architect.serve.options.hmr` in `angular.json`. Mirrors the `hmr`
+        /// option of `@angular/build:dev-server`.
+        #[arg(long, conflicts_with = "no_hmr")]
+        hmr: bool,
+        /// Disable Hot Module Replacement, forcing a full page reload on every
+        /// rebuild. Overrides `architect.serve.options.hmr` in `angular.json`.
+        #[arg(long = "no-hmr", conflicts_with = "hmr")]
+        no_hmr: bool,
     },
     /// Extract translatable messages from every component template in the
     /// project and emit a translation file (XLIFF 2.0 by default; XLIFF 1.2
@@ -410,6 +421,8 @@ fn main() {
             ssl,
             ssl_key,
             ssl_cert,
+            hmr,
+            no_hmr,
         } => {
             let parsed_headers = match parse_header_overrides(headers.as_deref()) {
                 Ok(h) => h,
@@ -417,6 +430,15 @@ fn main() {
                     eprintln!("{} {e}", "Error:".red().bold());
                     process::exit(1);
                 }
+            };
+            // CLI flags win over angular.json: `--hmr` → Some(true),
+            // `--no-hmr` → Some(false), neither → None (inherit config).
+            let hmr_override = if hmr {
+                Some(true)
+            } else if no_hmr {
+                Some(false)
+            } else {
+                None
             };
             if let Err(e) = serve_cmd::run(
                 &project,
@@ -430,6 +452,7 @@ fn main() {
                 ssl,
                 ssl_key.as_deref(),
                 ssl_cert.as_deref(),
+                hmr_override,
             ) {
                 eprintln!("{} {e}", "Error:".red().bold());
                 process::exit(1);
@@ -1883,7 +1906,7 @@ pub(crate) fn resolve_out_dir(
 }
 
 /// Try to find angular.json by searching upward from the project file's directory.
-fn find_and_resolve_angular_json(
+pub(crate) fn find_and_resolve_angular_json(
     project: &Path,
     configuration: Option<&str>,
 ) -> NgcResult<Option<ResolvedAngularProject>> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -141,6 +141,16 @@ struct BuildResult {
     total_size_bytes: u64,
     /// Wall-clock duration of the build pipeline.
     duration_ms: u64,
+    /// HMR component-update modules, keyed by component id. Populated only
+    /// when the build runs with HMR enabled (`serve --hmr`); internal to the
+    /// dev server, so excluded from the `--output-json` shape.
+    #[serde(skip)]
+    hmr_component_updates: HashMap<String, String>,
+    /// Map from an external resource (`templateUrl`/`styleUrls`) path to the
+    /// owning component's HMR id, so a changed `.html`/`.css` maps to the
+    /// component to hot-swap.
+    #[serde(skip)]
+    hmr_resource_to_component: HashMap<PathBuf, String>,
 }
 
 #[derive(Parser)]
@@ -554,6 +564,8 @@ fn main() {
                             modules_bundled: 0,
                             total_size_bytes: 0,
                             duration_ms: started.elapsed().as_millis() as u64,
+                            hmr_component_updates: HashMap::new(),
+                            hmr_resource_to_component: HashMap::new(),
                         };
                         let json = serde_json::to_string_pretty(&result)
                             .expect("BuildResult serialization should not fail");
@@ -605,6 +617,7 @@ fn run_build(
         strict_templates,
         None,
         None,
+        false,
     )
 }
 
@@ -631,6 +644,7 @@ pub(crate) fn run_build_with_cache(
         false,
         cache,
         None,
+        false,
     )
 }
 
@@ -644,6 +658,7 @@ pub(crate) fn run_build_with_cache(
 /// `strict_templates` mirrors the `--strict-templates` build flag: when
 /// true, any template that would otherwise fall back to JIT compilation
 /// produces an [`NgcError::TemplateCompileError`] instead.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_build_with_options(
     project: &Path,
     out_dir_override: Option<&Path>,
@@ -652,6 +667,7 @@ pub(crate) fn run_build_with_options(
     strict_templates: bool,
     mut cache: Option<&mut incremental::BuildCache>,
     base_href_override: Option<&str>,
+    hmr: bool,
 ) -> NgcResult<BuildResult> {
     let started_at = Instant::now();
 
@@ -720,7 +736,10 @@ pub(crate) fn run_build_with_options(
         .iter()
         .filter_map(|p| incremental::BuildCache::hash_file(p).map(|h| (p.clone(), h)))
         .collect();
-    let compile_opts = ngc_template_compiler::CompileOptions { strict_templates };
+    let compile_opts = ngc_template_compiler::CompileOptions {
+        strict_templates,
+        hmr,
+    };
     let (compiled, transform_cache_seed) = compile_decorators_cached(
         &files,
         &style_ctx,
@@ -729,6 +748,29 @@ pub(crate) fn run_build_with_options(
         &file_hashes,
     )?;
     drop(templates_span);
+
+    // Aggregate HMR artifacts (when enabled) into lookup maps the dev server
+    // consumes: id → update module, and source/resource path → component id.
+    let mut hmr_component_updates: HashMap<String, String> = HashMap::new();
+    let mut hmr_resource_to_component: HashMap<PathBuf, String> = HashMap::new();
+    if hmr {
+        for cf in &compiled {
+            if let Some(artifacts) = &cf.hmr {
+                for comp in &artifacts.components {
+                    hmr_component_updates
+                        .insert(comp.id.clone(), comp.update_module_source.clone());
+                    for resource in &comp.resource_files {
+                        // Canonicalize so the watcher's emitted paths (also
+                        // canonicalized at lookup) match across symlinks.
+                        let key = resource
+                            .canonicalize()
+                            .unwrap_or_else(|_| resource.clone());
+                        hmr_resource_to_component.insert(key, comp.id.clone());
+                    }
+                }
+            }
+        }
+    }
 
     // Report any JIT fallbacks. Each fallback also goes into
     // `BuildResult.warnings` so the architect builder shim can surface it
@@ -1485,6 +1527,8 @@ pub(crate) fn run_build_with_options(
         modules_bundled,
         total_size_bytes,
         duration_ms: started_at.elapsed().as_millis() as u64,
+        hmr_component_updates,
+        hmr_resource_to_component,
     })
 }
 
@@ -2841,6 +2885,7 @@ fn compile_decorators_cached(
                 source: hit.compiled_source,
                 compiled: true,
                 jit_fallback: hit.jit_fallback,
+                hmr: hit.hmr,
             });
             continue;
         }
@@ -2868,6 +2913,7 @@ fn compile_decorators_cached(
                         // Filled in by the transform step.
                         transformed_code: String::new(),
                         transformed_map: None,
+                        hmr: cf.hmr.clone(),
                     },
                 );
             }

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -40,6 +40,7 @@ pub fn run(
     ssl: bool,
     ssl_key: Option<&Path>,
     ssl_cert: Option<&Path>,
+    hmr_override: Option<bool>,
 ) -> NgcResult<()> {
     run_with_stop(
         project,
@@ -53,6 +54,7 @@ pub fn run(
         ssl,
         ssl_key,
         ssl_cert,
+        hmr_override,
         install_ctrlc,
     )
 }
@@ -121,12 +123,32 @@ pub(crate) fn run_with_stop(
     ssl: bool,
     ssl_key: Option<&Path>,
     ssl_cert: Option<&Path>,
+    hmr_override: Option<bool>,
     install_stop: impl FnOnce(Arc<AtomicBool>),
 ) -> NgcResult<()> {
     let tls = resolve_tls(ssl, ssl_key, ssl_cert, host)?;
 
     let out_dir = crate::resolve_out_dir(project, None, configuration)?;
     let mut cache = BuildCache::new();
+
+    // Resolve HMR: CLI `--hmr`/`--no-hmr` wins; otherwise inherit
+    // `architect.serve.options.hmr` from angular.json (default `false`).
+    // Also collect the absolute paths of the global stylesheet entries so a
+    // rebuild that touches only those can be classified as a CSS-only update.
+    let resolved = crate::find_and_resolve_angular_json(project, configuration)?;
+    let hmr_enabled = hmr_override.unwrap_or_else(|| resolved.as_ref().map(|p| p.hmr).unwrap_or(false));
+    let global_style_paths: std::collections::HashSet<PathBuf> = resolved
+        .as_ref()
+        .map(|p| {
+            p.styles
+                .iter()
+                .map(|s| canonical_or_owned(&s.path))
+                .collect()
+        })
+        .unwrap_or_default();
+    if hmr_enabled {
+        eprintln!("{}", "ngc-rs HMR enabled".bold().green());
+    }
 
     // Normalize the user-supplied servePath up-front so the dev server
     // mount and the index.html `<base href>` fallback agree on the
@@ -185,6 +207,9 @@ pub(crate) fn run_with_stop(
     let project_path = project.to_path_buf();
     let configuration_owned = configuration.map(|s| s.to_string());
     let serve_path_owned = normalized_serve_path.clone();
+    // Monotonic cache-buster for the swapped `styles.css` href on CSS-only
+    // updates; must change every rebuild so the browser re-fetches.
+    let mut hmr_tick: u64 = 0;
 
     let build_fn = move |dirty: &[PathBuf]| -> NgcResult<()> {
         if dirty.iter().any(|p| !is_ts_path(p)) {
@@ -209,7 +234,19 @@ pub(crate) fn run_with_stop(
                     result.modules_bundled,
                     dirty.len()
                 );
-                if event_tx.send(DevServerEvent::Reload).is_err() {
+                // CSS-only fast path: when HMR is on and every changed file is
+                // a global stylesheet entry, swap `styles.css` in place
+                // instead of reloading (preserving component/form state).
+                let css_only = hmr_enabled && is_global_css_only_change(dirty, &global_style_paths);
+                let event = if css_only {
+                    hmr_tick += 1;
+                    DevServerEvent::CssUpdate {
+                        timestamp: hmr_tick,
+                    }
+                } else {
+                    DevServerEvent::Reload
+                };
+                if event_tx.send(event).is_err() {
                     tracing::debug!("dev server event channel closed");
                 }
                 Ok(())
@@ -247,6 +284,28 @@ pub(crate) fn build_failure_event(err: &NgcError) -> DevServerEvent {
         line,
         column,
     }
+}
+
+/// Canonicalize `path`, falling back to its owned form when canonicalization
+/// fails (e.g. the file was deleted between resolve and compare). Used so the
+/// watcher's emitted paths and the resolved style paths compare equal even
+/// across symlinks.
+fn canonical_or_owned(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// True when a rebuild's `dirty` set is non-empty and every changed file is a
+/// global stylesheet entry — the case where HMR can swap `styles.css` in place
+/// instead of reloading. An empty set (or any non-stylesheet change) returns
+/// `false`, falling back to a full reload.
+fn is_global_css_only_change(
+    dirty: &[PathBuf],
+    global_style_paths: &std::collections::HashSet<PathBuf>,
+) -> bool {
+    !dirty.is_empty()
+        && dirty
+            .iter()
+            .all(|p| global_style_paths.contains(&canonical_or_owned(p)))
 }
 
 fn error_location(err: &NgcError) -> (Option<PathBuf>, Option<u32>, Option<u32>) {
@@ -447,6 +506,48 @@ mod tests {
         )
         .expect_err("missing file should error");
         assert!(matches!(err, NgcError::Io { .. }));
+    }
+
+    #[test]
+    fn css_only_change_classification() {
+        use std::collections::HashSet;
+        let styles: HashSet<PathBuf> = [PathBuf::from("/proj/src/styles.css"), PathBuf::from("/proj/src/theme.scss")]
+            .into_iter()
+            .collect();
+
+        // All dirty files are global stylesheets → CSS-only.
+        assert!(is_global_css_only_change(
+            &[PathBuf::from("/proj/src/styles.css")],
+            &styles
+        ));
+        assert!(is_global_css_only_change(
+            &[
+                PathBuf::from("/proj/src/styles.css"),
+                PathBuf::from("/proj/src/theme.scss")
+            ],
+            &styles
+        ));
+
+        // A non-stylesheet change (or a stylesheet not in the global set)
+        // forces a full reload.
+        assert!(!is_global_css_only_change(
+            &[PathBuf::from("/proj/src/app.component.ts")],
+            &styles
+        ));
+        assert!(!is_global_css_only_change(
+            &[
+                PathBuf::from("/proj/src/styles.css"),
+                PathBuf::from("/proj/src/app.component.ts")
+            ],
+            &styles
+        ));
+        assert!(!is_global_css_only_change(
+            &[PathBuf::from("/proj/src/app.component.css")],
+            &styles
+        ));
+
+        // Empty dirty set never qualifies.
+        assert!(!is_global_css_only_change(&[], &styles));
     }
 
     #[test]

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -17,8 +17,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use colored::Colorize;
-use ngc_dev_server::{DevServer, DevServerConfig, DevServerEvent, TlsConfig};
+use ngc_dev_server::{
+    ComponentUpdates, DevServer, DevServerConfig, DevServerEvent, TlsConfig, HMR_RUNTIME_PRELUDE,
+};
 use ngc_diagnostics::{NgcError, NgcResult};
 use ngc_watch::{Watcher, WatcherConfig};
 
@@ -174,6 +179,17 @@ pub(crate) fn run_with_stop(
         initial.output_files.len(),
     );
 
+    // Shared registry of per-component HMR update modules served at
+    // `/@ng/component`. Empty until the compiler emits update modules; we
+    // share one handle between the dev server and the rebuild callback.
+    let component_updates: ComponentUpdates = Arc::new(Mutex::new(HashMap::new()));
+
+    // When HMR is on, bind `import.meta.hot` inside the entry module so the
+    // per-component initializers can register update handlers.
+    if hmr_enabled {
+        inject_hmr_runtime(&out_dir);
+    }
+
     let (event_tx, event_rx) = channel::<DevServerEvent>();
     let cfg = DevServerConfig::new(&out_dir)
         .with_host(host.to_string())
@@ -181,7 +197,8 @@ pub(crate) fn run_with_stop(
         .with_serve_path(normalized_serve_path.as_deref())
         .with_allowed_hosts(allowed_hosts.iter().cloned())
         .with_headers(headers.iter().cloned())
-        .with_tls(tls);
+        .with_tls(tls)
+        .with_component_updates(Arc::clone(&component_updates));
     let server = DevServer::start(cfg, event_rx)?;
     let scheme = server.scheme();
     let url = match server.serve_path() {
@@ -207,6 +224,7 @@ pub(crate) fn run_with_stop(
     let project_path = project.to_path_buf();
     let configuration_owned = configuration.map(|s| s.to_string());
     let serve_path_owned = normalized_serve_path.clone();
+    let out_dir_owned = out_dir.clone();
     // Monotonic cache-buster for the swapped `styles.css` href on CSS-only
     // updates; must change every rebuild so the browser re-fetches.
     let mut hmr_tick: u64 = 0;
@@ -234,6 +252,10 @@ pub(crate) fn run_with_stop(
                     result.modules_bundled,
                     dirty.len()
                 );
+                // Re-bind `import.meta.hot` in the freshly written entry chunk.
+                if hmr_enabled {
+                    inject_hmr_runtime(&out_dir_owned);
+                }
                 // CSS-only fast path: when HMR is on and every changed file is
                 // a global stylesheet entry, swap `styles.css` in place
                 // instead of reloading (preserving component/form state).
@@ -292,6 +314,33 @@ pub(crate) fn build_failure_event(err: &NgcError) -> DevServerEvent {
 /// across symlinks.
 fn canonical_or_owned(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Prepend the HMR runtime prelude to the entry chunk (`main.js`) so the
+/// per-component HMR initializers can resolve `import.meta.hot`. The build
+/// rewrites `main.js` from scratch each cycle, so this runs after every
+/// successful build. A guard skips the work if the prelude is already present
+/// (defensive — a fresh build never has it). Failures are logged and ignored:
+/// a missing entry chunk just means HMR initializers won't bind, which
+/// degrades to live reload rather than breaking the served app.
+fn inject_hmr_runtime(out_dir: &Path) {
+    let main_js = out_dir.join("main.js");
+    let existing = match std::fs::read_to_string(&main_js) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!(path = %main_js.display(), error = %e, "no entry chunk to inject HMR runtime into");
+            return;
+        }
+    };
+    if existing.starts_with(HMR_RUNTIME_PRELUDE) {
+        return;
+    }
+    let mut patched = String::with_capacity(HMR_RUNTIME_PRELUDE.len() + existing.len());
+    patched.push_str(HMR_RUNTIME_PRELUDE);
+    patched.push_str(&existing);
+    if let Err(e) = std::fs::write(&main_js, patched) {
+        tracing::debug!(path = %main_js.display(), error = %e, "could not inject HMR runtime");
+    }
 }
 
 /// True when a rebuild's `dirty` set is non-empty and every changed file is a

--- a/crates/cli/src/serve_cmd.rs
+++ b/crates/cli/src/serve_cmd.rs
@@ -171,6 +171,7 @@ pub(crate) fn run_with_stop(
         false,
         Some(&mut cache),
         normalized_serve_path.as_deref(),
+        hmr_enabled,
     )?;
     eprintln!(
         "{} {} module(s), {} file(s)",
@@ -180,9 +181,14 @@ pub(crate) fn run_with_stop(
     );
 
     // Shared registry of per-component HMR update modules served at
-    // `/@ng/component`. Empty until the compiler emits update modules; we
-    // share one handle between the dev server and the rebuild callback.
+    // `/@ng/component`. Seed it from the initial build; the rebuild callback
+    // replaces its contents each cycle.
     let component_updates: ComponentUpdates = Arc::new(Mutex::new(HashMap::new()));
+    if hmr_enabled {
+        if let Ok(mut map) = component_updates.lock() {
+            map.clone_from(&initial.hmr_component_updates);
+        }
+    }
 
     // When HMR is on, bind `import.meta.hot` inside the entry module so the
     // per-component initializers can register update handlers.
@@ -225,8 +231,9 @@ pub(crate) fn run_with_stop(
     let configuration_owned = configuration.map(|s| s.to_string());
     let serve_path_owned = normalized_serve_path.clone();
     let out_dir_owned = out_dir.clone();
-    // Monotonic cache-buster for the swapped `styles.css` href on CSS-only
-    // updates; must change every rebuild so the browser re-fetches.
+    let registry = Arc::clone(&component_updates);
+    // Monotonic cache-buster for swapped stylesheets and component-update
+    // fetches; must change every rebuild so the browser re-fetches.
     let mut hmr_tick: u64 = 0;
 
     let build_fn = move |dirty: &[PathBuf]| -> NgcResult<()> {
@@ -243,6 +250,7 @@ pub(crate) fn run_with_stop(
             false,
             Some(&mut cache),
             serve_path_owned.as_deref(),
+            hmr_enabled,
         );
         match outcome {
             Ok(result) => {
@@ -252,24 +260,26 @@ pub(crate) fn run_with_stop(
                     result.modules_bundled,
                     dirty.len()
                 );
-                // Re-bind `import.meta.hot` in the freshly written entry chunk.
                 if hmr_enabled {
+                    // Re-bind `import.meta.hot` in the freshly written entry
+                    // chunk and refresh the served update-module registry.
                     inject_hmr_runtime(&out_dir_owned);
-                }
-                // CSS-only fast path: when HMR is on and every changed file is
-                // a global stylesheet entry, swap `styles.css` in place
-                // instead of reloading (preserving component/form state).
-                let css_only = hmr_enabled && is_global_css_only_change(dirty, &global_style_paths);
-                let event = if css_only {
-                    hmr_tick += 1;
-                    DevServerEvent::CssUpdate {
-                        timestamp: hmr_tick,
+                    if let Ok(mut map) = registry.lock() {
+                        map.clone_from(&result.hmr_component_updates);
                     }
-                } else {
-                    DevServerEvent::Reload
-                };
-                if event_tx.send(event).is_err() {
-                    tracing::debug!("dev server event channel closed");
+                }
+                hmr_tick += 1;
+                for event in classify_rebuild(
+                    hmr_enabled,
+                    dirty,
+                    &global_style_paths,
+                    &result.hmr_resource_to_component,
+                    hmr_tick,
+                ) {
+                    if event_tx.send(event).is_err() {
+                        tracing::debug!("dev server event channel closed");
+                        break;
+                    }
                 }
                 Ok(())
             }
@@ -316,30 +326,40 @@ fn canonical_or_owned(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
-/// Prepend the HMR runtime prelude to the entry chunk (`main.js`) so the
-/// per-component HMR initializers can resolve `import.meta.hot`. The build
-/// rewrites `main.js` from scratch each cycle, so this runs after every
-/// successful build. A guard skips the work if the prelude is already present
-/// (defensive — a fresh build never has it). Failures are logged and ignored:
-/// a missing entry chunk just means HMR initializers won't bind, which
-/// degrades to live reload rather than breaking the served app.
+/// Prepend the HMR runtime prelude to every emitted JS chunk so the
+/// per-component HMR initializers — which live in `main.js` for eager
+/// components and in lazy `chunk-*.js` for routed ones — can resolve
+/// `import.meta.hot` (each ES module has its own `import.meta`). The build
+/// rewrites the chunks from scratch each cycle, so this runs after every
+/// successful build. A per-file guard skips the work if the prelude is already
+/// present. Failures are logged and ignored: a chunk that can't be patched
+/// just degrades that component to live reload rather than breaking the app.
 fn inject_hmr_runtime(out_dir: &Path) {
-    let main_js = out_dir.join("main.js");
-    let existing = match std::fs::read_to_string(&main_js) {
-        Ok(s) => s,
+    let entries = match std::fs::read_dir(out_dir) {
+        Ok(e) => e,
         Err(e) => {
-            tracing::debug!(path = %main_js.display(), error = %e, "no entry chunk to inject HMR runtime into");
+            tracing::debug!(path = %out_dir.display(), error = %e, "could not read out_dir to inject HMR runtime");
             return;
         }
     };
-    if existing.starts_with(HMR_RUNTIME_PRELUDE) {
-        return;
-    }
-    let mut patched = String::with_capacity(HMR_RUNTIME_PRELUDE.len() + existing.len());
-    patched.push_str(HMR_RUNTIME_PRELUDE);
-    patched.push_str(&existing);
-    if let Err(e) = std::fs::write(&main_js, patched) {
-        tracing::debug!(path = %main_js.display(), error = %e, "could not inject HMR runtime");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Top-level `.js` chunks only (skip source maps and nested locale dirs).
+        if path.extension().and_then(|e| e.to_str()) != Some("js") {
+            continue;
+        }
+        let Ok(existing) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if existing.starts_with(HMR_RUNTIME_PRELUDE) {
+            continue;
+        }
+        let mut patched = String::with_capacity(HMR_RUNTIME_PRELUDE.len() + existing.len());
+        patched.push_str(HMR_RUNTIME_PRELUDE);
+        patched.push_str(&existing);
+        if let Err(e) = std::fs::write(&path, patched) {
+            tracing::debug!(path = %path.display(), error = %e, "could not inject HMR runtime into chunk");
+        }
     }
 }
 
@@ -355,6 +375,49 @@ fn is_global_css_only_change(
         && dirty
             .iter()
             .all(|p| global_style_paths.contains(&canonical_or_owned(p)))
+}
+
+/// Decide which dev-server event(s) a successful rebuild should fan out.
+///
+/// * HMR off → always a full [`DevServerEvent::Reload`].
+/// * Every dirty file is a global stylesheet → one [`DevServerEvent::CssUpdate`].
+/// * Every dirty file is an external component resource (`templateUrl` /
+///   `styleUrls`) of a known component → one [`DevServerEvent::ComponentUpdate`]
+///   per affected component, swapping it in place.
+/// * Anything else (a `.ts` class change, an inline-template edit, or an
+///   unrecognised file) → a full reload. Inline-template/`.ts` HMR is
+///   intentionally deferred to a follow-up.
+fn classify_rebuild(
+    hmr_enabled: bool,
+    dirty: &[PathBuf],
+    global_style_paths: &std::collections::HashSet<PathBuf>,
+    resource_to_component: &HashMap<PathBuf, String>,
+    timestamp: u64,
+) -> Vec<DevServerEvent> {
+    if !hmr_enabled {
+        return vec![DevServerEvent::Reload];
+    }
+    if is_global_css_only_change(dirty, global_style_paths) {
+        return vec![DevServerEvent::CssUpdate { timestamp }];
+    }
+    if dirty.is_empty() {
+        return vec![DevServerEvent::Reload];
+    }
+    let mut ids: Vec<String> = Vec::new();
+    for path in dirty {
+        match resource_to_component.get(&canonical_or_owned(path)) {
+            Some(id) => {
+                if !ids.contains(id) {
+                    ids.push(id.clone());
+                }
+            }
+            // A `.ts` change, inline-template edit, or unknown file → reload.
+            None => return vec![DevServerEvent::Reload],
+        }
+    }
+    ids.into_iter()
+        .map(|id| DevServerEvent::ComponentUpdate { id, timestamp })
+        .collect()
 }
 
 fn error_location(err: &NgcError) -> (Option<PathBuf>, Option<u32>, Option<u32>) {
@@ -597,6 +660,87 @@ mod tests {
 
         // Empty dirty set never qualifies.
         assert!(!is_global_css_only_change(&[], &styles));
+    }
+
+    #[test]
+    fn classify_rebuild_routes_events() {
+        use std::collections::{HashMap, HashSet};
+        let styles: HashSet<PathBuf> = [PathBuf::from("/proj/src/styles.css")].into_iter().collect();
+        let mut resources: HashMap<PathBuf, String> = HashMap::new();
+        resources.insert(PathBuf::from("/proj/src/app/app.component.html"), "id-app".to_string());
+        resources.insert(PathBuf::from("/proj/src/app/app.component.css"), "id-app".to_string());
+        resources.insert(PathBuf::from("/proj/src/app/foo.component.html"), "id-foo".to_string());
+
+        // HMR off → always reload.
+        assert!(matches!(
+            classify_rebuild(false, &[PathBuf::from("/proj/src/app/app.component.html")], &styles, &resources, 1).as_slice(),
+            [DevServerEvent::Reload]
+        ));
+
+        // Global stylesheet only → CssUpdate.
+        assert!(matches!(
+            classify_rebuild(true, &[PathBuf::from("/proj/src/styles.css")], &styles, &resources, 5).as_slice(),
+            [DevServerEvent::CssUpdate { timestamp: 5 }]
+        ));
+
+        // A component template → one ComponentUpdate for its id.
+        let evs = classify_rebuild(true, &[PathBuf::from("/proj/src/app/app.component.html")], &styles, &resources, 7);
+        match evs.as_slice() {
+            [DevServerEvent::ComponentUpdate { id, timestamp: 7 }] => assert_eq!(id, "id-app"),
+            other => panic!("expected one ComponentUpdate, got {other:?}"),
+        }
+
+        // Two resources of the same component → deduped to a single update.
+        let evs = classify_rebuild(
+            true,
+            &[
+                PathBuf::from("/proj/src/app/app.component.html"),
+                PathBuf::from("/proj/src/app/app.component.css"),
+            ],
+            &styles,
+            &resources,
+            9,
+        );
+        assert_eq!(evs.len(), 1);
+
+        // Two distinct components → one update each.
+        let evs = classify_rebuild(
+            true,
+            &[
+                PathBuf::from("/proj/src/app/app.component.html"),
+                PathBuf::from("/proj/src/app/foo.component.html"),
+            ],
+            &styles,
+            &resources,
+            9,
+        );
+        assert_eq!(evs.len(), 2);
+
+        // A `.ts` (or any unknown) change → reload, even mixed with a resource.
+        assert!(matches!(
+            classify_rebuild(true, &[PathBuf::from("/proj/src/app/app.component.ts")], &styles, &resources, 1).as_slice(),
+            [DevServerEvent::Reload]
+        ));
+        assert!(matches!(
+            classify_rebuild(
+                true,
+                &[
+                    PathBuf::from("/proj/src/app/app.component.html"),
+                    PathBuf::from("/proj/src/app/app.component.ts"),
+                ],
+                &styles,
+                &resources,
+                1
+            )
+            .as_slice(),
+            [DevServerEvent::Reload]
+        ));
+
+        // Empty dirty set → reload.
+        assert!(matches!(
+            classify_rebuild(true, &[], &styles, &resources, 1).as_slice(),
+            [DevServerEvent::Reload]
+        ));
     }
 
     #[test]

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -46,10 +46,20 @@ use tiny_http::{Header, Method, Response, Server, SslConfig, StatusCode};
 ///
 /// * [`DevServerEvent::Reload`] → `event: reload`
 /// * [`DevServerEvent::BuildFailed`] → `event: build-failed`
+/// * [`DevServerEvent::CssUpdate`] → `event: css-update`
 #[derive(Debug, Clone)]
 pub enum DevServerEvent {
     /// A successful rebuild — connected browsers should refresh the page.
     Reload,
+    /// A successful rebuild that only changed global stylesheet(s). HMR
+    /// clients swap the `styles.css` `<link>` in place (cache-busting with
+    /// `timestamp`) without reloading the page, preserving component and
+    /// form state. Only emitted when HMR is enabled; otherwise a plain
+    /// [`DevServerEvent::Reload`] is sent.
+    CssUpdate {
+        /// Monotonic cache-buster appended to the swapped stylesheet href.
+        timestamp: u64,
+    },
     /// A rebuild failed — connected browsers should display an error
     /// overlay with the message and (when available) the offending file
     /// and source coordinates.
@@ -695,6 +705,9 @@ fn fanout_loop(rx: Receiver<DevServerEvent>, clients: SseClients) {
 pub fn sse_frame(event: &DevServerEvent) -> String {
     match event {
         DevServerEvent::Reload => "event: reload\ndata: rebuild\n\n".to_string(),
+        DevServerEvent::CssUpdate { timestamp } => {
+            format!("event: css-update\ndata: {{\"timestamp\":{timestamp}}}\n\n")
+        }
         DevServerEvent::BuildFailed {
             message,
             file,
@@ -1074,7 +1087,7 @@ pub fn mime_for(path: &Path) -> &'static str {
 /// Malformed `data:` payloads (non-JSON, missing keys) are tolerated and
 /// fall back to a generic "build failed" message rather than crashing the
 /// listener.
-pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);function swapCss(t){var links=document.querySelectorAll('link[rel="stylesheet"]');for(var i=0;i < links.length;i++){(function(link){var href=link.getAttribute('href');if(!href){return;}var base=href.split('?')[0];if(!/(^|\/)styles\.css$/.test(base)){return;}var next=link.cloneNode(false);next.setAttribute('href',base+'?ngcss='+t);next.addEventListener('load',function(){if(link.parentNode){link.parentNode.removeChild(link);}});next.addEventListener('error',function(){if(next.parentNode){next.parentNode.removeChild(next);}});link.parentNode.insertBefore(next,link.nextSibling);})(links[i]);}}var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});s.addEventListener('css-update',function(e){var t=0;try{t=(JSON.parse(e.data)||{}).timestamp||0;}catch(_){}if(!t){t=(new Date()).getTime();}dismiss();swapCss(t);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
 
 /// Insert the live-reload client script into an HTML byte buffer.
 ///
@@ -1243,6 +1256,38 @@ mod tests {
         assert_eq!(
             sse_frame(&DevServerEvent::Reload),
             "event: reload\ndata: rebuild\n\n"
+        );
+    }
+
+    #[test]
+    fn sse_frame_for_css_update_emits_named_event_with_timestamp() {
+        let frame = sse_frame(&DevServerEvent::CssUpdate { timestamp: 7 });
+        assert!(frame.starts_with("event: css-update\n"));
+        let data_line = frame.lines().nth(1).expect("data line");
+        let json: serde_json::Value = serde_json::from_str(
+            data_line.strip_prefix("data: ").expect("data: prefix"),
+        )
+        .expect("css-update payload is JSON");
+        assert_eq!(json["timestamp"], 7);
+        assert!(frame.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn live_reload_script_handles_css_update_in_place() {
+        // The injected client must subscribe to `css-update` and swap the
+        // global styles.css link instead of reloading the page.
+        assert!(LIVE_RELOAD_SCRIPT.contains("addEventListener('css-update'"));
+        assert!(LIVE_RELOAD_SCRIPT.contains("function swapCss"));
+        assert!(LIVE_RELOAD_SCRIPT.contains("styles\\.css"));
+        // CSS updates must not trigger a full reload.
+        let after_css = LIVE_RELOAD_SCRIPT
+            .split("addEventListener('css-update'")
+            .nth(1)
+            .expect("css-update handler present");
+        let handler_body = after_css.split("});").next().unwrap_or("");
+        assert!(
+            !handler_body.contains("location.reload"),
+            "css-update handler must not reload the page"
         );
     }
 

--- a/crates/dev-server/src/lib.rs
+++ b/crates/dev-server/src/lib.rs
@@ -27,6 +27,7 @@
 //!   mounts a full-page error overlay (dismissible with `Esc`) showing the
 //!   build error and source location.
 
+use std::collections::HashMap;
 use std::io::Write;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::path::{Path, PathBuf};
@@ -60,6 +61,18 @@ pub enum DevServerEvent {
         /// Monotonic cache-buster appended to the swapped stylesheet href.
         timestamp: u64,
     },
+    /// A successful rebuild that changed only a single component's template
+    /// and/or styles. HMR clients re-fetch that component's update module
+    /// from `/@ng/component?c=<id>&t=<timestamp>` and call
+    /// `ɵɵreplaceMetadata` to swap it in place — no reload, state preserved.
+    /// `id` is the percent-encoded `relpath@ClassName` the compiler embeds in
+    /// the component's HMR initializer. Only emitted when HMR is enabled.
+    ComponentUpdate {
+        /// Percent-encoded component id (`encodeURIComponent("relpath@Class")`).
+        id: String,
+        /// Monotonic cache-buster matching the `t` query param on the fetch.
+        timestamp: u64,
+    },
     /// A rebuild failed — connected browsers should display an error
     /// overlay with the message and (when available) the offending file
     /// and source coordinates.
@@ -87,6 +100,14 @@ impl From<ReloadEvent> for DevServerEvent {
         DevServerEvent::Reload
     }
 }
+
+/// Shared registry of per-component HMR update modules, keyed by the
+/// percent-encoded component id (`encodeURIComponent("relpath@Class")`).
+/// The build pipeline replaces its contents after each rebuild; the
+/// `/@ng/component?c=<id>` endpoint reads it to serve the update module a
+/// running app dynamically imports. Cloning shares the same underlying map
+/// (`Arc`), so the serve loop and the build callback see each other's writes.
+pub type ComponentUpdates = Arc<Mutex<HashMap<String, String>>>;
 
 /// Configuration for [`DevServer`].
 #[derive(Debug, Clone)]
@@ -117,6 +138,10 @@ pub struct DevServerConfig {
     /// the long-lived SSE live-reload stream — is wrapped in TLS. Mirrors
     /// `@angular/build:dev-server`'s `ssl`/`sslKey`/`sslCert` options.
     pub tls: Option<TlsConfig>,
+    /// Registry of per-component HMR update modules served at
+    /// `/@ng/component?c=<id>`. Empty by default (live reload only); the
+    /// `serve` command shares a handle and populates it on each HMR rebuild.
+    pub component_updates: ComponentUpdates,
 }
 
 impl DevServerConfig {
@@ -131,7 +156,16 @@ impl DevServerConfig {
             allowed_hosts: Vec::new(),
             headers: Vec::new(),
             tls: None,
+            component_updates: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Share an external [`ComponentUpdates`] registry so the build pipeline
+    /// can publish per-component HMR update modules the `/@ng/component`
+    /// endpoint then serves. Pass a handle you retain a clone of.
+    pub fn with_component_updates(mut self, updates: ComponentUpdates) -> Self {
+        self.component_updates = updates;
+        self
     }
 
     /// Override the bind host.
@@ -571,6 +605,7 @@ impl DevServer {
         let allowed_hosts = Arc::new(AllowedHosts::resolve(&config.allowed_hosts, &config.host));
         let allowed_hosts_for_loop = Arc::clone(&allowed_hosts);
         let custom_headers = Arc::new(CustomHeaders::resolve(&config.headers));
+        let component_updates = Arc::clone(&config.component_updates);
         let join = thread::Builder::new()
             .name("ngc-dev-server-accept".into())
             .spawn(move || {
@@ -581,6 +616,7 @@ impl DevServer {
                     serve_path_for_loop,
                     allowed_hosts_for_loop,
                     custom_headers,
+                    component_updates,
                 )
             })
             .map_err(|e| NgcError::ServeError {
@@ -708,6 +744,12 @@ pub fn sse_frame(event: &DevServerEvent) -> String {
         DevServerEvent::CssUpdate { timestamp } => {
             format!("event: css-update\ndata: {{\"timestamp\":{timestamp}}}\n\n")
         }
+        DevServerEvent::ComponentUpdate { id, timestamp } => {
+            // `id` is already percent-encoded JS-identifier-safe text, but
+            // route it through serde so any stray quote can't break the JSON.
+            let payload = serde_json::json!({ "id": id, "timestamp": timestamp });
+            format!("event: angular:component-update\ndata: {payload}\n\n")
+        }
         DevServerEvent::BuildFailed {
             message,
             file,
@@ -725,6 +767,7 @@ pub fn sse_frame(event: &DevServerEvent) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn serve_loop(
     server: Arc<Server>,
     root: PathBuf,
@@ -732,6 +775,7 @@ fn serve_loop(
     serve_path: Option<String>,
     allowed_hosts: Arc<AllowedHosts>,
     headers: Arc<CustomHeaders>,
+    component_updates: ComponentUpdates,
 ) {
     for request in server.incoming_requests() {
         let root = root.clone();
@@ -739,6 +783,7 @@ fn serve_loop(
         let serve_path = serve_path.clone();
         let allowed_hosts = Arc::clone(&allowed_hosts);
         let headers = Arc::clone(&headers);
+        let component_updates = Arc::clone(&component_updates);
         thread::spawn(move || {
             if let Err(e) = handle_request(
                 request,
@@ -747,6 +792,7 @@ fn serve_loop(
                 serve_path.as_deref(),
                 &allowed_hosts,
                 &headers,
+                &component_updates,
             ) {
                 tracing::warn!(error = %e, "dev server request failed");
             }
@@ -754,6 +800,7 @@ fn serve_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_request(
     request: tiny_http::Request,
     root: &Path,
@@ -761,6 +808,7 @@ fn handle_request(
     serve_path: Option<&str>,
     allowed_hosts: &AllowedHosts,
     headers: &CustomHeaders,
+    component_updates: &ComponentUpdates,
 ) -> NgcResult<()> {
     if !matches!(request.method(), Method::Get | Method::Head) {
         let resp = Response::from_string("method not allowed").with_status_code(StatusCode(405));
@@ -787,7 +835,54 @@ fn handle_request(
         return handle_sse(request, clients, headers);
     }
 
+    if stripped == "/@ng/component" {
+        return handle_component_update(request, &url, component_updates, headers);
+    }
+
     serve_static(request, root, stripped, serve_path, headers)
+}
+
+/// Serve a per-component HMR update module for `GET /@ng/component?c=<id>`.
+///
+/// The `c` query value is the percent-encoded component id the compiler
+/// embedded in the component's HMR initializer; it's used verbatim as the
+/// registry key (the running app sends exactly what was embedded). When no
+/// module is registered for the id, an empty `200` is returned — the running
+/// app's loader guards on `m.default`, so an empty module is a safe no-op
+/// (mirrors `@angular/build`'s component middleware).
+fn handle_component_update(
+    request: tiny_http::Request,
+    url: &str,
+    component_updates: &ComponentUpdates,
+    headers: &CustomHeaders,
+) -> NgcResult<()> {
+    let Some(id) = query_param(url, "c") else {
+        let resp = Response::from_string("missing c parameter").with_status_code(StatusCode(400));
+        return request.respond(resp).map_err(io_err);
+    };
+    let code = component_updates
+        .lock()
+        .ok()
+        .and_then(|map| map.get(id).cloned())
+        .unwrap_or_default();
+    let mut resp = Response::from_data(code.into_bytes());
+    resp.add_header(header("Content-Type", "text/javascript")?);
+    resp.add_header(header("Cache-Control", "no-cache")?);
+    headers.apply(&mut resp, &["Content-Type", "Cache-Control"]);
+    request.respond(resp).map_err(io_err)
+}
+
+/// Extract a raw (still percent-encoded) query parameter value from a URL.
+///
+/// Returns the substring after `<name>=` up to the next `&`. The value is
+/// **not** percent-decoded: component ids are stored and matched in their
+/// encoded form, so decoding here would break the registry lookup.
+fn query_param<'a>(url: &'a str, name: &str) -> Option<&'a str> {
+    let query = url.split_once('?')?.1;
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == name).then_some(v)
+    })
 }
 
 /// Read the request's `Host:` header value, or return the empty string when
@@ -1087,7 +1182,18 @@ pub fn mime_for(path: &Path) -> &'static str {
 /// Malformed `data:` payloads (non-JSON, missing keys) are tolerated and
 /// fall back to a generic "build failed" message rather than crashing the
 /// listener.
-pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);function swapCss(t){var links=document.querySelectorAll('link[rel="stylesheet"]');for(var i=0;i < links.length;i++){(function(link){var href=link.getAttribute('href');if(!href){return;}var base=href.split('?')[0];if(!/(^|\/)styles\.css$/.test(base)){return;}var next=link.cloneNode(false);next.setAttribute('href',base+'?ngcss='+t);next.addEventListener('load',function(){if(link.parentNode){link.parentNode.removeChild(link);}});next.addEventListener('error',function(){if(next.parentNode){next.parentNode.removeChild(next);}});link.parentNode.insertBefore(next,link.nextSibling);})(links[i]);}}var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});s.addEventListener('css-update',function(e){var t=0;try{t=(JSON.parse(e.data)||{}).timestamp||0;}catch(_){}if(!t){t=(new Date()).getTime();}dismiss();swapCss(t);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+pub const LIVE_RELOAD_SCRIPT: &str = r#"<script>(function(){try{var ID='__ngc_rs_overlay__';function dismiss(){var n=document.getElementById(ID);if(n){n.remove();}window.__ngcRsOverlay=null;}function show(payload){dismiss();var data={};try{data=JSON.parse(payload)||{};}catch(_){}var msg=typeof data.message==='string'&&data.message?data.message:'ngc-rs rebuild failed';var loc='';if(typeof data.file==='string'&&data.file){loc=data.file;if(typeof data.line==='number'){loc+=':'+data.line;if(typeof data.column==='number'){loc+=':'+data.column;}}}var overlay=document.createElement('div');overlay.id=ID;overlay.setAttribute('role','alert');overlay.style.cssText='position:fixed;inset:0;z-index:2147483647;background:rgba(20,20,20,0.92);color:#ff6b6b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:14px;line-height:1.5;padding:32px;overflow:auto;white-space:pre-wrap;word-break:break-word;';var header=document.createElement('div');header.textContent='ngc-rs build failed';header.style.cssText='font-weight:bold;font-size:16px;margin-bottom:16px;color:#ff8a8a;';overlay.appendChild(header);if(loc){var locEl=document.createElement('div');locEl.textContent=loc;locEl.style.cssText='color:#ffd166;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';overlay.appendChild(locEl);}var body=document.createElement('pre');body.textContent=msg;body.style.cssText='margin:0;color:#ff6b6b;white-space:pre-wrap;word-break:break-word;';overlay.appendChild(body);var hint=document.createElement('div');hint.textContent='Press Esc to dismiss · overlay reappears on next failed rebuild';hint.style.cssText='margin-top:24px;color:#888;font-size:12px;';overlay.appendChild(hint);(document.body||document.documentElement).appendChild(overlay);window.__ngcRsOverlay=overlay;}function onKey(e){if(e.key==='Escape'){dismiss();}}document.addEventListener('keydown',onKey);function swapCss(t){var links=document.querySelectorAll('link[rel="stylesheet"]');for(var i=0;i < links.length;i++){(function(link){var href=link.getAttribute('href');if(!href){return;}var base=href.split('?')[0];if(!/(^|\/)styles\.css$/.test(base)){return;}var next=link.cloneNode(false);next.setAttribute('href',base+'?ngcss='+t);next.addEventListener('load',function(){if(link.parentNode){link.parentNode.removeChild(link);}});next.addEventListener('error',function(){if(next.parentNode){next.parentNode.removeChild(next);}});link.parentNode.insertBefore(next,link.nextSibling);})(links[i]);}}var hmrHandlers={};function emitHmr(ev,d){var a=hmrHandlers[ev]||[];for(var i=0;i < a.length;i++){try{a[i](d);}catch(err){console.error('[ngc-rs] hmr handler error',err);}}}window.__ngcHmr={on:function(ev,cb){(hmrHandlers[ev]=hmrHandlers[ev]||[]).push(cb);},off:function(ev,cb){var a=hmrHandlers[ev];if(a){var i=a.indexOf(cb);if(i>=0){a.splice(i,1);}}},send:function(){}};var s=new EventSource('/__ngc_reload');s.addEventListener('reload',function(){dismiss();location.reload();});s.addEventListener('build-failed',function(e){show(e.data);});s.addEventListener('css-update',function(e){var t=0;try{t=(JSON.parse(e.data)||{}).timestamp||0;}catch(_){}if(!t){t=(new Date()).getTime();}dismiss();swapCss(t);});s.addEventListener('angular:component-update',function(e){var d={};try{d=JSON.parse(e.data)||{};}catch(_){}dismiss();emitHmr('angular:component-update',d);});}catch(e){console.warn('[ngc-rs] live reload unavailable',e);}})();</script>"#;
+
+/// Module-scope prelude prepended to the entry chunk (`main.js`) when HMR is
+/// enabled. The per-component HMR initializers the compiler emits reference
+/// `import.meta.hot`, which only exists inside a module's `import.meta`; this
+/// binds it to the event bus the injected [`LIVE_RELOAD_SCRIPT`] publishes on
+/// `window.__ngcHmr`. The inline script runs before the deferred module, so
+/// `window.__ngcHmr` is already defined when this line executes. A no-op stub
+/// is used as a fallback so the bundle never throws if live reload failed to
+/// initialise.
+pub const HMR_RUNTIME_PRELUDE: &str =
+    "import.meta.hot=globalThis.__ngcHmr||{on:function(){},off:function(){},send:function(){}};\n";
 
 /// Insert the live-reload client script into an HTML byte buffer.
 ///
@@ -1289,6 +1395,42 @@ mod tests {
             !handler_body.contains("location.reload"),
             "css-update handler must not reload the page"
         );
+    }
+
+    #[test]
+    fn sse_frame_for_component_update_emits_angular_event() {
+        let frame = sse_frame(&DevServerEvent::ComponentUpdate {
+            id: "src%2Fapp%2Fapp.component.ts%40AppComponent".to_string(),
+            timestamp: 42,
+        });
+        assert!(frame.starts_with("event: angular:component-update\n"));
+        let data_line = frame.lines().nth(1).expect("data line");
+        let json: serde_json::Value =
+            serde_json::from_str(data_line.strip_prefix("data: ").expect("data: prefix"))
+                .expect("component-update payload is JSON");
+        assert_eq!(json["id"], "src%2Fapp%2Fapp.component.ts%40AppComponent");
+        assert_eq!(json["timestamp"], 42);
+        assert!(frame.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn query_param_extracts_raw_encoded_value() {
+        let url = "/@ng/component?c=src%2Fapp%40App&t=17";
+        assert_eq!(query_param(url, "c"), Some("src%2Fapp%40App"));
+        assert_eq!(query_param(url, "t"), Some("17"));
+        assert_eq!(query_param(url, "missing"), None);
+        assert_eq!(query_param("/@ng/component", "c"), None);
+    }
+
+    #[test]
+    fn live_reload_script_exposes_hmr_bus() {
+        // The injected client must publish the `__ngcHmr` bus and dispatch
+        // component-update events to registered handlers.
+        assert!(LIVE_RELOAD_SCRIPT.contains("window.__ngcHmr"));
+        assert!(LIVE_RELOAD_SCRIPT.contains("addEventListener('angular:component-update'"));
+        // The runtime prelude binds import.meta.hot to that bus.
+        assert!(HMR_RUNTIME_PRELUDE.contains("import.meta.hot"));
+        assert!(HMR_RUNTIME_PRELUDE.contains("globalThis.__ngcHmr"));
     }
 
     #[test]

--- a/crates/dev-server/tests/integration.rs
+++ b/crates/dev-server/tests/integration.rs
@@ -119,6 +119,45 @@ fn get_root_returns_index_html_with_injected_client() {
 }
 
 #[test]
+fn component_endpoint_serves_registered_update_module() {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    let root = TempDir::new().expect("tempdir");
+    write_file(root.path(), "index.html", b"<html><body></body></html>");
+    let registry: ngc_dev_server::ComponentUpdates = Arc::new(Mutex::new(HashMap::new()));
+    let id = "src%2Fapp%2Fapp.component.ts%40AppComponent";
+    registry
+        .lock()
+        .unwrap()
+        .insert(id.to_string(), "export default function(){}".to_string());
+
+    let cfg = DevServerConfig::new(root.path())
+        .with_port(0)
+        .with_component_updates(Arc::clone(&registry));
+    let (_tx, rx) = channel::<DevServerEvent>();
+    let server = DevServer::start(cfg, rx).expect("start dev server");
+
+    // Registered id → the update module, as text/javascript.
+    let resp = http_get(server.addr(), &format!("/@ng/component?c={id}&t=99"));
+    assert_eq!(resp.status, 200);
+    assert!(resp
+        .header("Content-Type")
+        .expect("content-type")
+        .starts_with("text/javascript"));
+    assert_eq!(resp.body, b"export default function(){}");
+
+    // Unknown id → empty 200 (the running app guards on m.default).
+    let resp = http_get(server.addr(), "/@ng/component?c=nope&t=1");
+    assert_eq!(resp.status, 200);
+    assert!(resp.body.is_empty());
+
+    // Missing `c` → 400.
+    let resp = http_get(server.addr(), "/@ng/component");
+    assert_eq!(resp.status, 400);
+}
+
+#[test]
 fn get_index_html_directly_also_injects_client() {
     let fx = Fixture::new();
     let resp = http_get(fx.server.addr(), "/index.html");

--- a/crates/project-resolver/src/angular_json.rs
+++ b/crates/project-resolver/src/angular_json.rs
@@ -93,6 +93,32 @@ pub enum RawLocaleEntry {
 pub struct RawArchitect {
     /// Build target configuration.
     pub build: Option<RawBuildTarget>,
+    /// Serve (dev-server) target configuration. Only the options ngc-rs
+    /// honours are modelled — currently just `hmr`.
+    pub serve: Option<RawServeTarget>,
+}
+
+/// A serve target (`@angular/build:dev-server`) with default options and
+/// named configurations. Only the subset ngc-rs reads is modelled.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RawServeTarget {
+    /// Default serve options.
+    pub options: Option<RawServeOptions>,
+    /// Named configurations (e.g. "production", "development").
+    pub configurations: Option<HashMap<String, RawServeOptions>>,
+    /// Default configuration name used when none is specified.
+    pub default_configuration: Option<String>,
+}
+
+/// Serve options from `architect.serve.options` (or a per-configuration
+/// block). Only `hmr` is honoured today.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RawServeOptions {
+    /// Enable Hot Module Replacement. When absent, ngc-rs defaults to `false`
+    /// (full-reload live reload).
+    pub hmr: Option<bool>,
 }
 
 /// A build target with default options and named configurations.
@@ -532,6 +558,11 @@ pub struct ResolvedAngularProject {
     /// is by exact name or `<name>/...` prefix, mirroring how
     /// `@angular/build:application` (esbuild) treats package externals.
     pub external_dependencies: Vec<String>,
+    /// Resolved `architect.serve.options.hmr` (with the active
+    /// configuration's override layered on top). `false` when absent —
+    /// matching ngc-rs's default of full-reload live reload. The CLI
+    /// `--hmr`/`--no-hmr` flag takes precedence over this value.
+    pub hmr: bool,
 }
 
 /// Type of a resolved size budget.
@@ -840,6 +871,22 @@ pub fn resolve_angular_project(
         .or_else(|| options.and_then(|o| o.external_dependencies.clone()))
         .unwrap_or_default();
 
+    // Resolve serve `hmr`: base serve options, with the active
+    // configuration's serve override layered on top when present. Absent →
+    // `false` (full-reload live reload). The serve target reuses the same
+    // configuration name as the build (matching `ng serve -c <config>`).
+    let serve_target = project.architect.as_ref().and_then(|a| a.serve.as_ref());
+    let serve_options = serve_target.and_then(|st| st.options.as_ref());
+    let serve_config = config_name.as_deref().and_then(|cn| {
+        serve_target
+            .and_then(|st| st.configurations.as_ref())
+            .and_then(|configs| configs.get(cn))
+    });
+    let hmr = serve_config
+        .and_then(|sc| sc.hmr)
+        .or_else(|| serve_options.and_then(|o| o.hmr))
+        .unwrap_or(false);
+
     debug!(
         project = %name,
         output_path = %output_path.display(),
@@ -872,6 +919,7 @@ pub fn resolve_angular_project(
         define,
         scripts,
         external_dependencies,
+        hmr,
     })
 }
 
@@ -1104,6 +1152,61 @@ mod tests {
         assert_eq!(result.project_name, "my-app");
         assert!(result.output_path.ends_with("dist/my-app"));
         assert!(result.ts_config.ends_with("tsconfig.app.json"));
+    }
+
+    #[test]
+    fn test_hmr_defaults_to_false_when_no_serve_target() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": { "options": { "tsConfig": "tsconfig.json" } }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(!result.hmr);
+    }
+
+    #[test]
+    fn test_hmr_read_from_serve_options() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": { "options": { "tsConfig": "tsconfig.json" } },
+                        "serve": { "options": { "hmr": true } }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let result = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(result.hmr);
+    }
+
+    #[test]
+    fn test_hmr_serve_configuration_overrides_base() {
+        let json = r#"{
+            "projects": {
+                "app": {
+                    "architect": {
+                        "build": { "options": { "tsConfig": "tsconfig.json" } },
+                        "serve": {
+                            "options": { "hmr": false },
+                            "configurations": { "development": { "hmr": true } }
+                        }
+                    }
+                }
+            }
+        }"#;
+        let f = write_temp_json(json);
+        let base = resolve_angular_project(f.path(), None, None).unwrap();
+        assert!(!base.hmr, "base serve options keep hmr false");
+        let dev = resolve_angular_project(f.path(), None, Some("development")).unwrap();
+        assert!(dev.hmr, "development configuration overrides hmr to true");
     }
 
     #[test]

--- a/crates/template-compiler/Cargo.toml
+++ b/crates/template-compiler/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 ngc-diagnostics = { path = "../diagnostics" }
+ngc-ts-transform = { path = "../ts-transform" }
 serde_json = "1.0"
 oxc_allocator = "0.122"
 oxc_diagnostics = "0.122"
@@ -23,7 +24,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 ngc-project-resolver = { path = "../project-resolver" }
-ngc-ts-transform = { path = "../ts-transform" }
 insta = { version = "1.46", features = ["glob"] }
 tempfile = "3"
 which = "8"

--- a/crates/template-compiler/src/hmr.rs
+++ b/crates/template-compiler/src/hmr.rs
@@ -1,0 +1,223 @@
+//! Hot Module Replacement (HMR) codegen for `@Component` classes.
+//!
+//! Mirrors Angular's esbuild HMR exactly (reverse-engineered from
+//! `@angular/compiler` + `@angular/core`):
+//!
+//! * A per-component **initializer IIFE** is appended to the component module.
+//!   It registers an `import.meta.hot` listener for `angular:component-update`
+//!   and, on a matching id, dynamically imports the component's update module
+//!   and calls `i0.ɵɵreplaceMetadata` to swap the definition in place.
+//! * A separate **update module** is produced (not written to disk — served on
+//!   demand by the dev server at `/@ng/component?c=<id>`). Its `export default`
+//!   is a function that re-applies the freshly compiled `ɵcmp` to the existing
+//!   class. It carries no imports: the `@angular/core` namespace arrives as the
+//!   `ɵɵnamespaces` array argument and local template dependencies arrive as
+//!   positional parameters.
+//!
+//! The update module reassigns only `ɵcmp` (template + styles), never `ɵfac`:
+//! the serve command only emits a component update when a component's factory
+//! and class body are byte-identical to the previous build (template-/style-
+//! only change), so the running factory is already correct. This keeps the
+//! update module free of constructor-DI symbols it would otherwise need in
+//! scope.
+
+use crate::codegen::IvyOutput;
+
+/// Percent-encode `input` with JavaScript `encodeURIComponent` semantics.
+///
+/// `encodeURIComponent` leaves the "unreserved" set unescaped —
+/// `A-Z a-z 0-9 - _ . ! ~ * ' ( )` — and `%XX`-encodes every other byte
+/// (UTF-8, uppercase hex). This is deliberately *not* a generic URL encoder:
+/// the result is the component id contract shared by the compiler-emitted
+/// initializer, the dev-server registry key, and the running app's fetch URL.
+pub fn encode_uri_component(input: &str) -> String {
+    fn is_unreserved(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')')
+    }
+    let mut out = String::with_capacity(input.len());
+    for &b in input.as_bytes() {
+        if is_unreserved(b) {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push(char::from_digit((b >> 4) as u32, 16).unwrap().to_ascii_uppercase());
+            out.push(char::from_digit((b & 0xf) as u32, 16).unwrap().to_ascii_uppercase());
+        }
+    }
+    out
+}
+
+/// Compute a component's HMR id: `encodeURIComponent("<relpath>@<ClassName>")`.
+///
+/// `relpath` is `file_path` relative to `project_root` with `/` separators
+/// (falling back to the file's own components when it isn't under the root).
+/// The compiler is the sole producer of this id — it is embedded verbatim in
+/// the initializer and used as the dev-server registry key — so the exact
+/// `project_root` only needs to be applied *consistently*, not to match any
+/// external value.
+pub fn component_hmr_id(
+    project_root: &std::path::Path,
+    file_path: &std::path::Path,
+    class_name: &str,
+) -> String {
+    let rel = file_path.strip_prefix(project_root).unwrap_or(file_path);
+    // Join components with `/` so the id is stable across platforms.
+    let rel_str = rel
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>()
+        .join("/");
+    encode_uri_component(&format!("{rel_str}@{class_name}"))
+}
+
+/// Build the per-component HMR initializer IIFE appended to the component
+/// module. `locals` are the template dependency identifiers (the `imports:`
+/// entries), passed to `ɵɵreplaceMetadata` in the same order the update
+/// module declares its parameters.
+///
+/// References `i0` (the `import * as i0 from '@angular/core'` namespace the
+/// HMR rewrite adds) for `ɵɵreplaceMetadata`, and the component class plus
+/// each local by binding — all resolved in the module's top-level scope.
+pub fn build_initializer(class_name: &str, id: &str, locals: &[String]) -> String {
+    let locals_arr = locals.join(", ");
+    // Plain JS (no TS annotations) so it survives ts-transform untouched.
+    format!(
+        "(() => {{\n\
+         var __ngId = '{id}';\n\
+         function {class_name}_HmrLoad(t) {{\n\
+         return import('./@ng/component?c=' + __ngId + '&t=' + encodeURIComponent(t)).then(\n\
+         m => m.default && i0.\u{0275}\u{0275}replaceMetadata({class_name}, m.default, [i0], [{locals_arr}], import.meta, __ngId));\n\
+         }}\n\
+         if (import.meta.hot) {{\n\
+         import.meta.hot.on('angular:component-update', d => {{ if (d.id === __ngId) {class_name}_HmrLoad(d.timestamp); }});\n\
+         }}\n\
+         }})();\n"
+    )
+}
+
+/// Build the TypeScript source of a component's HMR update module.
+///
+/// The caller runs the result through `ngc_ts_transform::transform_source` to
+/// strip TypeScript annotations (and validate it as JS) before serving it.
+///
+/// Reuses the existing Ivy codegen verbatim via the linker's proven var-alias
+/// technique: every runtime symbol (`ɵɵdefineComponent`, `ɵɵelement`, …) is
+/// rebound from the `i0` namespace as a local `var`, so the unmodified `ɵcmp`
+/// definition string — which references those symbols by their bare names —
+/// resolves against the locals. Template dependency identifiers resolve to the
+/// function's positional parameters.
+pub fn build_update_module_ts(class_name: &str, ivy: &IvyOutput, locals: &[String]) -> String {
+    let mut out = String::new();
+
+    // export default function X_UpdateMetadata(X, ɵɵnamespaces, dep1, dep2) {
+    out.push_str(&format!(
+        "export default function {class_name}_UpdateMetadata({class_name}, \u{0275}\u{0275}namespaces"
+    ));
+    for local in locals {
+        out.push_str(", ");
+        out.push_str(local);
+    }
+    out.push_str(") {\n");
+
+    // Rebind every runtime symbol from the core namespace so the reused def
+    // text (which uses bare `ɵɵ…` names) resolves without imports.
+    out.push_str("  const i0 = \u{0275}\u{0275}namespaces[0];\n");
+    for sym in &ivy.ivy_imports {
+        out.push_str(&format!("  var {sym} = i0.{sym};\n"));
+    }
+
+    // Child template functions referenced by the main template, in scope.
+    for child in &ivy.child_template_functions {
+        out.push_str(child);
+        out.push('\n');
+    }
+
+    // Reassign the component definition. `static_fields[0]` is
+    // `static ɵcmp = ɵɵdefineComponent({...})`; turn the class-field form into
+    // an assignment statement on the class passed in as the first parameter.
+    let def = ivy.static_fields.first().map(|s| s.as_str()).unwrap_or("");
+    let def_expr = def
+        .strip_prefix("static \u{0275}cmp = ")
+        .unwrap_or(def);
+    out.push_str(&format!("  {class_name}.\u{0275}cmp = {def_expr};\n"));
+
+    out.push_str("}\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::path::Path;
+
+    #[test]
+    fn encode_uri_component_matches_js_semantics() {
+        assert_eq!(
+            encode_uri_component("src/app/app.component.ts@AppComponent"),
+            "src%2Fapp%2Fapp.component.ts%40AppComponent"
+        );
+        // Unreserved set is left untouched.
+        assert_eq!(encode_uri_component("-_.!~*'()"), "-_.!~*'()");
+        // Spaces, slashes, and unicode are percent-encoded (UTF-8, upper hex).
+        assert_eq!(encode_uri_component("a b/c"), "a%20b%2Fc");
+        assert_eq!(encode_uri_component("é"), "%C3%A9");
+    }
+
+    #[test]
+    fn component_hmr_id_is_relative_with_forward_slashes() {
+        let id = component_hmr_id(
+            Path::new("/proj"),
+            Path::new("/proj/src/app/app.component.ts"),
+            "AppComponent",
+        );
+        assert_eq!(id, "src%2Fapp%2Fapp.component.ts%40AppComponent");
+    }
+
+    #[test]
+    fn component_hmr_id_falls_back_when_not_under_root() {
+        let id = component_hmr_id(
+            Path::new("/other"),
+            Path::new("/proj/app.component.ts"),
+            "App",
+        );
+        // Not under root → encodes the full path it was given.
+        assert!(id.ends_with("app.component.ts%40App"));
+        assert!(id.contains("%2F"));
+    }
+
+    #[test]
+    fn initializer_embeds_id_locals_and_replace_metadata() {
+        let init = build_initializer("AppComponent", "the%2Fid%40AppComponent", &["RouterOutlet".into(), "MyPipe".into()]);
+        assert!(init.contains("var __ngId = 'the%2Fid%40AppComponent';"));
+        assert!(init.contains("i0.\u{0275}\u{0275}replaceMetadata(AppComponent, m.default, [i0], [RouterOutlet, MyPipe], import.meta, __ngId)"));
+        assert!(init.contains("import('./@ng/component?c=' + __ngId + '&t=' + encodeURIComponent(t))"));
+        assert!(init.contains("import.meta.hot.on('angular:component-update'"));
+    }
+
+    #[test]
+    fn update_module_rebinds_namespace_and_assigns_cmp() {
+        let ivy = IvyOutput {
+            factory_code: "static \u{0275}fac = function App_Factory(t) { return new (t || App)(); }".into(),
+            static_fields: vec![
+                "static \u{0275}cmp = \u{0275}\u{0275}defineComponent({ type: App, template: function App_Template(rf, ctx) {} })".into(),
+            ],
+            child_template_functions: vec!["function App_div_0_Template(rf, ctx) {}".into()],
+            ivy_imports: {
+                let mut s = BTreeSet::new();
+                s.insert("\u{0275}\u{0275}defineComponent".to_string());
+                s.insert("\u{0275}\u{0275}element".to_string());
+                s
+            },
+            consts: vec![],
+        };
+        let module = build_update_module_ts("App", &ivy, &["RouterOutlet".into()]);
+        assert!(module.contains("export default function App_UpdateMetadata(App, \u{0275}\u{0275}namespaces, RouterOutlet)"));
+        assert!(module.contains("const i0 = \u{0275}\u{0275}namespaces[0];"));
+        assert!(module.contains("var \u{0275}\u{0275}defineComponent = i0.\u{0275}\u{0275}defineComponent;"));
+        assert!(module.contains("function App_div_0_Template"));
+        assert!(module.contains("App.\u{0275}cmp = \u{0275}\u{0275}defineComponent({"));
+        // The update module must not reassign the factory (template/style-only).
+        assert!(!module.contains(".\u{0275}fac"));
+    }
+}

--- a/crates/template-compiler/src/lib.rs
+++ b/crates/template-compiler/src/lib.rs
@@ -10,6 +10,7 @@ mod codegen;
 mod directive_codegen;
 mod extract;
 mod factory_codegen;
+pub mod hmr;
 pub mod host_codegen;
 pub mod i18n;
 mod injectable_codegen;
@@ -73,6 +74,11 @@ pub struct CompileOptions {
     /// `@angular/build:application`'s `strictTemplates` behaviour, which has
     /// no JIT fallback.
     pub strict_templates: bool,
+    /// When `true`, emit Angular HMR codegen for each compiled `@Component`:
+    /// a per-component initializer IIFE appended to the module, plus a
+    /// separate update module returned in [`CompiledFile::hmr`]. Dev-only
+    /// (`ngc-rs serve --hmr`); production builds leave this `false`.
+    pub hmr: bool,
 }
 
 /// Lightweight metadata for template compilation without `ExtractedComponent`.
@@ -255,6 +261,36 @@ pub struct CompiledFile {
     pub compiled: bool,
     /// Whether JIT fallback was used (decorator left as-is).
     pub jit_fallback: bool,
+    /// HMR artifacts for this file, present only when [`CompileOptions::hmr`]
+    /// is set and a component was compiled. `None` otherwise.
+    pub hmr: Option<HmrArtifacts>,
+}
+
+/// HMR artifacts produced for one source file when HMR codegen is enabled.
+#[derive(Debug, Clone)]
+pub struct HmrArtifacts {
+    /// One entry per `@Component` in the file. Today the compiler emits at
+    /// most one (the pipeline is single-component per file); a `Vec` keeps
+    /// the shape forward-compatible.
+    pub components: Vec<HmrComponent>,
+}
+
+/// HMR codegen for a single component: its id, the update module the dev
+/// server serves at `/@ng/component?c=<id>`, and the resource files whose
+/// edits map back to this component.
+#[derive(Debug, Clone)]
+pub struct HmrComponent {
+    /// The component class name.
+    pub class_name: String,
+    /// `encodeURIComponent("<relpath>@<ClassName>")` — the dev-server
+    /// registry key and the id embedded in the component's initializer.
+    pub id: String,
+    /// The update module source (already transformed to JS): an ES module
+    /// whose `export default` re-applies the component's `ɵcmp`.
+    pub update_module_source: String,
+    /// Absolute paths of external resources (`templateUrl` + `styleUrls`).
+    /// A change to one of these maps the rebuild to this component id.
+    pub resource_files: Vec<PathBuf>,
 }
 
 /// Compile all Angular decorators in the given TypeScript source files.
@@ -408,6 +444,7 @@ fn compile_file_fallthrough(
         source: source.to_string(),
         compiled: false,
         jit_fallback: false,
+        hmr: None,
     })
 }
 
@@ -435,6 +472,7 @@ fn compile_file_dispatch(
             source: source.to_string(),
             compiled: false,
             jit_fallback: false,
+            hmr: None,
         });
     }
 
@@ -470,6 +508,7 @@ fn compile_file_dispatch(
         source: source.to_string(),
         compiled: false,
         jit_fallback: false,
+        hmr: None,
     })
 }
 
@@ -486,6 +525,7 @@ fn finalize_injectable(
         source: rewritten,
         compiled: true,
         jit_fallback: false,
+        hmr: None,
     })
 }
 
@@ -502,6 +542,7 @@ fn finalize_directive(
         source: rewritten,
         compiled: true,
         jit_fallback: false,
+        hmr: None,
     })
 }
 
@@ -518,6 +559,7 @@ fn finalize_pipe(
         source: rewritten,
         compiled: true,
         jit_fallback: false,
+        hmr: None,
     })
 }
 
@@ -534,6 +576,7 @@ fn finalize_ng_module(
         source: rewritten,
         compiled: true,
         jit_fallback: false,
+        hmr: None,
     })
 }
 
@@ -686,6 +729,7 @@ pub fn compile_component_with_options(
                 source: source.to_string(),
                 compiled: false,
                 jit_fallback: false,
+                hmr: None,
             });
         }
     };
@@ -711,6 +755,7 @@ pub fn compile_component_with_options(
             source: source.to_string(),
             compiled: false,
             jit_fallback: true,
+            hmr: None,
         });
     }
 
@@ -737,6 +782,7 @@ pub fn compile_component_with_options(
             source: source.to_string(),
             compiled: false,
             jit_fallback: false,
+            hmr: None,
         });
     };
 
@@ -746,8 +792,42 @@ pub fn compile_component_with_options(
     // Generate Ivy code
     let ivy_output = codegen::generate_ivy(&extracted, &template_ast)?;
 
-    // Rewrite the source
-    let rewritten = rewrite::rewrite_source(source, &extracted, &ivy_output)?;
+    // Rewrite the source. In HMR mode the rewrite also adds an
+    // `import * as i0 from '@angular/core'` so the appended initializer can
+    // reach `i0.ɵɵreplaceMetadata` and pass the core namespace to the update.
+    let mut rewritten = rewrite::rewrite_source(source, &extracted, &ivy_output, compile_opts.hmr)?;
+
+    // HMR codegen: build the per-component update module and append the
+    // initializer IIFE to the module. The update module is returned in
+    // `CompiledFile::hmr` for the dev server to serve on demand.
+    let hmr = if compile_opts.hmr {
+        let id = hmr::component_hmr_id(&style_ctx.project_root, file_path, &extracted.class_name);
+        let locals = &extracted.imports_identifiers;
+        let update_ts = hmr::build_update_module_ts(&extracted.class_name, &ivy_output, locals);
+        let update_module_source = ngc_ts_transform::transform_source(&update_ts, "ngc-hmr-update.ts")?;
+        rewritten.push('\n');
+        rewritten.push_str(&hmr::build_initializer(&extracted.class_name, &id, locals));
+
+        let base_dir = file_path.parent().unwrap_or(Path::new("."));
+        let mut resource_files = Vec::new();
+        if let Some(ref url) = extracted.template_url {
+            resource_files.push(base_dir.join(url));
+        }
+        for url in &extracted.style_urls {
+            resource_files.push(base_dir.join(url));
+        }
+
+        Some(HmrArtifacts {
+            components: vec![HmrComponent {
+                class_name: extracted.class_name.clone(),
+                id,
+                update_module_source,
+                resource_files,
+            }],
+        })
+    } else {
+        None
+    };
 
     debug!(path = %file_path.display(), "compiled template to Ivy");
 
@@ -756,6 +836,7 @@ pub fn compile_component_with_options(
         source: rewritten,
         compiled: true,
         jit_fallback: false,
+        hmr,
     })
 }
 
@@ -798,6 +879,7 @@ export class XComponent {}
         let style_ctx = StyleContext::default();
         let strict = CompileOptions {
             strict_templates: true,
+            ..Default::default()
         };
         let lenient = CompileOptions::default();
 
@@ -829,6 +911,75 @@ export class XComponent {}
             js.err(),
             result.source
         );
+    }
+
+    #[test]
+    fn test_hmr_codegen_produces_valid_artifacts() {
+        let source = "import { Component } from '@angular/core';\n\n@Component({\n  selector: 'app-counter',\n  standalone: true,\n  template: '<button (click)=\"inc()\">{{ count }}</button>',\n  styles: ['button { color: red; }'],\n})\nexport class CounterComponent {\n  count = 0;\n  inc() { this.count++; }\n}\n";
+        let path = PathBuf::from("/proj/src/app/counter.component.ts");
+        let style_ctx = StyleContext {
+            project_root: PathBuf::from("/proj"),
+            ..Default::default()
+        };
+        let opts = CompileOptions {
+            hmr: true,
+            ..Default::default()
+        };
+        let result = compile_component_with_options(source, &path, &style_ctx, &opts)
+            .expect("hmr compile should succeed");
+        assert!(result.compiled);
+
+        // The rewritten module must add the `i0` namespace import and the
+        // appended HMR initializer wired to `import.meta.hot`.
+        assert!(result.source.contains("import * as i0 from '@angular/core';"));
+        assert!(result
+            .source
+            .contains("import.meta.hot.on('angular:component-update'"));
+        assert!(result
+            .source
+            .contains("i0.\u{0275}\u{0275}replaceMetadata(CounterComponent"));
+
+        // HMR artifacts present, with the expected id, and the update module
+        // is valid JavaScript that re-applies ɵcmp.
+        let hmr = result.hmr.expect("hmr artifacts present");
+        assert_eq!(hmr.components.len(), 1);
+        let comp = &hmr.components[0];
+        assert_eq!(comp.class_name, "CounterComponent");
+        assert_eq!(
+            comp.id,
+            "src%2Fapp%2Fcounter.component.ts%40CounterComponent"
+        );
+        assert!(comp
+            .update_module_source
+            .contains("CounterComponent.\u{0275}cmp"));
+        // The served update module must already be valid JS (TS stripped).
+        let alloc = oxc_allocator::Allocator::default();
+        let parsed = oxc_parser::Parser::new(
+            &alloc,
+            &comp.update_module_source,
+            oxc_span::SourceType::mjs(),
+        )
+        .parse();
+        assert!(
+            parsed.errors.is_empty(),
+            "update module should be valid JS: {:?}\n\n{}",
+            parsed.errors,
+            comp.update_module_source
+        );
+        // No factory reassignment (template/style-only update path).
+        assert!(!comp.update_module_source.contains(".\u{0275}fac"));
+    }
+
+    #[test]
+    fn test_no_hmr_artifacts_when_disabled() {
+        let source = "import { Component } from '@angular/core';\n\n@Component({\n  selector: 'app-x',\n  standalone: true,\n  template: '<div>{{ x }}</div>',\n})\nexport class XComponent { x = 1; }\n";
+        let path = PathBuf::from("/proj/src/x.component.ts");
+        let style_ctx = StyleContext::default();
+        let result =
+            compile_component_with_options(source, &path, &style_ctx, &CompileOptions::default())
+                .expect("compile");
+        assert!(result.hmr.is_none());
+        assert!(!result.source.contains("import * as i0"));
     }
 
     #[test]

--- a/crates/template-compiler/src/rewrite.rs
+++ b/crates/template-compiler/src/rewrite.rs
@@ -13,6 +13,7 @@ pub fn rewrite_source(
     source: &str,
     component: &ExtractedComponent,
     ivy_output: &IvyOutput,
+    hmr: bool,
 ) -> NgcResult<String> {
     let common = DecoratorCommon {
         decorator_span: component.decorator_span,
@@ -20,7 +21,16 @@ pub fn rewrite_source(
         angular_core_import_span: component.angular_core_import_span,
         other_angular_core_imports: component.other_angular_core_imports.clone(),
     };
-    rewrite_source_generic(source, &common, ivy_output)
+    let out = rewrite_source_generic(source, &common, ivy_output)?;
+    if hmr {
+        // The HMR initializer (appended later) and `ɵɵreplaceMetadata` need a
+        // namespace handle for `@angular/core`; the bundler resolves this to
+        // the synthesized core namespace object. The existing named import is
+        // left in place for the def's own runtime symbols.
+        Ok(format!("import * as i0 from '@angular/core';\n{out}"))
+    } else {
+        Ok(out)
+    }
 }
 
 /// Rewrite a TypeScript source string to replace any Angular decorator with
@@ -187,7 +197,7 @@ mod tests {
     fn test_rewrite_removes_decorator() {
         let component = make_component();
         let ivy = make_ivy_output();
-        let result = rewrite_source(TEST_SOURCE, &component, &ivy).expect("should rewrite");
+        let result = rewrite_source(TEST_SOURCE, &component, &ivy, false).expect("should rewrite");
         assert!(!result.contains("@Component"));
         assert!(result.contains("\u{0275}\u{0275}defineComponent"));
         assert!(result.contains("class AppComponent"));
@@ -198,7 +208,7 @@ mod tests {
     fn test_rewrite_updates_imports() {
         let component = make_component();
         let ivy = make_ivy_output();
-        let result = rewrite_source(TEST_SOURCE, &component, &ivy).expect("should rewrite");
+        let result = rewrite_source(TEST_SOURCE, &component, &ivy, false).expect("should rewrite");
         assert!(result.contains("\u{0275}\u{0275}defineComponent"));
         assert!(result.contains("\u{0275}\u{0275}element"));
         assert!(!result.contains("import { Component }"));
@@ -208,7 +218,7 @@ mod tests {
     fn test_rewrite_inserts_static_fields() {
         let component = make_component();
         let ivy = make_ivy_output();
-        let result = rewrite_source(TEST_SOURCE, &component, &ivy).expect("should rewrite");
+        let result = rewrite_source(TEST_SOURCE, &component, &ivy, false).expect("should rewrite");
         assert!(result.contains("static \u{0275}fac"));
         assert!(result.contains("static \u{0275}cmp"));
         // Static fields should be inside the class body


### PR DESCRIPTION
Lights up Angular-parity template/style HMR end to end (#145), building on the config plumbing (#185) and dev-server endpoint + runtime bus (#186). **Stacked on #186.**

## template-compiler
- New `hmr` module: `encode_uri_component` (JS `encodeURIComponent` semantics), per-component id `encodeURIComponent("relpath@Class")`, the initializer IIFE, and the update-module codegen. The update module reuses the existing Ivy definition verbatim via the linker's var-alias technique (`var ɵɵX = i0.ɵɵX`), with `@angular/core` arriving as the `namespaces` argument and template deps as positional params; it reassigns only `ɵcmp` (template/style-only path).
- `CompileOptions.hmr` and `CompiledFile.hmr` carry the artifacts; the source rewrite adds `import * as i0` so the appended initializer can reach `ɵɵreplaceMetadata`.

## cli
- Thread `hmr` through the build; aggregate per-component update modules and resource→component maps into the build result; cache the artifacts in the incremental module cache.
- **serve**: classify each rebuild — global stylesheet → css-update, external component template/style → component-update(s), `.ts`/inline/unknown → full reload — and inject the `import.meta.hot` prelude into **every** chunk (eager `main.js` and lazy `chunk-*.js`).

## Verified end-to-end (Angular 21 app)
- Editing a component template (`.html`) → swapped in place via the `/@ng/component` update module and `ɵɵreplaceMetadata`; **no reload**, state preserved. The served module reflected the live template edit.
- Editing a component external style (`.scss`) → component-update.
- Editing a global stylesheet → css-update `<link>` swap.
- Editing a component class (`.ts`) → full reload.

The bundler correctly bound `import * as i0` to the synthesized core namespace (`var i0 = __ns_angular_core_...`), and the initializer / update-module references resolved after bundling.

## Definition of done (#145)
- `.css` edit replaces styles in-place without reload ✅
- `.html` template re-renders the affected component without reload ✅
- `.ts` edit falls back to full reload ✅
- `hmr: true` enables the above; `hmr: false` (default) keeps full-reload behavior ✅

## Follow-ups (deferred)
- Inline-template / inline-style (`.ts`) HMR detection via def diffing (currently reloads).
- Multiple components per file (currently HMRs the first component; pipeline is single-component today).

Targets the milestone branch via the stack; retarget to it once #186 merges.
