### PR TITLE
chore: ignore local /scripts dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@
 MILESTONES.md
 .env
 .env.*
-/scripts/bench_local.sh
-/scripts/deploy_to_container.sh
+/scripts/
 /test/


### PR DESCRIPTION
Ignores the whole local `/scripts` directory (dev/bench helpers like `bench_local.sh`, `bundle_size.sh`) instead of listing individual files, so new scripts don't show up as untracked.